### PR TITLE
Fix #6 - Allow early ending table/createReadStream

### DIFF
--- a/src/table.js
+++ b/src/table.js
@@ -485,7 +485,7 @@ Table.prototype.createReadStream = function(options) {
     reqOpts.rowsLimit = options.limit;
   }
 
-  return pumpify.obj([
+  var stream = pumpify.obj([
     this.requestStream(grpcOpts, reqOpts),
     through.obj(function(data, enc, next) {
       var throughStream = this;
@@ -494,6 +494,10 @@ Table.prototype.createReadStream = function(options) {
       });
 
       rows.forEach(function(rowData) {
+        if (stream._ended) {
+          return;
+        }
+
         var row = self.row(rowData.key);
 
         row.data = rowData.data;
@@ -503,6 +507,8 @@ Table.prototype.createReadStream = function(options) {
       next();
     }),
   ]);
+
+  return stream;
 };
 
 /**

--- a/system-test/bigtable.js
+++ b/system-test/bigtable.js
@@ -669,18 +669,51 @@ describe('Bigtable', function() {
       });
 
       it('should end stream early', function(done) {
-        var rows = [];
+        var entries = [
+          {
+            key: 'gwashington',
+            data: {
+              follows: {
+                jadams: 1,
+              },
+            },
+          },
+          {
+            key: 'tjefferson',
+            data: {
+              follows: {
+                gwashington: 1,
+                jadams: 1,
+              },
+            },
+          },
+          {
+            key: 'jadams',
+            data: {
+              follows: {
+                gwashington: 1,
+                tjefferson: 1,
+              },
+            },
+          },
+        ];
 
-        TABLE.createReadStream()
-          .on('error', done)
-          .on('data', function(row) {
-            rows.push(row);
-            this.end();
-          })
-          .on('end', function() {
-            assert.strictEqual(rows.length, 1);
-            done();
-          });
+        TABLE.insert(entries, function(err) {
+          assert.ifError(err);
+
+          var rows = [];
+
+          TABLE.createReadStream()
+            .on('error', done)
+            .on('data', function(row) {
+              rows.push(row);
+              this.end();
+            })
+            .on('end', function() {
+              assert.strictEqual(rows.length, 1);
+              done();
+            });
+        });
       });
 
       describe('filters', function() {

--- a/system-test/bigtable.js
+++ b/system-test/bigtable.js
@@ -668,6 +668,21 @@ describe('Bigtable', function() {
           });
       });
 
+      it('should end stream early', function(done) {
+        var rows = [];
+
+        TABLE.createReadStream()
+          .on('error', done)
+          .on('data', function(row) {
+            rows.push(row);
+            this.end();
+          })
+          .on('end', function() {
+            assert.strictEqual(rows.length, 1);
+            done();
+          });
+      });
+
       describe('filters', function() {
         it('should get rows via column data', function(done) {
           var filter = {

--- a/test/table.js
+++ b/test/table.js
@@ -634,6 +634,22 @@ describe('Bigtable/Table', function() {
             done();
           });
       });
+
+      it('should allow a stream to end early', function(done) {
+        var rows = [];
+
+        table
+          .createReadStream()
+          .on('error', done)
+          .on('data', function(row) {
+            rows.push(row);
+            this.end();
+          })
+          .on('end', function() {
+            assert.strictEqual(rows.length, 1);
+            done();
+          });
+      });
     });
 
     describe('error', function() {


### PR DESCRIPTION
Fixed data transformation stream to stop processing data on `end` event
Still, need to fix GRPC stream closing.

Fixes #6 

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
