### PR TITLE
Add missing error code to RowError

### DIFF
--- a/src/row.js
+++ b/src/row.js
@@ -34,6 +34,7 @@ var Mutation = require('./mutation.js');
  */
 var RowError = createErrorClass('RowError', function(row) {
   this.message = 'Unknown row: ' + row + '.';
+  this.code = 404;
 });
 
 /**

--- a/src/table.js
+++ b/src/table.js
@@ -347,7 +347,7 @@ Table.prototype.createFamily = function(name, rule, callback) {
  * @param {boolean} [options.decode=true] If set to `false` it will not decode
  *     Buffer values returned from Bigtable.
  * @param {string} [options.end] End value for key range.
-* @param {Filter} [options.filter] Row filters allow you to
+ * @param {Filter} [options.filter] Row filters allow you to
  *     both make advanced queries and format how the data is returned.
  * @param {string[]} [options.keys] A list of row keys.
  * @param {number} [options.limit] Maximum number of rows to be returned.

--- a/system-test/bigtable.js
+++ b/system-test/bigtable.js
@@ -379,7 +379,6 @@ describe('Bigtable', function() {
   });
 
   describe('rows', function() {
-
     describe('.exists()', function() {
       var row = TABLE.row('alincoln');
 
@@ -414,7 +413,6 @@ describe('Bigtable', function() {
           done();
         });
       });
-
     });
 
     describe('inserting data', function() {

--- a/system-test/bigtable.js
+++ b/system-test/bigtable.js
@@ -379,6 +379,44 @@ describe('Bigtable', function() {
   });
 
   describe('rows', function() {
+
+    describe('.exists()', function() {
+      var row = TABLE.row('alincoln');
+
+      beforeEach(function(done) {
+        var rowData = {
+          follows: {
+            gwashington: 1,
+            jadams: 1,
+            tjefferson: 1,
+          },
+        };
+
+        row.create(rowData, done);
+      });
+
+      afterEach(row.delete.bind(row));
+
+      it('should check if a row exists', function(done) {
+        row.exists(function(err, exists) {
+          assert.ifError(err);
+          assert.strictEqual(exists, true);
+          done();
+        });
+      });
+
+      it('should check if a row does not exist', function(done) {
+        var row = TABLE.row('gwashington');
+
+        row.exists(function(err, exists) {
+          assert.ifError(err);
+          assert.strictEqual(exists, false);
+          done();
+        });
+      });
+
+    });
+
     describe('inserting data', function() {
       it('should insert rows', function(done) {
         var rows = [

--- a/test/row.js
+++ b/test/row.js
@@ -941,6 +941,7 @@ describe('Bigtable/Row', function() {
       row.get(function(err, row_, apiResponse) {
         assert(err instanceof Row.RowError);
         assert.strictEqual(err.message, 'Unknown row: ' + row.id + '.');
+        assert.strictEqual(err.code, 404);
         assert.deepEqual(row_, null);
         assert.strictEqual(response, apiResponse);
         done();
@@ -1208,6 +1209,11 @@ describe('Bigtable/Row', function() {
     it('should supply the correct message', function() {
       var error = new Row.RowError('test');
       assert.strictEqual(error.message, 'Unknown row: test.');
+    });
+
+    it('should supply a 404 error code', function() {
+      var error = new Row.RowError('test');
+      assert.strictEqual(error.code, 404);
     });
   });
 });


### PR DESCRIPTION
Fixes #5

There was a missing err.code assignment that was missing in RowError, [Family](https://github.com/googleapis/nodejs-bigtable/blob/443ba9b2bf33de7de6cf49b3a1feb231eda88375/src/family.js#L27-L30) has a similar snippet.

Also added tests around the `row.exists()` method.