### PR TITLE
GAPIC v2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,6 +91,7 @@ jobs:
   node4:
     docker:
       - image: node:4
+        user: node
     steps:
       - checkout
       - run:
@@ -106,30 +107,38 @@ jobs:
   node6:
     docker:
       - image: node:6
+        user: node
     <<: *unit_tests
   node7:
     docker:
       - image: node:7
+        user: node
     <<: *unit_tests
   node8:
     docker:
       - image: node:8
+        user: node
     <<: *unit_tests
   node9:
     docker:
       - image: node:9
+        user: node
     <<: *unit_tests
 
   lint:
     docker:
       - image: node:8
+        user: node
     steps:
       - checkout
       - run:
           name: Install modules and dependencies.
           command: |
+            mkdir -p /home/node/.npm-global
             npm install
             npm link
+          environment:
+            NPM_CONFIG_PREFIX: /home/node/.npm-global
       - run:
           name: Link the module being tested to the samples.
           command: |
@@ -137,9 +146,13 @@ jobs:
             npm link @google-cloud/bigtable
             npm install
             cd ..
+          environment:
+            NPM_CONFIG_PREFIX: /home/node/.npm-global
       - run:
           name: Run linting.
           command: npm run lint
+          environment:
+            NPM_CONFIG_PREFIX: /home/node/.npm-global
 
   docs:
     docker:
@@ -156,6 +169,7 @@ jobs:
   sample_tests:
     docker:
       - image: node:8
+        user: node
     steps:
       - checkout
       - run:
@@ -167,8 +181,11 @@ jobs:
       - run:
           name: Install and link the module.
           command: |
+            mkdir -p /home/node/.npm-global
             npm install
             npm link
+          environment:
+            NPM_CONFIG_PREFIX: /home/node/.npm-global
       - run:
           name: Link the module being tested to the samples.
           command: |
@@ -176,21 +193,25 @@ jobs:
             npm link @google-cloud/bigtable
             npm install
             cd ..
+          environment:
+            NPM_CONFIG_PREFIX: /home/node/.npm-global
       - run:
           name: Run sample tests.
           command: npm run samples-test
           environment:
             GCLOUD_PROJECT: long-door-651
-            GOOGLE_APPLICATION_CREDENTIALS: /var/bigtable/.circleci/key.json
+            GOOGLE_APPLICATION_CREDENTIALS: /home/node/bigtable-samples/.circleci/key.json
+            NPM_CONFIG_PREFIX: /home/node/.npm-global
       - run:
           name: Remove unencrypted key.
           command: rm .circleci/key.json
           when: always
-    working_directory: /var/bigtable/
+    working_directory: /home/node/bigtable-samples/
 
   system_tests:
     docker:
       - image: node:8
+        user: node
     steps:
       - checkout
       - run:
@@ -215,6 +236,7 @@ jobs:
   publish_npm:
     docker:
       - image: node:8
+        user: node
     steps:
       - checkout
       - run:

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "google-gax": "^0.14.3",
     "is": "^3.0.1",
     "lodash.flatten": "^4.2.0",
+    "lodash.merge": "^4.6.0",
     "node-int64": "^0.4.0",
     "prop-assign": "^1.0.0",
     "pumpify": "^1.3.3",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "create-error-class": "^3.0.2",
     "dot-prop": "^4.2.0",
     "extend": "^3.0.0",
+    "google-gax": "^0.14.3",
     "is": "^3.0.1",
     "lodash.flatten": "^4.2.0",
     "node-int64": "^0.4.0",

--- a/protos/google/bigtable/v2/bigtable.proto
+++ b/protos/google/bigtable/v2/bigtable.proto
@@ -1,4 +1,4 @@
-// Copyright 2016 Google Inc.
+// Copyright 2017 Google Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,15 +21,17 @@ import "google/bigtable/v2/data.proto";
 import "google/protobuf/wrappers.proto";
 import "google/rpc/status.proto";
 
+option csharp_namespace = "Google.Cloud.Bigtable.V2";
 option go_package = "google.golang.org/genproto/googleapis/bigtable/v2;bigtable";
 option java_multiple_files = true;
 option java_outer_classname = "BigtableProto";
 option java_package = "com.google.bigtable.v2";
+option php_namespace = "Google\\Cloud\\Bigtable\\V2";
 
 
 // Service for reading from and writing to existing Bigtable tables.
 service Bigtable {
-  // Streams back the contents of all requested rows, optionally
+  // Streams back the contents of all requested rows in key order, optionally
   // applying the same Reader filter to each. Depending on their size,
   // rows and cells may be broken up across multiple responses, but
   // atomicity of each row will still be preserved. See the
@@ -64,11 +66,11 @@ service Bigtable {
     option (google.api.http) = { post: "/v2/{table_name=projects/*/instances/*/tables/*}:checkAndMutateRow" body: "*" };
   }
 
-  // Modifies a row atomically. The method reads the latest existing timestamp
-  // and value from the specified columns and writes a new entry based on
-  // pre-defined read/modify/write rules. The new value for the timestamp is the
-  // greater of the existing timestamp or the current server time. The method
-  // returns the new contents of all modified cells.
+  // Modifies a row atomically on the server. The method reads the latest
+  // existing timestamp and value from the specified columns and writes a new
+  // entry based on pre-defined read/modify/write rules. The new value for the
+  // timestamp is the greater of the existing timestamp or the current server
+  // time. The method returns the new contents of all modified cells.
   rpc ReadModifyWriteRow(ReadModifyWriteRowRequest) returns (ReadModifyWriteRowResponse) {
     option (google.api.http) = { post: "/v2/{table_name=projects/*/instances/*/tables/*}:readModifyWriteRow" body: "*" };
   }
@@ -80,6 +82,15 @@ message ReadRowsRequest {
   // Values are of the form
   // `projects/<project>/instances/<instance>/tables/<table>`.
   string table_name = 1;
+
+  // This is a private alpha release of Cloud Bigtable replication. This feature
+  // is not currently available to most Cloud Bigtable customers. This feature
+  // might be changed in backward-incompatible ways and is not recommended for
+  // production use. It is not subject to any SLA or deprecation policy.
+  //
+  // This value specifies routing for replication. If not specified, the
+  // "default" application profile will be used.
+  string app_profile_id = 5;
 
   // The row keys and/or ranges to read. If not specified, reads from all rows.
   RowSet rows = 2;
@@ -176,6 +187,15 @@ message SampleRowKeysRequest {
   // Values are of the form
   // `projects/<project>/instances/<instance>/tables/<table>`.
   string table_name = 1;
+
+  // This is a private alpha release of Cloud Bigtable replication. This feature
+  // is not currently available to most Cloud Bigtable customers. This feature
+  // might be changed in backward-incompatible ways and is not recommended for
+  // production use. It is not subject to any SLA or deprecation policy.
+  //
+  // This value specifies routing for replication. If not specified, the
+  // "default" application profile will be used.
+  string app_profile_id = 2;
 }
 
 // Response message for Bigtable.SampleRowKeys.
@@ -202,6 +222,15 @@ message MutateRowRequest {
   // Values are of the form
   // `projects/<project>/instances/<instance>/tables/<table>`.
   string table_name = 1;
+
+  // This is a private alpha release of Cloud Bigtable replication. This feature
+  // is not currently available to most Cloud Bigtable customers. This feature
+  // might be changed in backward-incompatible ways and is not recommended for
+  // production use. It is not subject to any SLA or deprecation policy.
+  //
+  // This value specifies routing for replication. If not specified, the
+  // "default" application profile will be used.
+  string app_profile_id = 4;
 
   // The key of the row to which the mutation should be applied.
   bytes row_key = 2;
@@ -232,6 +261,15 @@ message MutateRowsRequest {
 
   // The unique name of the table to which the mutations should be applied.
   string table_name = 1;
+
+  // This is a private alpha release of Cloud Bigtable replication. This feature
+  // is not currently available to most Cloud Bigtable customers. This feature
+  // might be changed in backward-incompatible ways and is not recommended for
+  // production use. It is not subject to any SLA or deprecation policy.
+  //
+  // This value specifies routing for replication. If not specified, the
+  // "default" application profile will be used.
+  string app_profile_id = 3;
 
   // The row keys and corresponding mutations to be applied in bulk.
   // Each entry is applied as an atomic mutation, but the entries may be
@@ -266,6 +304,15 @@ message CheckAndMutateRowRequest {
   // Values are of the form
   // `projects/<project>/instances/<instance>/tables/<table>`.
   string table_name = 1;
+
+  // This is a private alpha release of Cloud Bigtable replication. This feature
+  // is not currently available to most Cloud Bigtable customers. This feature
+  // might be changed in backward-incompatible ways and is not recommended for
+  // production use. It is not subject to any SLA or deprecation policy.
+  //
+  // This value specifies routing for replication. If not specified, the
+  // "default" application profile will be used.
+  string app_profile_id = 7;
 
   // The key of the row to which the conditional mutation should be applied.
   bytes row_key = 2;
@@ -305,6 +352,15 @@ message ReadModifyWriteRowRequest {
   // Values are of the form
   // `projects/<project>/instances/<instance>/tables/<table>`.
   string table_name = 1;
+
+  // This is a private alpha release of Cloud Bigtable replication. This feature
+  // is not currently available to most Cloud Bigtable customers. This feature
+  // might be changed in backward-incompatible ways and is not recommended for
+  // production use. It is not subject to any SLA or deprecation policy.
+  //
+  // This value specifies routing for replication. If not specified, the
+  // "default" application profile will be used.
+  string app_profile_id = 4;
 
   // The key of the row to which the read/modify/write rules should be applied.
   bytes row_key = 2;

--- a/protos/google/bigtable/v2/data.proto
+++ b/protos/google/bigtable/v2/data.proto
@@ -1,4 +1,4 @@
-// Copyright 2016 Google Inc.
+// Copyright 2017 Google Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,10 +16,12 @@ syntax = "proto3";
 
 package google.bigtable.v2;
 
+option csharp_namespace = "Google.Cloud.Bigtable.V2";
 option go_package = "google.golang.org/genproto/googleapis/bigtable/v2;bigtable";
 option java_multiple_files = true;
 option java_outer_classname = "DataProto";
 option java_package = "com.google.bigtable.v2";
+option php_namespace = "Google\\Cloud\\Bigtable\\V2";
 
 
 // Specifies the complete (requested) contents of a single row of a table.

--- a/src/index.js
+++ b/src/index.js
@@ -27,6 +27,10 @@ var util = require('util');
 var Cluster = require('./cluster.js');
 var Instance = require('./instance.js');
 
+const gapic = Object.freeze({
+  v2: require('./v2'),
+});
+
 /**
  * @typedef {object} ClientConfig
  * @property {string} [apiEndpoint] Override the default API endpoint used
@@ -696,3 +700,4 @@ Bigtable.Instance = Instance;
  * Full quickstart example:
  */
 module.exports = Bigtable;
+module.exports.v2 = gapic.v2;

--- a/src/v2/bigtable_client.js
+++ b/src/v2/bigtable_client.js
@@ -621,9 +621,7 @@ class BigtableClient {
    * @returns {String} - A string representing the project.
    */
   matchProjectFromTableName(tableName) {
-    return this._pathTemplates.tablePathTemplate
-      .match(tableName)
-      .project;
+    return this._pathTemplates.tablePathTemplate.match(tableName).project;
   }
 
   /**
@@ -634,9 +632,7 @@ class BigtableClient {
    * @returns {String} - A string representing the instance.
    */
   matchInstanceFromTableName(tableName) {
-    return this._pathTemplates.tablePathTemplate
-      .match(tableName)
-      .instance;
+    return this._pathTemplates.tablePathTemplate.match(tableName).instance;
   }
 
   /**
@@ -647,11 +643,8 @@ class BigtableClient {
    * @returns {String} - A string representing the table.
    */
   matchTableFromTableName(tableName) {
-    return this._pathTemplates.tablePathTemplate
-      .match(tableName)
-      .table;
+    return this._pathTemplates.tablePathTemplate.match(tableName).table;
   }
 }
-
 
 module.exports = BigtableClient;

--- a/src/v2/bigtable_client.js
+++ b/src/v2/bigtable_client.js
@@ -1,0 +1,657 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const gapicConfig = require('./bigtable_client_config');
+const gax = require('google-gax');
+const merge = require('lodash.merge');
+const path = require('path');
+
+const VERSION = require('../../package.json').version;
+
+/**
+ * Service for reading from and writing to existing Bigtable tables.
+ *
+ * @class
+ * @memberof v2
+ */
+class BigtableClient {
+  /**
+   * Construct an instance of BigtableClient.
+   *
+   * @param {object} [options] - The configuration object. See the subsequent
+   *   parameters for more details.
+   * @param {object} [options.credentials] - Credentials object.
+   * @param {string} [options.credentials.client_email]
+   * @param {string} [options.credentials.private_key]
+   * @param {string} [options.email] - Account email address. Required when
+   *   usaing a .pem or .p12 keyFilename.
+   * @param {string} [options.keyFilename] - Full path to the a .json, .pem, or
+   *     .p12 key downloaded from the Google Developers Console. If you provide
+   *     a path to a JSON file, the projectId option above is not necessary.
+   *     NOTE: .pem and .p12 require you to specify options.email as well.
+   * @param {number} [options.port] - The port on which to connect to
+   *     the remote host.
+   * @param {string} [options.projectId] - The project ID from the Google
+   *     Developer's Console, e.g. 'grape-spaceship-123'. We will also check
+   *     the environment variable GCLOUD_PROJECT for your project ID. If your
+   *     app is running in an environment which supports
+   *     {@link https://developers.google.com/identity/protocols/application-default-credentials Application Default Credentials},
+   *     your project ID will be detected automatically.
+   * @param {function} [options.promise] - Custom promise module to use instead
+   *     of native Promises.
+   * @param {string} [options.servicePath] - The domain name of the
+   *     API remote host.
+   */
+  constructor(opts) {
+    this._descriptors = {};
+
+    // Ensure that options include the service address and port.
+    opts = Object.assign(
+      {
+        clientConfig: {},
+        port: this.constructor.port,
+        servicePath: this.constructor.servicePath,
+      },
+      opts
+    );
+
+    // Create a `gaxGrpc` object, with any grpc-specific options
+    // sent to the client.
+    opts.scopes = this.constructor.scopes;
+    var gaxGrpc = gax.grpc(opts);
+
+    // Save the auth object to the client, for use by other methods.
+    this.auth = gaxGrpc.auth;
+
+    // Determine the client header string.
+    var clientHeader = [
+      `gl-node/${process.version.node}`,
+      `grpc/${gaxGrpc.grpcVersion}`,
+      `gax/${gax.version}`,
+      `gapic/${VERSION}`,
+    ];
+    if (opts.libName && opts.libVersion) {
+      clientHeader.push(`${opts.libName}/${opts.libVersion}`);
+    }
+
+    // Load the applicable protos.
+    var protos = merge(
+      {},
+      gaxGrpc.loadProto(
+        path.join(__dirname, '..', '..', 'protos'),
+        'google/bigtable/v2/bigtable.proto'
+      )
+    );
+
+    // This API contains "path templates"; forward-slash-separated
+    // identifiers to uniquely identify resources within the API.
+    // Create useful helper objects for these.
+    this._pathTemplates = {
+      tablePathTemplate: new gax.PathTemplate(
+        'projects/{project}/instances/{instance}/tables/{table}'
+      ),
+    };
+
+    // Some of the methods on this service provide streaming responses.
+    // Provide descriptors for these.
+    this._descriptors.stream = {
+      readRows: new gax.StreamDescriptor(gax.StreamType.SERVER_STREAMING),
+      sampleRowKeys: new gax.StreamDescriptor(gax.StreamType.SERVER_STREAMING),
+      mutateRows: new gax.StreamDescriptor(gax.StreamType.SERVER_STREAMING),
+    };
+
+    // Put together the default options sent with requests.
+    var defaults = gaxGrpc.constructSettings(
+      'google.bigtable.v2.Bigtable',
+      gapicConfig,
+      opts.clientConfig,
+      {'x-goog-api-client': clientHeader.join(' ')}
+    );
+
+    // Set up a dictionary of "inner API calls"; the core implementation
+    // of calling the API is handled in `google-gax`, with this code
+    // merely providing the destination and request information.
+    this._innerApiCalls = {};
+
+    // Put together the "service stub" for
+    // google.bigtable.v2.Bigtable.
+    var bigtableStub = gaxGrpc.createStub(
+      protos.google.bigtable.v2.Bigtable,
+      opts
+    );
+
+    // Iterate over each of the methods that the service provides
+    // and create an API call method for each.
+    var bigtableStubMethods = [
+      'readRows',
+      'sampleRowKeys',
+      'mutateRow',
+      'mutateRows',
+      'checkAndMutateRow',
+      'readModifyWriteRow',
+    ];
+    for (let methodName of bigtableStubMethods) {
+      this._innerApiCalls[methodName] = gax.createApiCall(
+        bigtableStub.then(
+          stub =>
+            function() {
+              var args = Array.prototype.slice.call(arguments, 0);
+              return stub[methodName].apply(stub, args);
+            }
+        ),
+        defaults[methodName],
+        this._descriptors.stream[methodName]
+      );
+    }
+  }
+
+  /**
+   * The DNS address for this API service.
+   */
+  static get servicePath() {
+    return 'bigtable.googleapis.com';
+  }
+
+  /**
+   * The port for this API service.
+   */
+  static get port() {
+    return 443;
+  }
+
+  /**
+   * The scopes needed to make gRPC calls for every method defined
+   * in this service.
+   */
+  static get scopes() {
+    return [
+      'https://www.googleapis.com/auth/bigtable.data',
+      'https://www.googleapis.com/auth/bigtable.data.readonly',
+      'https://www.googleapis.com/auth/cloud-bigtable.data',
+      'https://www.googleapis.com/auth/cloud-bigtable.data.readonly',
+      'https://www.googleapis.com/auth/cloud-platform',
+      'https://www.googleapis.com/auth/cloud-platform.read-only',
+    ];
+  }
+
+  /**
+   * Return the project ID used by this class.
+   * @param {function(Error, string)} callback - the callback to
+   *   be called with the current project Id.
+   */
+  getProjectId(callback) {
+    return this.auth.getProjectId(callback);
+  }
+
+  // -------------------
+  // -- Service calls --
+  // -------------------
+
+  /**
+   * Streams back the contents of all requested rows in key order, optionally
+   * applying the same Reader filter to each. Depending on their size,
+   * rows and cells may be broken up across multiple responses, but
+   * atomicity of each row will still be preserved. See the
+   * ReadRowsResponse documentation for details.
+   *
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string} request.tableName
+   *   The unique name of the table from which to read.
+   *   Values are of the form
+   *   `projects/<project>/instances/<instance>/tables/<table>`.
+   * @param {string} [request.appProfileId]
+   *   This is a private alpha release of Cloud Bigtable replication. This feature
+   *   is not currently available to most Cloud Bigtable customers. This feature
+   *   might be changed in backward-incompatible ways and is not recommended for
+   *   production use. It is not subject to any SLA or deprecation policy.
+   *
+   *   This value specifies routing for replication. If not specified, the
+   *   "default" application profile will be used.
+   * @param {Object} [request.rows]
+   *   The row keys and/or ranges to read. If not specified, reads from all rows.
+   *
+   *   This object should have the same structure as [RowSet]{@link google.bigtable.v2.RowSet}
+   * @param {Object} [request.filter]
+   *   The filter to apply to the contents of the specified row(s). If unset,
+   *   reads the entirety of each row.
+   *
+   *   This object should have the same structure as [RowFilter]{@link google.bigtable.v2.RowFilter}
+   * @param {number} [request.rowsLimit]
+   *   The read will terminate after committing to N rows' worth of results. The
+   *   default (zero) is to return all results.
+   * @param {Object} [options]
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+   * @returns {Stream}
+   *   An object stream which emits [ReadRowsResponse]{@link google.bigtable.v2.ReadRowsResponse} on 'data' event.
+   *
+   * @example
+   *
+   * const bigtable = require('@google-cloud/bigtable');
+   *
+   * var client = new bigtable.v2.BigtableClient({
+   *   // optional auth parameters.
+   * });
+   *
+   * var formattedTableName = client.tablePath('[PROJECT]', '[INSTANCE]', '[TABLE]');
+   * client.readRows({tableName: formattedTableName}).on('data', response => {
+   *   // doThingsWith(response)
+   * });
+   */
+  readRows(request, options) {
+    options = options || {};
+
+    return this._innerApiCalls.readRows(request, options);
+  }
+
+  /**
+   * Returns a sample of row keys in the table. The returned row keys will
+   * delimit contiguous sections of the table of approximately equal size,
+   * which can be used to break up the data for distributed tasks like
+   * mapreduces.
+   *
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string} request.tableName
+   *   The unique name of the table from which to sample row keys.
+   *   Values are of the form
+   *   `projects/<project>/instances/<instance>/tables/<table>`.
+   * @param {string} [request.appProfileId]
+   *   This is a private alpha release of Cloud Bigtable replication. This feature
+   *   is not currently available to most Cloud Bigtable customers. This feature
+   *   might be changed in backward-incompatible ways and is not recommended for
+   *   production use. It is not subject to any SLA or deprecation policy.
+   *
+   *   This value specifies routing for replication. If not specified, the
+   *   "default" application profile will be used.
+   * @param {Object} [options]
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+   * @returns {Stream}
+   *   An object stream which emits [SampleRowKeysResponse]{@link google.bigtable.v2.SampleRowKeysResponse} on 'data' event.
+   *
+   * @example
+   *
+   * const bigtable = require('@google-cloud/bigtable');
+   *
+   * var client = new bigtable.v2.BigtableClient({
+   *   // optional auth parameters.
+   * });
+   *
+   * var formattedTableName = client.tablePath('[PROJECT]', '[INSTANCE]', '[TABLE]');
+   * client.sampleRowKeys({tableName: formattedTableName}).on('data', response => {
+   *   // doThingsWith(response)
+   * });
+   */
+  sampleRowKeys(request, options) {
+    options = options || {};
+
+    return this._innerApiCalls.sampleRowKeys(request, options);
+  }
+
+  /**
+   * Mutates a row atomically. Cells already present in the row are left
+   * unchanged unless explicitly changed by `mutation`.
+   *
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string} request.tableName
+   *   The unique name of the table to which the mutation should be applied.
+   *   Values are of the form
+   *   `projects/<project>/instances/<instance>/tables/<table>`.
+   * @param {string} request.rowKey
+   *   The key of the row to which the mutation should be applied.
+   * @param {Object[]} request.mutations
+   *   Changes to be atomically applied to the specified row. Entries are applied
+   *   in order, meaning that earlier mutations can be masked by later ones.
+   *   Must contain at least one entry and at most 100000.
+   *
+   *   This object should have the same structure as [Mutation]{@link google.bigtable.v2.Mutation}
+   * @param {string} [request.appProfileId]
+   *   This is a private alpha release of Cloud Bigtable replication. This feature
+   *   is not currently available to most Cloud Bigtable customers. This feature
+   *   might be changed in backward-incompatible ways and is not recommended for
+   *   production use. It is not subject to any SLA or deprecation policy.
+   *
+   *   This value specifies routing for replication. If not specified, the
+   *   "default" application profile will be used.
+   * @param {Object} [options]
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+   * @param {function(?Error, ?Object)} [callback]
+   *   The function which will be called with the result of the API call.
+   *
+   *   The second parameter to the callback is an object representing [MutateRowResponse]{@link google.bigtable.v2.MutateRowResponse}.
+   * @returns {Promise} - The promise which resolves to an array.
+   *   The first element of the array is an object representing [MutateRowResponse]{@link google.bigtable.v2.MutateRowResponse}.
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *
+   * @example
+   *
+   * const bigtable = require('@google-cloud/bigtable');
+   *
+   * var client = new bigtable.v2.BigtableClient({
+   *   // optional auth parameters.
+   * });
+   *
+   * var formattedTableName = client.tablePath('[PROJECT]', '[INSTANCE]', '[TABLE]');
+   * var rowKey = '';
+   * var mutations = [];
+   * var request = {
+   *   tableName: formattedTableName,
+   *   rowKey: rowKey,
+   *   mutations: mutations,
+   * };
+   * client.mutateRow(request)
+   *   .then(responses => {
+   *     var response = responses[0];
+   *     // doThingsWith(response)
+   *   })
+   *   .catch(err => {
+   *     console.error(err);
+   *   });
+   */
+  mutateRow(request, options, callback) {
+    if (options instanceof Function && callback === undefined) {
+      callback = options;
+      options = {};
+    }
+    options = options || {};
+
+    return this._innerApiCalls.mutateRow(request, options, callback);
+  }
+
+  /**
+   * Mutates multiple rows in a batch. Each individual row is mutated
+   * atomically as in MutateRow, but the entire batch is not executed
+   * atomically.
+   *
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string} request.tableName
+   *   The unique name of the table to which the mutations should be applied.
+   * @param {Object[]} request.entries
+   *   The row keys and corresponding mutations to be applied in bulk.
+   *   Each entry is applied as an atomic mutation, but the entries may be
+   *   applied in arbitrary order (even between entries for the same row).
+   *   At least one entry must be specified, and in total the entries can
+   *   contain at most 100000 mutations.
+   *
+   *   This object should have the same structure as [Entry]{@link google.bigtable.v2.Entry}
+   * @param {string} [request.appProfileId]
+   *   This is a private alpha release of Cloud Bigtable replication. This feature
+   *   is not currently available to most Cloud Bigtable customers. This feature
+   *   might be changed in backward-incompatible ways and is not recommended for
+   *   production use. It is not subject to any SLA or deprecation policy.
+   *
+   *   This value specifies routing for replication. If not specified, the
+   *   "default" application profile will be used.
+   * @param {Object} [options]
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+   * @returns {Stream}
+   *   An object stream which emits [MutateRowsResponse]{@link google.bigtable.v2.MutateRowsResponse} on 'data' event.
+   *
+   * @example
+   *
+   * const bigtable = require('@google-cloud/bigtable');
+   *
+   * var client = new bigtable.v2.BigtableClient({
+   *   // optional auth parameters.
+   * });
+   *
+   * var formattedTableName = client.tablePath('[PROJECT]', '[INSTANCE]', '[TABLE]');
+   * var entries = [];
+   * var request = {
+   *   tableName: formattedTableName,
+   *   entries: entries,
+   * };
+   * client.mutateRows(request).on('data', response => {
+   *   // doThingsWith(response)
+   * });
+   */
+  mutateRows(request, options) {
+    options = options || {};
+
+    return this._innerApiCalls.mutateRows(request, options);
+  }
+
+  /**
+   * Mutates a row atomically based on the output of a predicate Reader filter.
+   *
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string} request.tableName
+   *   The unique name of the table to which the conditional mutation should be
+   *   applied.
+   *   Values are of the form
+   *   `projects/<project>/instances/<instance>/tables/<table>`.
+   * @param {string} request.rowKey
+   *   The key of the row to which the conditional mutation should be applied.
+   * @param {string} [request.appProfileId]
+   *   This is a private alpha release of Cloud Bigtable replication. This feature
+   *   is not currently available to most Cloud Bigtable customers. This feature
+   *   might be changed in backward-incompatible ways and is not recommended for
+   *   production use. It is not subject to any SLA or deprecation policy.
+   *
+   *   This value specifies routing for replication. If not specified, the
+   *   "default" application profile will be used.
+   * @param {Object} [request.predicateFilter]
+   *   The filter to be applied to the contents of the specified row. Depending
+   *   on whether or not any results are yielded, either `true_mutations` or
+   *   `false_mutations` will be executed. If unset, checks that the row contains
+   *   any values at all.
+   *
+   *   This object should have the same structure as [RowFilter]{@link google.bigtable.v2.RowFilter}
+   * @param {Object[]} [request.trueMutations]
+   *   Changes to be atomically applied to the specified row if `predicate_filter`
+   *   yields at least one cell when applied to `row_key`. Entries are applied in
+   *   order, meaning that earlier mutations can be masked by later ones.
+   *   Must contain at least one entry if `false_mutations` is empty, and at most
+   *   100000.
+   *
+   *   This object should have the same structure as [Mutation]{@link google.bigtable.v2.Mutation}
+   * @param {Object[]} [request.falseMutations]
+   *   Changes to be atomically applied to the specified row if `predicate_filter`
+   *   does not yield any cells when applied to `row_key`. Entries are applied in
+   *   order, meaning that earlier mutations can be masked by later ones.
+   *   Must contain at least one entry if `true_mutations` is empty, and at most
+   *   100000.
+   *
+   *   This object should have the same structure as [Mutation]{@link google.bigtable.v2.Mutation}
+   * @param {Object} [options]
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+   * @param {function(?Error, ?Object)} [callback]
+   *   The function which will be called with the result of the API call.
+   *
+   *   The second parameter to the callback is an object representing [CheckAndMutateRowResponse]{@link google.bigtable.v2.CheckAndMutateRowResponse}.
+   * @returns {Promise} - The promise which resolves to an array.
+   *   The first element of the array is an object representing [CheckAndMutateRowResponse]{@link google.bigtable.v2.CheckAndMutateRowResponse}.
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *
+   * @example
+   *
+   * const bigtable = require('@google-cloud/bigtable');
+   *
+   * var client = new bigtable.v2.BigtableClient({
+   *   // optional auth parameters.
+   * });
+   *
+   * var formattedTableName = client.tablePath('[PROJECT]', '[INSTANCE]', '[TABLE]');
+   * var rowKey = '';
+   * var request = {
+   *   tableName: formattedTableName,
+   *   rowKey: rowKey,
+   * };
+   * client.checkAndMutateRow(request)
+   *   .then(responses => {
+   *     var response = responses[0];
+   *     // doThingsWith(response)
+   *   })
+   *   .catch(err => {
+   *     console.error(err);
+   *   });
+   */
+  checkAndMutateRow(request, options, callback) {
+    if (options instanceof Function && callback === undefined) {
+      callback = options;
+      options = {};
+    }
+    options = options || {};
+
+    return this._innerApiCalls.checkAndMutateRow(request, options, callback);
+  }
+
+  /**
+   * Modifies a row atomically on the server. The method reads the latest
+   * existing timestamp and value from the specified columns and writes a new
+   * entry based on pre-defined read/modify/write rules. The new value for the
+   * timestamp is the greater of the existing timestamp or the current server
+   * time. The method returns the new contents of all modified cells.
+   *
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string} request.tableName
+   *   The unique name of the table to which the read/modify/write rules should be
+   *   applied.
+   *   Values are of the form
+   *   `projects/<project>/instances/<instance>/tables/<table>`.
+   * @param {string} request.rowKey
+   *   The key of the row to which the read/modify/write rules should be applied.
+   * @param {Object[]} request.rules
+   *   Rules specifying how the specified row's contents are to be transformed
+   *   into writes. Entries are applied in order, meaning that earlier rules will
+   *   affect the results of later ones.
+   *
+   *   This object should have the same structure as [ReadModifyWriteRule]{@link google.bigtable.v2.ReadModifyWriteRule}
+   * @param {string} [request.appProfileId]
+   *   This is a private alpha release of Cloud Bigtable replication. This feature
+   *   is not currently available to most Cloud Bigtable customers. This feature
+   *   might be changed in backward-incompatible ways and is not recommended for
+   *   production use. It is not subject to any SLA or deprecation policy.
+   *
+   *   This value specifies routing for replication. If not specified, the
+   *   "default" application profile will be used.
+   * @param {Object} [options]
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+   * @param {function(?Error, ?Object)} [callback]
+   *   The function which will be called with the result of the API call.
+   *
+   *   The second parameter to the callback is an object representing [ReadModifyWriteRowResponse]{@link google.bigtable.v2.ReadModifyWriteRowResponse}.
+   * @returns {Promise} - The promise which resolves to an array.
+   *   The first element of the array is an object representing [ReadModifyWriteRowResponse]{@link google.bigtable.v2.ReadModifyWriteRowResponse}.
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *
+   * @example
+   *
+   * const bigtable = require('@google-cloud/bigtable');
+   *
+   * var client = new bigtable.v2.BigtableClient({
+   *   // optional auth parameters.
+   * });
+   *
+   * var formattedTableName = client.tablePath('[PROJECT]', '[INSTANCE]', '[TABLE]');
+   * var rowKey = '';
+   * var rules = [];
+   * var request = {
+   *   tableName: formattedTableName,
+   *   rowKey: rowKey,
+   *   rules: rules,
+   * };
+   * client.readModifyWriteRow(request)
+   *   .then(responses => {
+   *     var response = responses[0];
+   *     // doThingsWith(response)
+   *   })
+   *   .catch(err => {
+   *     console.error(err);
+   *   });
+   */
+  readModifyWriteRow(request, options, callback) {
+    if (options instanceof Function && callback === undefined) {
+      callback = options;
+      options = {};
+    }
+    options = options || {};
+
+    return this._innerApiCalls.readModifyWriteRow(request, options, callback);
+  }
+
+  // --------------------
+  // -- Path templates --
+  // --------------------
+
+  /**
+   * Return a fully-qualified table resource name string.
+   *
+   * @param {String} project
+   * @param {String} instance
+   * @param {String} table
+   * @returns {String}
+   */
+  tablePath(project, instance, table) {
+    return this._pathTemplates.tablePathTemplate.render({
+      project: project,
+      instance: instance,
+      table: table,
+    });
+  }
+
+  /**
+   * Parse the tableName from a table resource.
+   *
+   * @param {String} tableName
+   *   A fully-qualified path representing a table resources.
+   * @returns {String} - A string representing the project.
+   */
+  matchProjectFromTableName(tableName) {
+    return this._pathTemplates.tablePathTemplate
+      .match(tableName)
+      .project;
+  }
+
+  /**
+   * Parse the tableName from a table resource.
+   *
+   * @param {String} tableName
+   *   A fully-qualified path representing a table resources.
+   * @returns {String} - A string representing the instance.
+   */
+  matchInstanceFromTableName(tableName) {
+    return this._pathTemplates.tablePathTemplate
+      .match(tableName)
+      .instance;
+  }
+
+  /**
+   * Parse the tableName from a table resource.
+   *
+   * @param {String} tableName
+   *   A fully-qualified path representing a table resources.
+   * @returns {String} - A string representing the table.
+   */
+  matchTableFromTableName(tableName) {
+    return this._pathTemplates.tablePathTemplate
+      .match(tableName)
+      .table;
+  }
+}
+
+
+module.exports = BigtableClient;

--- a/src/v2/bigtable_client_config.json
+++ b/src/v2/bigtable_client_config.json
@@ -1,0 +1,56 @@
+{
+  "interfaces": {
+    "google.bigtable.v2.Bigtable": {
+      "retry_codes": {
+        "idempotent": [
+          "DEADLINE_EXCEEDED",
+          "UNAVAILABLE"
+        ],
+        "non_idempotent": []
+      },
+      "retry_params": {
+        "default": {
+          "initial_retry_delay_millis": 100,
+          "retry_delay_multiplier": 1.3,
+          "max_retry_delay_millis": 60000,
+          "initial_rpc_timeout_millis": 20000,
+          "rpc_timeout_multiplier": 1.0,
+          "max_rpc_timeout_millis": 20000,
+          "total_timeout_millis": 600000
+        }
+      },
+      "methods": {
+        "ReadRows": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "SampleRowKeys": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "idempotent",
+          "retry_params_name": "default"
+        },
+        "MutateRow": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "MutateRows": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "CheckAndMutateRow": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "ReadModifyWriteRow": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        }
+      }
+    }
+  }
+}

--- a/src/v2/doc/google/bigtable/v2/doc_bigtable.js
+++ b/src/v2/doc/google/bigtable/v2/doc_bigtable.js
@@ -1,0 +1,459 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Note: this file is purely for documentation. Any contents are not expected
+// to be loaded as the JS file.
+
+/**
+ * Request message for Bigtable.ReadRows.
+ *
+ * @property {string} tableName
+ *   The unique name of the table from which to read.
+ *   Values are of the form
+ *   `projects/<project>/instances/<instance>/tables/<table>`.
+ *
+ * @property {string} appProfileId
+ *   This is a private alpha release of Cloud Bigtable replication. This feature
+ *   is not currently available to most Cloud Bigtable customers. This feature
+ *   might be changed in backward-incompatible ways and is not recommended for
+ *   production use. It is not subject to any SLA or deprecation policy.
+ *
+ *   This value specifies routing for replication. If not specified, the
+ *   "default" application profile will be used.
+ *
+ * @property {Object} rows
+ *   The row keys and/or ranges to read. If not specified, reads from all rows.
+ *
+ *   This object should have the same structure as [RowSet]{@link google.bigtable.v2.RowSet}
+ *
+ * @property {Object} filter
+ *   The filter to apply to the contents of the specified row(s). If unset,
+ *   reads the entirety of each row.
+ *
+ *   This object should have the same structure as [RowFilter]{@link google.bigtable.v2.RowFilter}
+ *
+ * @property {number} rowsLimit
+ *   The read will terminate after committing to N rows' worth of results. The
+ *   default (zero) is to return all results.
+ *
+ * @typedef ReadRowsRequest
+ * @memberof google.bigtable.v2
+ * @see [google.bigtable.v2.ReadRowsRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/bigtable/v2/bigtable.proto}
+ */
+var ReadRowsRequest = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Response message for Bigtable.ReadRows.
+ *
+ * @property {Object[]} chunks
+ *   This object should have the same structure as [CellChunk]{@link google.bigtable.v2.CellChunk}
+ *
+ * @property {string} lastScannedRowKey
+ *   Optionally the server might return the row key of the last row it
+ *   has scanned.  The client can use this to construct a more
+ *   efficient retry request if needed: any row keys or portions of
+ *   ranges less than this row key can be dropped from the request.
+ *   This is primarily useful for cases where the server has read a
+ *   lot of data that was filtered out since the last committed row
+ *   key, allowing the client to skip that work on a retry.
+ *
+ * @typedef ReadRowsResponse
+ * @memberof google.bigtable.v2
+ * @see [google.bigtable.v2.ReadRowsResponse definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/bigtable/v2/bigtable.proto}
+ */
+var ReadRowsResponse = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+
+  /**
+   * Specifies a piece of a row's contents returned as part of the read
+   * response stream.
+   *
+   * @property {string} rowKey
+   *   The row key for this chunk of data.  If the row key is empty,
+   *   this CellChunk is a continuation of the same row as the previous
+   *   CellChunk in the response stream, even if that CellChunk was in a
+   *   previous ReadRowsResponse message.
+   *
+   * @property {Object} familyName
+   *   The column family name for this chunk of data.  If this message
+   *   is not present this CellChunk is a continuation of the same column
+   *   family as the previous CellChunk.  The empty string can occur as a
+   *   column family name in a response so clients must check
+   *   explicitly for the presence of this message, not just for
+   *   `family_name.value` being non-empty.
+   *
+   *   This object should have the same structure as [StringValue]{@link google.protobuf.StringValue}
+   *
+   * @property {Object} qualifier
+   *   The column qualifier for this chunk of data.  If this message
+   *   is not present, this CellChunk is a continuation of the same column
+   *   as the previous CellChunk.  Column qualifiers may be empty so
+   *   clients must check for the presence of this message, not just
+   *   for `qualifier.value` being non-empty.
+   *
+   *   This object should have the same structure as [BytesValue]{@link google.protobuf.BytesValue}
+   *
+   * @property {number} timestampMicros
+   *   The cell's stored timestamp, which also uniquely identifies it
+   *   within its column.  Values are always expressed in
+   *   microseconds, but individual tables may set a coarser
+   *   granularity to further restrict the allowed values. For
+   *   example, a table which specifies millisecond granularity will
+   *   only allow values of `timestamp_micros` which are multiples of
+   *   1000.  Timestamps are only set in the first CellChunk per cell
+   *   (for cells split into multiple chunks).
+   *
+   * @property {string[]} labels
+   *   Labels applied to the cell by a
+   *   RowFilter.  Labels are only set
+   *   on the first CellChunk per cell.
+   *
+   * @property {string} value
+   *   The value stored in the cell.  Cell values can be split across
+   *   multiple CellChunks.  In that case only the value field will be
+   *   set in CellChunks after the first: the timestamp and labels
+   *   will only be present in the first CellChunk, even if the first
+   *   CellChunk came in a previous ReadRowsResponse.
+   *
+   * @property {number} valueSize
+   *   If this CellChunk is part of a chunked cell value and this is
+   *   not the final chunk of that cell, value_size will be set to the
+   *   total length of the cell value.  The client can use this size
+   *   to pre-allocate memory to hold the full cell value.
+   *
+   * @property {boolean} resetRow
+   *   Indicates that the client should drop all previous chunks for
+   *   `row_key`, as it will be re-read from the beginning.
+   *
+   * @property {boolean} commitRow
+   *   Indicates that the client can safely process all previous chunks for
+   *   `row_key`, as its data has been fully read.
+   *
+   * @typedef CellChunk
+   * @memberof google.bigtable.v2
+   * @see [google.bigtable.v2.ReadRowsResponse.CellChunk definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/bigtable/v2/bigtable.proto}
+   */
+  CellChunk: {
+    // This is for documentation. Actual contents will be loaded by gRPC.
+  }
+};
+
+/**
+ * Request message for Bigtable.SampleRowKeys.
+ *
+ * @property {string} tableName
+ *   The unique name of the table from which to sample row keys.
+ *   Values are of the form
+ *   `projects/<project>/instances/<instance>/tables/<table>`.
+ *
+ * @property {string} appProfileId
+ *   This is a private alpha release of Cloud Bigtable replication. This feature
+ *   is not currently available to most Cloud Bigtable customers. This feature
+ *   might be changed in backward-incompatible ways and is not recommended for
+ *   production use. It is not subject to any SLA or deprecation policy.
+ *
+ *   This value specifies routing for replication. If not specified, the
+ *   "default" application profile will be used.
+ *
+ * @typedef SampleRowKeysRequest
+ * @memberof google.bigtable.v2
+ * @see [google.bigtable.v2.SampleRowKeysRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/bigtable/v2/bigtable.proto}
+ */
+var SampleRowKeysRequest = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Response message for Bigtable.SampleRowKeys.
+ *
+ * @property {string} rowKey
+ *   Sorted streamed sequence of sample row keys in the table. The table might
+ *   have contents before the first row key in the list and after the last one,
+ *   but a key containing the empty string indicates "end of table" and will be
+ *   the last response given, if present.
+ *   Note that row keys in this list may not have ever been written to or read
+ *   from, and users should therefore not make any assumptions about the row key
+ *   structure that are specific to their use case.
+ *
+ * @property {number} offsetBytes
+ *   Approximate total storage space used by all rows in the table which precede
+ *   `row_key`. Buffering the contents of all rows between two subsequent
+ *   samples would require space roughly equal to the difference in their
+ *   `offset_bytes` fields.
+ *
+ * @typedef SampleRowKeysResponse
+ * @memberof google.bigtable.v2
+ * @see [google.bigtable.v2.SampleRowKeysResponse definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/bigtable/v2/bigtable.proto}
+ */
+var SampleRowKeysResponse = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Request message for Bigtable.MutateRow.
+ *
+ * @property {string} tableName
+ *   The unique name of the table to which the mutation should be applied.
+ *   Values are of the form
+ *   `projects/<project>/instances/<instance>/tables/<table>`.
+ *
+ * @property {string} appProfileId
+ *   This is a private alpha release of Cloud Bigtable replication. This feature
+ *   is not currently available to most Cloud Bigtable customers. This feature
+ *   might be changed in backward-incompatible ways and is not recommended for
+ *   production use. It is not subject to any SLA or deprecation policy.
+ *
+ *   This value specifies routing for replication. If not specified, the
+ *   "default" application profile will be used.
+ *
+ * @property {string} rowKey
+ *   The key of the row to which the mutation should be applied.
+ *
+ * @property {Object[]} mutations
+ *   Changes to be atomically applied to the specified row. Entries are applied
+ *   in order, meaning that earlier mutations can be masked by later ones.
+ *   Must contain at least one entry and at most 100000.
+ *
+ *   This object should have the same structure as [Mutation]{@link google.bigtable.v2.Mutation}
+ *
+ * @typedef MutateRowRequest
+ * @memberof google.bigtable.v2
+ * @see [google.bigtable.v2.MutateRowRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/bigtable/v2/bigtable.proto}
+ */
+var MutateRowRequest = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Response message for Bigtable.MutateRow.
+ * @typedef MutateRowResponse
+ * @memberof google.bigtable.v2
+ * @see [google.bigtable.v2.MutateRowResponse definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/bigtable/v2/bigtable.proto}
+ */
+var MutateRowResponse = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Request message for BigtableService.MutateRows.
+ *
+ * @property {string} tableName
+ *   The unique name of the table to which the mutations should be applied.
+ *
+ * @property {string} appProfileId
+ *   This is a private alpha release of Cloud Bigtable replication. This feature
+ *   is not currently available to most Cloud Bigtable customers. This feature
+ *   might be changed in backward-incompatible ways and is not recommended for
+ *   production use. It is not subject to any SLA or deprecation policy.
+ *
+ *   This value specifies routing for replication. If not specified, the
+ *   "default" application profile will be used.
+ *
+ * @property {Object[]} entries
+ *   The row keys and corresponding mutations to be applied in bulk.
+ *   Each entry is applied as an atomic mutation, but the entries may be
+ *   applied in arbitrary order (even between entries for the same row).
+ *   At least one entry must be specified, and in total the entries can
+ *   contain at most 100000 mutations.
+ *
+ *   This object should have the same structure as [Entry]{@link google.bigtable.v2.Entry}
+ *
+ * @typedef MutateRowsRequest
+ * @memberof google.bigtable.v2
+ * @see [google.bigtable.v2.MutateRowsRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/bigtable/v2/bigtable.proto}
+ */
+var MutateRowsRequest = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+
+  /**
+   * @property {string} rowKey
+   *   The key of the row to which the `mutations` should be applied.
+   *
+   * @property {Object[]} mutations
+   *   Changes to be atomically applied to the specified row. Mutations are
+   *   applied in order, meaning that earlier mutations can be masked by
+   *   later ones.
+   *   You must specify at least one mutation.
+   *
+   *   This object should have the same structure as [Mutation]{@link google.bigtable.v2.Mutation}
+   *
+   * @typedef Entry
+   * @memberof google.bigtable.v2
+   * @see [google.bigtable.v2.MutateRowsRequest.Entry definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/bigtable/v2/bigtable.proto}
+   */
+  Entry: {
+    // This is for documentation. Actual contents will be loaded by gRPC.
+  }
+};
+
+/**
+ * Response message for BigtableService.MutateRows.
+ *
+ * @property {Object[]} entries
+ *   One or more results for Entries from the batch request.
+ *
+ *   This object should have the same structure as [Entry]{@link google.bigtable.v2.Entry}
+ *
+ * @typedef MutateRowsResponse
+ * @memberof google.bigtable.v2
+ * @see [google.bigtable.v2.MutateRowsResponse definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/bigtable/v2/bigtable.proto}
+ */
+var MutateRowsResponse = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+
+  /**
+   * @property {number} index
+   *   The index into the original request's `entries` list of the Entry
+   *   for which a result is being reported.
+   *
+   * @property {Object} status
+   *   The result of the request Entry identified by `index`.
+   *   Depending on how requests are batched during execution, it is possible
+   *   for one Entry to fail due to an error with another Entry. In the event
+   *   that this occurs, the same error will be reported for both entries.
+   *
+   *   This object should have the same structure as [Status]{@link google.rpc.Status}
+   *
+   * @typedef Entry
+   * @memberof google.bigtable.v2
+   * @see [google.bigtable.v2.MutateRowsResponse.Entry definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/bigtable/v2/bigtable.proto}
+   */
+  Entry: {
+    // This is for documentation. Actual contents will be loaded by gRPC.
+  }
+};
+
+/**
+ * Request message for Bigtable.CheckAndMutateRow.
+ *
+ * @property {string} tableName
+ *   The unique name of the table to which the conditional mutation should be
+ *   applied.
+ *   Values are of the form
+ *   `projects/<project>/instances/<instance>/tables/<table>`.
+ *
+ * @property {string} appProfileId
+ *   This is a private alpha release of Cloud Bigtable replication. This feature
+ *   is not currently available to most Cloud Bigtable customers. This feature
+ *   might be changed in backward-incompatible ways and is not recommended for
+ *   production use. It is not subject to any SLA or deprecation policy.
+ *
+ *   This value specifies routing for replication. If not specified, the
+ *   "default" application profile will be used.
+ *
+ * @property {string} rowKey
+ *   The key of the row to which the conditional mutation should be applied.
+ *
+ * @property {Object} predicateFilter
+ *   The filter to be applied to the contents of the specified row. Depending
+ *   on whether or not any results are yielded, either `true_mutations` or
+ *   `false_mutations` will be executed. If unset, checks that the row contains
+ *   any values at all.
+ *
+ *   This object should have the same structure as [RowFilter]{@link google.bigtable.v2.RowFilter}
+ *
+ * @property {Object[]} trueMutations
+ *   Changes to be atomically applied to the specified row if `predicate_filter`
+ *   yields at least one cell when applied to `row_key`. Entries are applied in
+ *   order, meaning that earlier mutations can be masked by later ones.
+ *   Must contain at least one entry if `false_mutations` is empty, and at most
+ *   100000.
+ *
+ *   This object should have the same structure as [Mutation]{@link google.bigtable.v2.Mutation}
+ *
+ * @property {Object[]} falseMutations
+ *   Changes to be atomically applied to the specified row if `predicate_filter`
+ *   does not yield any cells when applied to `row_key`. Entries are applied in
+ *   order, meaning that earlier mutations can be masked by later ones.
+ *   Must contain at least one entry if `true_mutations` is empty, and at most
+ *   100000.
+ *
+ *   This object should have the same structure as [Mutation]{@link google.bigtable.v2.Mutation}
+ *
+ * @typedef CheckAndMutateRowRequest
+ * @memberof google.bigtable.v2
+ * @see [google.bigtable.v2.CheckAndMutateRowRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/bigtable/v2/bigtable.proto}
+ */
+var CheckAndMutateRowRequest = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Response message for Bigtable.CheckAndMutateRow.
+ *
+ * @property {boolean} predicateMatched
+ *   Whether or not the request's `predicate_filter` yielded any results for
+ *   the specified row.
+ *
+ * @typedef CheckAndMutateRowResponse
+ * @memberof google.bigtable.v2
+ * @see [google.bigtable.v2.CheckAndMutateRowResponse definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/bigtable/v2/bigtable.proto}
+ */
+var CheckAndMutateRowResponse = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Request message for Bigtable.ReadModifyWriteRow.
+ *
+ * @property {string} tableName
+ *   The unique name of the table to which the read/modify/write rules should be
+ *   applied.
+ *   Values are of the form
+ *   `projects/<project>/instances/<instance>/tables/<table>`.
+ *
+ * @property {string} appProfileId
+ *   This is a private alpha release of Cloud Bigtable replication. This feature
+ *   is not currently available to most Cloud Bigtable customers. This feature
+ *   might be changed in backward-incompatible ways and is not recommended for
+ *   production use. It is not subject to any SLA or deprecation policy.
+ *
+ *   This value specifies routing for replication. If not specified, the
+ *   "default" application profile will be used.
+ *
+ * @property {string} rowKey
+ *   The key of the row to which the read/modify/write rules should be applied.
+ *
+ * @property {Object[]} rules
+ *   Rules specifying how the specified row's contents are to be transformed
+ *   into writes. Entries are applied in order, meaning that earlier rules will
+ *   affect the results of later ones.
+ *
+ *   This object should have the same structure as [ReadModifyWriteRule]{@link google.bigtable.v2.ReadModifyWriteRule}
+ *
+ * @typedef ReadModifyWriteRowRequest
+ * @memberof google.bigtable.v2
+ * @see [google.bigtable.v2.ReadModifyWriteRowRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/bigtable/v2/bigtable.proto}
+ */
+var ReadModifyWriteRowRequest = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Response message for Bigtable.ReadModifyWriteRow.
+ *
+ * @property {Object} row
+ *   A Row containing the new contents of all cells modified by the request.
+ *
+ *   This object should have the same structure as [Row]{@link google.bigtable.v2.Row}
+ *
+ * @typedef ReadModifyWriteRowResponse
+ * @memberof google.bigtable.v2
+ * @see [google.bigtable.v2.ReadModifyWriteRowResponse definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/bigtable/v2/bigtable.proto}
+ */
+var ReadModifyWriteRowResponse = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};

--- a/src/v2/doc/google/bigtable/v2/doc_data.js
+++ b/src/v2/doc/google/bigtable/v2/doc_data.js
@@ -1,0 +1,680 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Note: this file is purely for documentation. Any contents are not expected
+// to be loaded as the JS file.
+
+/**
+ * Specifies the complete (requested) contents of a single row of a table.
+ * Rows which exceed 256MiB in size cannot be read in full.
+ *
+ * @property {string} key
+ *   The unique key which identifies this row within its table. This is the same
+ *   key that's used to identify the row in, for example, a MutateRowRequest.
+ *   May contain any non-empty byte string up to 4KiB in length.
+ *
+ * @property {Object[]} families
+ *   May be empty, but only if the entire row is empty.
+ *   The mutual ordering of column families is not specified.
+ *
+ *   This object should have the same structure as [Family]{@link google.bigtable.v2.Family}
+ *
+ * @typedef Row
+ * @memberof google.bigtable.v2
+ * @see [google.bigtable.v2.Row definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/bigtable/v2/data.proto}
+ */
+var Row = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Specifies (some of) the contents of a single row/column family intersection
+ * of a table.
+ *
+ * @property {string} name
+ *   The unique key which identifies this family within its row. This is the
+ *   same key that's used to identify the family in, for example, a RowFilter
+ *   which sets its "family_name_regex_filter" field.
+ *   Must match `[-_.a-zA-Z0-9]+`, except that AggregatingRowProcessors may
+ *   produce cells in a sentinel family with an empty name.
+ *   Must be no greater than 64 characters in length.
+ *
+ * @property {Object[]} columns
+ *   Must not be empty. Sorted in order of increasing "qualifier".
+ *
+ *   This object should have the same structure as [Column]{@link google.bigtable.v2.Column}
+ *
+ * @typedef Family
+ * @memberof google.bigtable.v2
+ * @see [google.bigtable.v2.Family definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/bigtable/v2/data.proto}
+ */
+var Family = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Specifies (some of) the contents of a single row/column intersection of a
+ * table.
+ *
+ * @property {string} qualifier
+ *   The unique key which identifies this column within its family. This is the
+ *   same key that's used to identify the column in, for example, a RowFilter
+ *   which sets its `column_qualifier_regex_filter` field.
+ *   May contain any byte string, including the empty string, up to 16kiB in
+ *   length.
+ *
+ * @property {Object[]} cells
+ *   Must not be empty. Sorted in order of decreasing "timestamp_micros".
+ *
+ *   This object should have the same structure as [Cell]{@link google.bigtable.v2.Cell}
+ *
+ * @typedef Column
+ * @memberof google.bigtable.v2
+ * @see [google.bigtable.v2.Column definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/bigtable/v2/data.proto}
+ */
+var Column = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Specifies (some of) the contents of a single row/column/timestamp of a table.
+ *
+ * @property {number} timestampMicros
+ *   The cell's stored timestamp, which also uniquely identifies it within
+ *   its column.
+ *   Values are always expressed in microseconds, but individual tables may set
+ *   a coarser granularity to further restrict the allowed values. For
+ *   example, a table which specifies millisecond granularity will only allow
+ *   values of `timestamp_micros` which are multiples of 1000.
+ *
+ * @property {string} value
+ *   The value stored in the cell.
+ *   May contain any byte string, including the empty string, up to 100MiB in
+ *   length.
+ *
+ * @property {string[]} labels
+ *   Labels applied to the cell by a RowFilter.
+ *
+ * @typedef Cell
+ * @memberof google.bigtable.v2
+ * @see [google.bigtable.v2.Cell definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/bigtable/v2/data.proto}
+ */
+var Cell = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Specifies a contiguous range of rows.
+ *
+ * @property {string} startKeyClosed
+ *   Used when giving an inclusive lower bound for the range.
+ *
+ * @property {string} startKeyOpen
+ *   Used when giving an exclusive lower bound for the range.
+ *
+ * @property {string} endKeyOpen
+ *   Used when giving an exclusive upper bound for the range.
+ *
+ * @property {string} endKeyClosed
+ *   Used when giving an inclusive upper bound for the range.
+ *
+ * @typedef RowRange
+ * @memberof google.bigtable.v2
+ * @see [google.bigtable.v2.RowRange definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/bigtable/v2/data.proto}
+ */
+var RowRange = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Specifies a non-contiguous set of rows.
+ *
+ * @property {string[]} rowKeys
+ *   Single rows included in the set.
+ *
+ * @property {Object[]} rowRanges
+ *   Contiguous row ranges included in the set.
+ *
+ *   This object should have the same structure as [RowRange]{@link google.bigtable.v2.RowRange}
+ *
+ * @typedef RowSet
+ * @memberof google.bigtable.v2
+ * @see [google.bigtable.v2.RowSet definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/bigtable/v2/data.proto}
+ */
+var RowSet = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Specifies a contiguous range of columns within a single column family.
+ * The range spans from &lt;column_family&gt;:&lt;start_qualifier&gt; to
+ * &lt;column_family&gt;:&lt;end_qualifier&gt;, where both bounds can be either
+ * inclusive or exclusive.
+ *
+ * @property {string} familyName
+ *   The name of the column family within which this range falls.
+ *
+ * @property {string} startQualifierClosed
+ *   Used when giving an inclusive lower bound for the range.
+ *
+ * @property {string} startQualifierOpen
+ *   Used when giving an exclusive lower bound for the range.
+ *
+ * @property {string} endQualifierClosed
+ *   Used when giving an inclusive upper bound for the range.
+ *
+ * @property {string} endQualifierOpen
+ *   Used when giving an exclusive upper bound for the range.
+ *
+ * @typedef ColumnRange
+ * @memberof google.bigtable.v2
+ * @see [google.bigtable.v2.ColumnRange definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/bigtable/v2/data.proto}
+ */
+var ColumnRange = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Specified a contiguous range of microsecond timestamps.
+ *
+ * @property {number} startTimestampMicros
+ *   Inclusive lower bound. If left empty, interpreted as 0.
+ *
+ * @property {number} endTimestampMicros
+ *   Exclusive upper bound. If left empty, interpreted as infinity.
+ *
+ * @typedef TimestampRange
+ * @memberof google.bigtable.v2
+ * @see [google.bigtable.v2.TimestampRange definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/bigtable/v2/data.proto}
+ */
+var TimestampRange = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Specifies a contiguous range of raw byte values.
+ *
+ * @property {string} startValueClosed
+ *   Used when giving an inclusive lower bound for the range.
+ *
+ * @property {string} startValueOpen
+ *   Used when giving an exclusive lower bound for the range.
+ *
+ * @property {string} endValueClosed
+ *   Used when giving an inclusive upper bound for the range.
+ *
+ * @property {string} endValueOpen
+ *   Used when giving an exclusive upper bound for the range.
+ *
+ * @typedef ValueRange
+ * @memberof google.bigtable.v2
+ * @see [google.bigtable.v2.ValueRange definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/bigtable/v2/data.proto}
+ */
+var ValueRange = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Takes a row as input and produces an alternate view of the row based on
+ * specified rules. For example, a RowFilter might trim down a row to include
+ * just the cells from columns matching a given regular expression, or might
+ * return all the cells of a row but not their values. More complicated filters
+ * can be composed out of these components to express requests such as, "within
+ * every column of a particular family, give just the two most recent cells
+ * which are older than timestamp X."
+ *
+ * There are two broad categories of RowFilters (true filters and transformers),
+ * as well as two ways to compose simple filters into more complex ones
+ * (chains and interleaves). They work as follows:
+ *
+ * * True filters alter the input row by excluding some of its cells wholesale
+ * from the output row. An example of a true filter is the `value_regex_filter`,
+ * which excludes cells whose values don't match the specified pattern. All
+ * regex true filters use RE2 syntax (https://github.com/google/re2/wiki/Syntax)
+ * in raw byte mode (RE2::Latin1), and are evaluated as full matches. An
+ * important point to keep in mind is that `RE2(.)` is equivalent by default to
+ * `RE2([^\n])`, meaning that it does not match newlines. When attempting to
+ * match an arbitrary byte, you should therefore use the escape sequence `\C`,
+ * which may need to be further escaped as `\\C` in your client language.
+ *
+ * * Transformers alter the input row by changing the values of some of its
+ * cells in the output, without excluding them completely. Currently, the only
+ * supported transformer is the `strip_value_transformer`, which replaces every
+ * cell's value with the empty string.
+ *
+ * * Chains and interleaves are described in more detail in the
+ * RowFilter.Chain and RowFilter.Interleave documentation.
+ *
+ * The total serialized size of a RowFilter message must not
+ * exceed 4096 bytes, and RowFilters may not be nested within each other
+ * (in Chains or Interleaves) to a depth of more than 20.
+ *
+ * @property {Object} chain
+ *   Applies several RowFilters to the data in sequence, progressively
+ *   narrowing the results.
+ *
+ *   This object should have the same structure as [Chain]{@link google.bigtable.v2.Chain}
+ *
+ * @property {Object} interleave
+ *   Applies several RowFilters to the data in parallel and combines the
+ *   results.
+ *
+ *   This object should have the same structure as [Interleave]{@link google.bigtable.v2.Interleave}
+ *
+ * @property {Object} condition
+ *   Applies one of two possible RowFilters to the data based on the output of
+ *   a predicate RowFilter.
+ *
+ *   This object should have the same structure as [Condition]{@link google.bigtable.v2.Condition}
+ *
+ * @property {boolean} sink
+ *   ADVANCED USE ONLY.
+ *   Hook for introspection into the RowFilter. Outputs all cells directly to
+ *   the output of the read rather than to any parent filter. Consider the
+ *   following example:
+ *
+ *       Chain(
+ *         FamilyRegex("A"),
+ *         Interleave(
+ *           All(),
+ *           Chain(Label("foo"), Sink())
+ *         ),
+ *         QualifierRegex("B")
+ *       )
+ *
+ *                           A,A,1,w
+ *                           A,B,2,x
+ *                           B,B,4,z
+ *                              |
+ *                       FamilyRegex("A")
+ *                              |
+ *                           A,A,1,w
+ *                           A,B,2,x
+ *                              |
+ *                 +------------+-------------+
+ *                 |                          |
+ *               All()                    Label(foo)
+ *                 |                          |
+ *              A,A,1,w              A,A,1,w,labels:[foo]
+ *              A,B,2,x              A,B,2,x,labels:[foo]
+ *                 |                          |
+ *                 |                        Sink() --------------+
+ *                 |                          |                  |
+ *                 +------------+      x------+          A,A,1,w,labels:[foo]
+ *                              |                        A,B,2,x,labels:[foo]
+ *                           A,A,1,w                             |
+ *                           A,B,2,x                             |
+ *                              |                                |
+ *                      QualifierRegex("B")                      |
+ *                              |                                |
+ *                           A,B,2,x                             |
+ *                              |                                |
+ *                              +--------------------------------+
+ *                              |
+ *                           A,A,1,w,labels:[foo]
+ *                           A,B,2,x,labels:[foo]  // could be switched
+ *                           A,B,2,x               // could be switched
+ *
+ *   Despite being excluded by the qualifier filter, a copy of every cell
+ *   that reaches the sink is present in the final result.
+ *
+ *   As with an Interleave,
+ *   duplicate cells are possible, and appear in an unspecified mutual order.
+ *   In this case we have a duplicate with column "A:B" and timestamp 2,
+ *   because one copy passed through the all filter while the other was
+ *   passed through the label and sink. Note that one copy has label "foo",
+ *   while the other does not.
+ *
+ *   Cannot be used within the `predicate_filter`, `true_filter`, or
+ *   `false_filter` of a Condition.
+ *
+ * @property {boolean} passAllFilter
+ *   Matches all cells, regardless of input. Functionally equivalent to
+ *   leaving `filter` unset, but included for completeness.
+ *
+ * @property {boolean} blockAllFilter
+ *   Does not match any cells, regardless of input. Useful for temporarily
+ *   disabling just part of a filter.
+ *
+ * @property {string} rowKeyRegexFilter
+ *   Matches only cells from rows whose keys satisfy the given RE2 regex. In
+ *   other words, passes through the entire row when the key matches, and
+ *   otherwise produces an empty row.
+ *   Note that, since row keys can contain arbitrary bytes, the `\C` escape
+ *   sequence must be used if a true wildcard is desired. The `.` character
+ *   will not match the new line character `\n`, which may be present in a
+ *   binary key.
+ *
+ * @property {number} rowSampleFilter
+ *   Matches all cells from a row with probability p, and matches no cells
+ *   from the row with probability 1-p.
+ *
+ * @property {string} familyNameRegexFilter
+ *   Matches only cells from columns whose families satisfy the given RE2
+ *   regex. For technical reasons, the regex must not contain the `:`
+ *   character, even if it is not being used as a literal.
+ *   Note that, since column families cannot contain the new line character
+ *   `\n`, it is sufficient to use `.` as a full wildcard when matching
+ *   column family names.
+ *
+ * @property {string} columnQualifierRegexFilter
+ *   Matches only cells from columns whose qualifiers satisfy the given RE2
+ *   regex.
+ *   Note that, since column qualifiers can contain arbitrary bytes, the `\C`
+ *   escape sequence must be used if a true wildcard is desired. The `.`
+ *   character will not match the new line character `\n`, which may be
+ *   present in a binary qualifier.
+ *
+ * @property {Object} columnRangeFilter
+ *   Matches only cells from columns within the given range.
+ *
+ *   This object should have the same structure as [ColumnRange]{@link google.bigtable.v2.ColumnRange}
+ *
+ * @property {Object} timestampRangeFilter
+ *   Matches only cells with timestamps within the given range.
+ *
+ *   This object should have the same structure as [TimestampRange]{@link google.bigtable.v2.TimestampRange}
+ *
+ * @property {string} valueRegexFilter
+ *   Matches only cells with values that satisfy the given regular expression.
+ *   Note that, since cell values can contain arbitrary bytes, the `\C` escape
+ *   sequence must be used if a true wildcard is desired. The `.` character
+ *   will not match the new line character `\n`, which may be present in a
+ *   binary value.
+ *
+ * @property {Object} valueRangeFilter
+ *   Matches only cells with values that fall within the given range.
+ *
+ *   This object should have the same structure as [ValueRange]{@link google.bigtable.v2.ValueRange}
+ *
+ * @property {number} cellsPerRowOffsetFilter
+ *   Skips the first N cells of each row, matching all subsequent cells.
+ *   If duplicate cells are present, as is possible when using an Interleave,
+ *   each copy of the cell is counted separately.
+ *
+ * @property {number} cellsPerRowLimitFilter
+ *   Matches only the first N cells of each row.
+ *   If duplicate cells are present, as is possible when using an Interleave,
+ *   each copy of the cell is counted separately.
+ *
+ * @property {number} cellsPerColumnLimitFilter
+ *   Matches only the most recent N cells within each column. For example,
+ *   if N=2, this filter would match column `foo:bar` at timestamps 10 and 9,
+ *   skip all earlier cells in `foo:bar`, and then begin matching again in
+ *   column `foo:bar2`.
+ *   If duplicate cells are present, as is possible when using an Interleave,
+ *   each copy of the cell is counted separately.
+ *
+ * @property {boolean} stripValueTransformer
+ *   Replaces each cell's value with the empty string.
+ *
+ * @property {string} applyLabelTransformer
+ *   Applies the given label to all cells in the output row. This allows
+ *   the client to determine which results were produced from which part of
+ *   the filter.
+ *
+ *   Values must be at most 15 characters in length, and match the RE2
+ *   pattern `[a-z0-9\\-]+`
+ *
+ *   Due to a technical limitation, it is not currently possible to apply
+ *   multiple labels to a cell. As a result, a Chain may have no more than
+ *   one sub-filter which contains a `apply_label_transformer`. It is okay for
+ *   an Interleave to contain multiple `apply_label_transformers`, as they
+ *   will be applied to separate copies of the input. This may be relaxed in
+ *   the future.
+ *
+ * @typedef RowFilter
+ * @memberof google.bigtable.v2
+ * @see [google.bigtable.v2.RowFilter definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/bigtable/v2/data.proto}
+ */
+var RowFilter = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+
+  /**
+   * A RowFilter which sends rows through several RowFilters in sequence.
+   *
+   * @property {Object[]} filters
+   *   The elements of "filters" are chained together to process the input row:
+   *   in row -> f(0) -> intermediate row -> f(1) -> ... -> f(N) -> out row
+   *   The full chain is executed atomically.
+   *
+   *   This object should have the same structure as [RowFilter]{@link google.bigtable.v2.RowFilter}
+   *
+   * @typedef Chain
+   * @memberof google.bigtable.v2
+   * @see [google.bigtable.v2.RowFilter.Chain definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/bigtable/v2/data.proto}
+   */
+  Chain: {
+    // This is for documentation. Actual contents will be loaded by gRPC.
+  },
+
+  /**
+   * A RowFilter which sends each row to each of several component
+   * RowFilters and interleaves the results.
+   *
+   * @property {Object[]} filters
+   *   The elements of "filters" all process a copy of the input row, and the
+   *   results are pooled, sorted, and combined into a single output row.
+   *   If multiple cells are produced with the same column and timestamp,
+   *   they will all appear in the output row in an unspecified mutual order.
+   *   Consider the following example, with three filters:
+   *
+   *                                    input row
+   *                                        |
+   *              -----------------------------------------------------
+   *              |                         |                         |
+   *             f(0)                      f(1)                      f(2)
+   *              |                         |                         |
+   *       1: foo,bar,10,x             foo,bar,10,z              far,bar,7,a
+   *       2: foo,blah,11,z            far,blah,5,x              far,blah,5,x
+   *              |                         |                         |
+   *              -----------------------------------------------------
+   *                                        |
+   *       1:                      foo,bar,10,z   // could have switched with #2
+   *       2:                      foo,bar,10,x   // could have switched with #1
+   *       3:                      foo,blah,11,z
+   *       4:                      far,bar,7,a
+   *       5:                      far,blah,5,x   // identical to #6
+   *       6:                      far,blah,5,x   // identical to #5
+   *
+   *   All interleaved filters are executed atomically.
+   *
+   *   This object should have the same structure as [RowFilter]{@link google.bigtable.v2.RowFilter}
+   *
+   * @typedef Interleave
+   * @memberof google.bigtable.v2
+   * @see [google.bigtable.v2.RowFilter.Interleave definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/bigtable/v2/data.proto}
+   */
+  Interleave: {
+    // This is for documentation. Actual contents will be loaded by gRPC.
+  },
+
+  /**
+   * A RowFilter which evaluates one of two possible RowFilters, depending on
+   * whether or not a predicate RowFilter outputs any cells from the input row.
+   *
+   * IMPORTANT NOTE: The predicate filter does not execute atomically with the
+   * true and false filters, which may lead to inconsistent or unexpected
+   * results. Additionally, Condition filters have poor performance, especially
+   * when filters are set for the false condition.
+   *
+   * @property {Object} predicateFilter
+   *   If `predicate_filter` outputs any cells, then `true_filter` will be
+   *   evaluated on the input row. Otherwise, `false_filter` will be evaluated.
+   *
+   *   This object should have the same structure as [RowFilter]{@link google.bigtable.v2.RowFilter}
+   *
+   * @property {Object} trueFilter
+   *   The filter to apply to the input row if `predicate_filter` returns any
+   *   results. If not provided, no results will be returned in the true case.
+   *
+   *   This object should have the same structure as [RowFilter]{@link google.bigtable.v2.RowFilter}
+   *
+   * @property {Object} falseFilter
+   *   The filter to apply to the input row if `predicate_filter` does not
+   *   return any results. If not provided, no results will be returned in the
+   *   false case.
+   *
+   *   This object should have the same structure as [RowFilter]{@link google.bigtable.v2.RowFilter}
+   *
+   * @typedef Condition
+   * @memberof google.bigtable.v2
+   * @see [google.bigtable.v2.RowFilter.Condition definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/bigtable/v2/data.proto}
+   */
+  Condition: {
+    // This is for documentation. Actual contents will be loaded by gRPC.
+  }
+};
+
+/**
+ * Specifies a particular change to be made to the contents of a row.
+ *
+ * @property {Object} setCell
+ *   Set a cell's value.
+ *
+ *   This object should have the same structure as [SetCell]{@link google.bigtable.v2.SetCell}
+ *
+ * @property {Object} deleteFromColumn
+ *   Deletes cells from a column.
+ *
+ *   This object should have the same structure as [DeleteFromColumn]{@link google.bigtable.v2.DeleteFromColumn}
+ *
+ * @property {Object} deleteFromFamily
+ *   Deletes cells from a column family.
+ *
+ *   This object should have the same structure as [DeleteFromFamily]{@link google.bigtable.v2.DeleteFromFamily}
+ *
+ * @property {Object} deleteFromRow
+ *   Deletes cells from the entire row.
+ *
+ *   This object should have the same structure as [DeleteFromRow]{@link google.bigtable.v2.DeleteFromRow}
+ *
+ * @typedef Mutation
+ * @memberof google.bigtable.v2
+ * @see [google.bigtable.v2.Mutation definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/bigtable/v2/data.proto}
+ */
+var Mutation = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+
+  /**
+   * A Mutation which sets the value of the specified cell.
+   *
+   * @property {string} familyName
+   *   The name of the family into which new data should be written.
+   *   Must match `[-_.a-zA-Z0-9]+`
+   *
+   * @property {string} columnQualifier
+   *   The qualifier of the column into which new data should be written.
+   *   Can be any byte string, including the empty string.
+   *
+   * @property {number} timestampMicros
+   *   The timestamp of the cell into which new data should be written.
+   *   Use -1 for current Bigtable server time.
+   *   Otherwise, the client should set this value itself, noting that the
+   *   default value is a timestamp of zero if the field is left unspecified.
+   *   Values must match the granularity of the table (e.g. micros, millis).
+   *
+   * @property {string} value
+   *   The value to be written into the specified cell.
+   *
+   * @typedef SetCell
+   * @memberof google.bigtable.v2
+   * @see [google.bigtable.v2.Mutation.SetCell definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/bigtable/v2/data.proto}
+   */
+  SetCell: {
+    // This is for documentation. Actual contents will be loaded by gRPC.
+  },
+
+  /**
+   * A Mutation which deletes cells from the specified column, optionally
+   * restricting the deletions to a given timestamp range.
+   *
+   * @property {string} familyName
+   *   The name of the family from which cells should be deleted.
+   *   Must match `[-_.a-zA-Z0-9]+`
+   *
+   * @property {string} columnQualifier
+   *   The qualifier of the column from which cells should be deleted.
+   *   Can be any byte string, including the empty string.
+   *
+   * @property {Object} timeRange
+   *   The range of timestamps within which cells should be deleted.
+   *
+   *   This object should have the same structure as [TimestampRange]{@link google.bigtable.v2.TimestampRange}
+   *
+   * @typedef DeleteFromColumn
+   * @memberof google.bigtable.v2
+   * @see [google.bigtable.v2.Mutation.DeleteFromColumn definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/bigtable/v2/data.proto}
+   */
+  DeleteFromColumn: {
+    // This is for documentation. Actual contents will be loaded by gRPC.
+  },
+
+  /**
+   * A Mutation which deletes all cells from the specified column family.
+   *
+   * @property {string} familyName
+   *   The name of the family from which cells should be deleted.
+   *   Must match `[-_.a-zA-Z0-9]+`
+   *
+   * @typedef DeleteFromFamily
+   * @memberof google.bigtable.v2
+   * @see [google.bigtable.v2.Mutation.DeleteFromFamily definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/bigtable/v2/data.proto}
+   */
+  DeleteFromFamily: {
+    // This is for documentation. Actual contents will be loaded by gRPC.
+  },
+
+  /**
+   * A Mutation which deletes all cells from the containing row.
+   * @typedef DeleteFromRow
+   * @memberof google.bigtable.v2
+   * @see [google.bigtable.v2.Mutation.DeleteFromRow definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/bigtable/v2/data.proto}
+   */
+  DeleteFromRow: {
+    // This is for documentation. Actual contents will be loaded by gRPC.
+  }
+};
+
+/**
+ * Specifies an atomic read/modify/write operation on the latest value of the
+ * specified column.
+ *
+ * @property {string} familyName
+ *   The name of the family to which the read/modify/write should be applied.
+ *   Must match `[-_.a-zA-Z0-9]+`
+ *
+ * @property {string} columnQualifier
+ *   The qualifier of the column to which the read/modify/write should be
+ *   applied.
+ *   Can be any byte string, including the empty string.
+ *
+ * @property {string} appendValue
+ *   Rule specifying that `append_value` be appended to the existing value.
+ *   If the targeted cell is unset, it will be treated as containing the
+ *   empty string.
+ *
+ * @property {number} incrementAmount
+ *   Rule specifying that `increment_amount` be added to the existing value.
+ *   If the targeted cell is unset, it will be treated as containing a zero.
+ *   Otherwise, the targeted cell must contain an 8-byte value (interpreted
+ *   as a 64-bit big-endian signed integer), or the entire request will fail.
+ *
+ * @typedef ReadModifyWriteRule
+ * @memberof google.bigtable.v2
+ * @see [google.bigtable.v2.ReadModifyWriteRule definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/bigtable/v2/data.proto}
+ */
+var ReadModifyWriteRule = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};

--- a/src/v2/doc/google/protobuf/doc_any.js
+++ b/src/v2/doc/google/protobuf/doc_any.js
@@ -1,0 +1,131 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Note: this file is purely for documentation. Any contents are not expected
+// to be loaded as the JS file.
+
+/**
+ * `Any` contains an arbitrary serialized protocol buffer message along with a
+ * URL that describes the type of the serialized message.
+ *
+ * Protobuf library provides support to pack/unpack Any values in the form
+ * of utility functions or additional generated methods of the Any type.
+ *
+ * Example 1: Pack and unpack a message in C++.
+ *
+ *     Foo foo = ...;
+ *     Any any;
+ *     any.PackFrom(foo);
+ *     ...
+ *     if (any.UnpackTo(&foo)) {
+ *       ...
+ *     }
+ *
+ * Example 2: Pack and unpack a message in Java.
+ *
+ *     Foo foo = ...;
+ *     Any any = Any.pack(foo);
+ *     ...
+ *     if (any.is(Foo.class)) {
+ *       foo = any.unpack(Foo.class);
+ *     }
+ *
+ *  Example 3: Pack and unpack a message in Python.
+ *
+ *     foo = Foo(...)
+ *     any = Any()
+ *     any.Pack(foo)
+ *     ...
+ *     if any.Is(Foo.DESCRIPTOR):
+ *       any.Unpack(foo)
+ *       ...
+ *
+ *  Example 4: Pack and unpack a message in Go
+ *
+ *      foo := &pb.Foo{...}
+ *      any, err := ptypes.MarshalAny(foo)
+ *      ...
+ *      foo := &pb.Foo{}
+ *      if err := ptypes.UnmarshalAny(any, foo); err != nil {
+ *        ...
+ *      }
+ *
+ * The pack methods provided by protobuf library will by default use
+ * 'type.googleapis.com/full.type.name' as the type URL and the unpack
+ * methods only use the fully qualified type name after the last '/'
+ * in the type URL, for example "foo.bar.com/x/y.z" will yield type
+ * name "y.z".
+ *
+ *
+ * # JSON
+ *
+ * The JSON representation of an `Any` value uses the regular
+ * representation of the deserialized, embedded message, with an
+ * additional field `@type` which contains the type URL. Example:
+ *
+ *     package google.profile;
+ *     message Person {
+ *       string first_name = 1;
+ *       string last_name = 2;
+ *     }
+ *
+ *     {
+ *       "@type": "type.googleapis.com/google.profile.Person",
+ *       "firstName": <string>,
+ *       "lastName": <string>
+ *     }
+ *
+ * If the embedded message type is well-known and has a custom JSON
+ * representation, that representation will be embedded adding a field
+ * `value` which holds the custom JSON in addition to the `@type`
+ * field. Example (for message google.protobuf.Duration):
+ *
+ *     {
+ *       "@type": "type.googleapis.com/google.protobuf.Duration",
+ *       "value": "1.212s"
+ *     }
+ *
+ * @property {string} typeUrl
+ *   A URL/resource name whose content describes the type of the
+ *   serialized protocol buffer message.
+ *
+ *   For URLs which use the scheme `http`, `https`, or no scheme, the
+ *   following restrictions and interpretations apply:
+ *
+ *   * If no scheme is provided, `https` is assumed.
+ *   * The last segment of the URL's path must represent the fully
+ *     qualified name of the type (as in `path/google.protobuf.Duration`).
+ *     The name should be in a canonical form (e.g., leading "." is
+ *     not accepted).
+ *   * An HTTP GET on the URL must yield a google.protobuf.Type
+ *     value in binary format, or produce an error.
+ *   * Applications are allowed to cache lookup results based on the
+ *     URL, or have them precompiled into a binary to avoid any
+ *     lookup. Therefore, binary compatibility needs to be preserved
+ *     on changes to types. (Use versioned type names to manage
+ *     breaking changes.)
+ *
+ *   Schemes other than `http`, `https` (or the empty scheme) might be
+ *   used with implementation specific semantics.
+ *
+ * @property {string} value
+ *   Must be a valid serialized protocol buffer of the above specified type.
+ *
+ * @typedef Any
+ * @memberof google.protobuf
+ * @see [google.protobuf.Any definition in proto format]{@link https://github.com/google/protobuf/blob/master/src/google/protobuf/any.proto}
+ */
+var Any = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};

--- a/src/v2/doc/google/protobuf/doc_wrappers.js
+++ b/src/v2/doc/google/protobuf/doc_wrappers.js
@@ -1,0 +1,160 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Note: this file is purely for documentation. Any contents are not expected
+// to be loaded as the JS file.
+
+/**
+ * Wrapper message for `double`.
+ *
+ * The JSON representation for `DoubleValue` is JSON number.
+ *
+ * @property {number} value
+ *   The double value.
+ *
+ * @typedef DoubleValue
+ * @memberof google.protobuf
+ * @see [google.protobuf.DoubleValue definition in proto format]{@link https://github.com/google/protobuf/blob/master/src/google/protobuf/wrappers.proto}
+ */
+var DoubleValue = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Wrapper message for `float`.
+ *
+ * The JSON representation for `FloatValue` is JSON number.
+ *
+ * @property {number} value
+ *   The float value.
+ *
+ * @typedef FloatValue
+ * @memberof google.protobuf
+ * @see [google.protobuf.FloatValue definition in proto format]{@link https://github.com/google/protobuf/blob/master/src/google/protobuf/wrappers.proto}
+ */
+var FloatValue = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Wrapper message for `int64`.
+ *
+ * The JSON representation for `Int64Value` is JSON string.
+ *
+ * @property {number} value
+ *   The int64 value.
+ *
+ * @typedef Int64Value
+ * @memberof google.protobuf
+ * @see [google.protobuf.Int64Value definition in proto format]{@link https://github.com/google/protobuf/blob/master/src/google/protobuf/wrappers.proto}
+ */
+var Int64Value = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Wrapper message for `uint64`.
+ *
+ * The JSON representation for `UInt64Value` is JSON string.
+ *
+ * @property {number} value
+ *   The uint64 value.
+ *
+ * @typedef UInt64Value
+ * @memberof google.protobuf
+ * @see [google.protobuf.UInt64Value definition in proto format]{@link https://github.com/google/protobuf/blob/master/src/google/protobuf/wrappers.proto}
+ */
+var UInt64Value = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Wrapper message for `int32`.
+ *
+ * The JSON representation for `Int32Value` is JSON number.
+ *
+ * @property {number} value
+ *   The int32 value.
+ *
+ * @typedef Int32Value
+ * @memberof google.protobuf
+ * @see [google.protobuf.Int32Value definition in proto format]{@link https://github.com/google/protobuf/blob/master/src/google/protobuf/wrappers.proto}
+ */
+var Int32Value = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Wrapper message for `uint32`.
+ *
+ * The JSON representation for `UInt32Value` is JSON number.
+ *
+ * @property {number} value
+ *   The uint32 value.
+ *
+ * @typedef UInt32Value
+ * @memberof google.protobuf
+ * @see [google.protobuf.UInt32Value definition in proto format]{@link https://github.com/google/protobuf/blob/master/src/google/protobuf/wrappers.proto}
+ */
+var UInt32Value = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Wrapper message for `bool`.
+ *
+ * The JSON representation for `BoolValue` is JSON `true` and `false`.
+ *
+ * @property {boolean} value
+ *   The bool value.
+ *
+ * @typedef BoolValue
+ * @memberof google.protobuf
+ * @see [google.protobuf.BoolValue definition in proto format]{@link https://github.com/google/protobuf/blob/master/src/google/protobuf/wrappers.proto}
+ */
+var BoolValue = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Wrapper message for `string`.
+ *
+ * The JSON representation for `StringValue` is JSON string.
+ *
+ * @property {string} value
+ *   The string value.
+ *
+ * @typedef StringValue
+ * @memberof google.protobuf
+ * @see [google.protobuf.StringValue definition in proto format]{@link https://github.com/google/protobuf/blob/master/src/google/protobuf/wrappers.proto}
+ */
+var StringValue = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Wrapper message for `bytes`.
+ *
+ * The JSON representation for `BytesValue` is JSON string.
+ *
+ * @property {string} value
+ *   The bytes value.
+ *
+ * @typedef BytesValue
+ * @memberof google.protobuf
+ * @see [google.protobuf.BytesValue definition in proto format]{@link https://github.com/google/protobuf/blob/master/src/google/protobuf/wrappers.proto}
+ */
+var BytesValue = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};

--- a/src/v2/doc/google/rpc/doc_status.js
+++ b/src/v2/doc/google/rpc/doc_status.js
@@ -1,0 +1,92 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Note: this file is purely for documentation. Any contents are not expected
+// to be loaded as the JS file.
+
+/**
+ * The `Status` type defines a logical error model that is suitable for different
+ * programming environments, including REST APIs and RPC APIs. It is used by
+ * [gRPC](https://github.com/grpc). The error model is designed to be:
+ *
+ * - Simple to use and understand for most users
+ * - Flexible enough to meet unexpected needs
+ *
+ * # Overview
+ *
+ * The `Status` message contains three pieces of data: error code, error message,
+ * and error details. The error code should be an enum value of
+ * google.rpc.Code, but it may accept additional error codes if needed.  The
+ * error message should be a developer-facing English message that helps
+ * developers *understand* and *resolve* the error. If a localized user-facing
+ * error message is needed, put the localized message in the error details or
+ * localize it in the client. The optional error details may contain arbitrary
+ * information about the error. There is a predefined set of error detail types
+ * in the package `google.rpc` that can be used for common error conditions.
+ *
+ * # Language mapping
+ *
+ * The `Status` message is the logical representation of the error model, but it
+ * is not necessarily the actual wire format. When the `Status` message is
+ * exposed in different client libraries and different wire protocols, it can be
+ * mapped differently. For example, it will likely be mapped to some exceptions
+ * in Java, but more likely mapped to some error codes in C.
+ *
+ * # Other uses
+ *
+ * The error model and the `Status` message can be used in a variety of
+ * environments, either with or without APIs, to provide a
+ * consistent developer experience across different environments.
+ *
+ * Example uses of this error model include:
+ *
+ * - Partial errors. If a service needs to return partial errors to the client,
+ *     it may embed the `Status` in the normal response to indicate the partial
+ *     errors.
+ *
+ * - Workflow errors. A typical workflow has multiple steps. Each step may
+ *     have a `Status` message for error reporting.
+ *
+ * - Batch operations. If a client uses batch request and batch response, the
+ *     `Status` message should be used directly inside batch response, one for
+ *     each error sub-response.
+ *
+ * - Asynchronous operations. If an API call embeds asynchronous operation
+ *     results in its response, the status of those operations should be
+ *     represented directly using the `Status` message.
+ *
+ * - Logging. If some API errors are stored in logs, the message `Status` could
+ *     be used directly after any stripping needed for security/privacy reasons.
+ *
+ * @property {number} code
+ *   The status code, which should be an enum value of google.rpc.Code.
+ *
+ * @property {string} message
+ *   A developer-facing error message, which should be in English. Any
+ *   user-facing error message should be localized and sent in the
+ *   google.rpc.Status.details field, or localized by the client.
+ *
+ * @property {Object[]} details
+ *   A list of messages that carry the error details.  There is a common set of
+ *   message types for APIs to use.
+ *
+ *   This object should have the same structure as [Any]{@link google.protobuf.Any}
+ *
+ * @typedef Status
+ * @memberof google.rpc
+ * @see [google.rpc.Status definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/rpc/status.proto}
+ */
+var Status = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};

--- a/src/v2/index.js
+++ b/src/v2/index.js
@@ -1,0 +1,19 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const BigtableClient = require('./bigtable_client');
+
+module.exports.BigtableClient = BigtableClient;

--- a/test/gapic-v2.js
+++ b/test/gapic-v2.js
@@ -1,0 +1,441 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const assert = require('assert');
+const through2 = require('through2');
+
+const bigtableModule = require('../src');
+
+var FAKE_STATUS_CODE = 1;
+var error = new Error();
+error.code = FAKE_STATUS_CODE;
+
+describe('BigtableClient', () => {
+  describe('readRows', () => {
+    it('invokes readRows without error', done => {
+      var client = new bigtableModule.v2.BigtableClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      var formattedTableName = client.tablePath('[PROJECT]', '[INSTANCE]', '[TABLE]');
+      var request = {
+        tableName: formattedTableName,
+      };
+
+      // Mock response
+      var lastScannedRowKey = '-126';
+      var expectedResponse = {
+        lastScannedRowKey: lastScannedRowKey,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.readRows = mockServerStreamingGrpcMethod(request, expectedResponse);
+
+      var stream = client.readRows(request);
+      stream.on('data', response => {
+        assert.deepStrictEqual(response, expectedResponse);
+        done();
+      });
+      stream.on('error', err => {
+        done(err);
+      });
+
+      stream.write();
+    });
+
+    it('invokes readRows with error', done => {
+      var client = new bigtableModule.v2.BigtableClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      var formattedTableName = client.tablePath('[PROJECT]', '[INSTANCE]', '[TABLE]');
+      var request = {
+        tableName: formattedTableName,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.readRows = mockServerStreamingGrpcMethod(request, null, error);
+
+      var stream = client.readRows(request);
+      stream.on('data', () => {
+        assert.fail();
+      });
+      stream.on('error', err => {
+        assert(err instanceof Error);
+        assert.equal(err.code, FAKE_STATUS_CODE);
+        done();
+      });
+
+      stream.write();
+    });
+  });
+
+  describe('sampleRowKeys', () => {
+    it('invokes sampleRowKeys without error', done => {
+      var client = new bigtableModule.v2.BigtableClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      var formattedTableName = client.tablePath('[PROJECT]', '[INSTANCE]', '[TABLE]');
+      var request = {
+        tableName: formattedTableName,
+      };
+
+      // Mock response
+      var rowKey = '122';
+      var offsetBytes = 889884095;
+      var expectedResponse = {
+        rowKey: rowKey,
+        offsetBytes: offsetBytes,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.sampleRowKeys = mockServerStreamingGrpcMethod(request, expectedResponse);
+
+      var stream = client.sampleRowKeys(request);
+      stream.on('data', response => {
+        assert.deepStrictEqual(response, expectedResponse);
+        done();
+      });
+      stream.on('error', err => {
+        done(err);
+      });
+
+      stream.write();
+    });
+
+    it('invokes sampleRowKeys with error', done => {
+      var client = new bigtableModule.v2.BigtableClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      var formattedTableName = client.tablePath('[PROJECT]', '[INSTANCE]', '[TABLE]');
+      var request = {
+        tableName: formattedTableName,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.sampleRowKeys = mockServerStreamingGrpcMethod(request, null, error);
+
+      var stream = client.sampleRowKeys(request);
+      stream.on('data', () => {
+        assert.fail();
+      });
+      stream.on('error', err => {
+        assert(err instanceof Error);
+        assert.equal(err.code, FAKE_STATUS_CODE);
+        done();
+      });
+
+      stream.write();
+    });
+  });
+
+  describe('mutateRow', () => {
+    it('invokes mutateRow without error', done => {
+      var client = new bigtableModule.v2.BigtableClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      var formattedTableName = client.tablePath('[PROJECT]', '[INSTANCE]', '[TABLE]');
+      var rowKey = '122';
+      var mutations = [];
+      var request = {
+        tableName: formattedTableName,
+        rowKey: rowKey,
+        mutations: mutations,
+      };
+
+      // Mock response
+      var expectedResponse = {};
+
+      // Mock Grpc layer
+      client._innerApiCalls.mutateRow = mockSimpleGrpcMethod(
+        request,
+        expectedResponse
+      );
+
+      client.mutateRow(request, (err, response) => {
+        assert.ifError(err);
+        assert.deepStrictEqual(response, expectedResponse);
+        done();
+      });
+    });
+
+    it('invokes mutateRow with error', done => {
+      var client = new bigtableModule.v2.BigtableClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      var formattedTableName = client.tablePath('[PROJECT]', '[INSTANCE]', '[TABLE]');
+      var rowKey = '122';
+      var mutations = [];
+      var request = {
+        tableName: formattedTableName,
+        rowKey: rowKey,
+        mutations: mutations,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.mutateRow = mockSimpleGrpcMethod(
+        request,
+        null,
+        error
+      );
+
+      client.mutateRow(request, (err, response) => {
+        assert(err instanceof Error);
+        assert.equal(err.code, FAKE_STATUS_CODE);
+        assert(typeof response === 'undefined');
+        done();
+      });
+    });
+  });
+
+  describe('mutateRows', () => {
+    it('invokes mutateRows without error', done => {
+      var client = new bigtableModule.v2.BigtableClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      var formattedTableName = client.tablePath('[PROJECT]', '[INSTANCE]', '[TABLE]');
+      var entries = [];
+      var request = {
+        tableName: formattedTableName,
+        entries: entries,
+      };
+
+      // Mock response
+      var expectedResponse = {};
+
+      // Mock Grpc layer
+      client._innerApiCalls.mutateRows = mockServerStreamingGrpcMethod(request, expectedResponse);
+
+      var stream = client.mutateRows(request);
+      stream.on('data', response => {
+        assert.deepStrictEqual(response, expectedResponse);
+        done();
+      });
+      stream.on('error', err => {
+        done(err);
+      });
+
+      stream.write();
+    });
+
+    it('invokes mutateRows with error', done => {
+      var client = new bigtableModule.v2.BigtableClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      var formattedTableName = client.tablePath('[PROJECT]', '[INSTANCE]', '[TABLE]');
+      var entries = [];
+      var request = {
+        tableName: formattedTableName,
+        entries: entries,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.mutateRows = mockServerStreamingGrpcMethod(request, null, error);
+
+      var stream = client.mutateRows(request);
+      stream.on('data', () => {
+        assert.fail();
+      });
+      stream.on('error', err => {
+        assert(err instanceof Error);
+        assert.equal(err.code, FAKE_STATUS_CODE);
+        done();
+      });
+
+      stream.write();
+    });
+  });
+
+  describe('checkAndMutateRow', () => {
+    it('invokes checkAndMutateRow without error', done => {
+      var client = new bigtableModule.v2.BigtableClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      var formattedTableName = client.tablePath('[PROJECT]', '[INSTANCE]', '[TABLE]');
+      var rowKey = '122';
+      var request = {
+        tableName: formattedTableName,
+        rowKey: rowKey,
+      };
+
+      // Mock response
+      var predicateMatched = true;
+      var expectedResponse = {
+        predicateMatched: predicateMatched,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.checkAndMutateRow = mockSimpleGrpcMethod(
+        request,
+        expectedResponse
+      );
+
+      client.checkAndMutateRow(request, (err, response) => {
+        assert.ifError(err);
+        assert.deepStrictEqual(response, expectedResponse);
+        done();
+      });
+    });
+
+    it('invokes checkAndMutateRow with error', done => {
+      var client = new bigtableModule.v2.BigtableClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      var formattedTableName = client.tablePath('[PROJECT]', '[INSTANCE]', '[TABLE]');
+      var rowKey = '122';
+      var request = {
+        tableName: formattedTableName,
+        rowKey: rowKey,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.checkAndMutateRow = mockSimpleGrpcMethod(
+        request,
+        null,
+        error
+      );
+
+      client.checkAndMutateRow(request, (err, response) => {
+        assert(err instanceof Error);
+        assert.equal(err.code, FAKE_STATUS_CODE);
+        assert(typeof response === 'undefined');
+        done();
+      });
+    });
+  });
+
+  describe('readModifyWriteRow', () => {
+    it('invokes readModifyWriteRow without error', done => {
+      var client = new bigtableModule.v2.BigtableClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      var formattedTableName = client.tablePath('[PROJECT]', '[INSTANCE]', '[TABLE]');
+      var rowKey = '122';
+      var rules = [];
+      var request = {
+        tableName: formattedTableName,
+        rowKey: rowKey,
+        rules: rules,
+      };
+
+      // Mock response
+      var expectedResponse = {};
+
+      // Mock Grpc layer
+      client._innerApiCalls.readModifyWriteRow = mockSimpleGrpcMethod(
+        request,
+        expectedResponse
+      );
+
+      client.readModifyWriteRow(request, (err, response) => {
+        assert.ifError(err);
+        assert.deepStrictEqual(response, expectedResponse);
+        done();
+      });
+    });
+
+    it('invokes readModifyWriteRow with error', done => {
+      var client = new bigtableModule.v2.BigtableClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      var formattedTableName = client.tablePath('[PROJECT]', '[INSTANCE]', '[TABLE]');
+      var rowKey = '122';
+      var rules = [];
+      var request = {
+        tableName: formattedTableName,
+        rowKey: rowKey,
+        rules: rules,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.readModifyWriteRow = mockSimpleGrpcMethod(
+        request,
+        null,
+        error
+      );
+
+      client.readModifyWriteRow(request, (err, response) => {
+        assert(err instanceof Error);
+        assert.equal(err.code, FAKE_STATUS_CODE);
+        assert(typeof response === 'undefined');
+        done();
+      });
+    });
+  });
+
+});
+
+function mockSimpleGrpcMethod(expectedRequest, response, error) {
+  return function(actualRequest, options, callback) {
+    assert.deepStrictEqual(actualRequest, expectedRequest);
+    if (error) {
+      callback(error);
+    } else if (response) {
+      callback(null, response);
+    } else {
+      callback(null);
+    }
+  };
+}
+
+function mockServerStreamingGrpcMethod(expectedRequest, response, error) {
+  return actualRequest => {
+    assert.deepStrictEqual(actualRequest, expectedRequest);
+    var mockStream = through2.obj((chunk, enc, callback) => {
+      if (error) {
+        callback(error);
+      }
+      else {
+        callback(null, response);
+      }
+    });
+    return mockStream;
+  };
+}

--- a/test/gapic-v2.js
+++ b/test/gapic-v2.js
@@ -32,7 +32,11 @@ describe('BigtableClient', () => {
       });
 
       // Mock request
-      var formattedTableName = client.tablePath('[PROJECT]', '[INSTANCE]', '[TABLE]');
+      var formattedTableName = client.tablePath(
+        '[PROJECT]',
+        '[INSTANCE]',
+        '[TABLE]'
+      );
       var request = {
         tableName: formattedTableName,
       };
@@ -44,7 +48,10 @@ describe('BigtableClient', () => {
       };
 
       // Mock Grpc layer
-      client._innerApiCalls.readRows = mockServerStreamingGrpcMethod(request, expectedResponse);
+      client._innerApiCalls.readRows = mockServerStreamingGrpcMethod(
+        request,
+        expectedResponse
+      );
 
       var stream = client.readRows(request);
       stream.on('data', response => {
@@ -65,13 +72,21 @@ describe('BigtableClient', () => {
       });
 
       // Mock request
-      var formattedTableName = client.tablePath('[PROJECT]', '[INSTANCE]', '[TABLE]');
+      var formattedTableName = client.tablePath(
+        '[PROJECT]',
+        '[INSTANCE]',
+        '[TABLE]'
+      );
       var request = {
         tableName: formattedTableName,
       };
 
       // Mock Grpc layer
-      client._innerApiCalls.readRows = mockServerStreamingGrpcMethod(request, null, error);
+      client._innerApiCalls.readRows = mockServerStreamingGrpcMethod(
+        request,
+        null,
+        error
+      );
 
       var stream = client.readRows(request);
       stream.on('data', () => {
@@ -95,7 +110,11 @@ describe('BigtableClient', () => {
       });
 
       // Mock request
-      var formattedTableName = client.tablePath('[PROJECT]', '[INSTANCE]', '[TABLE]');
+      var formattedTableName = client.tablePath(
+        '[PROJECT]',
+        '[INSTANCE]',
+        '[TABLE]'
+      );
       var request = {
         tableName: formattedTableName,
       };
@@ -109,7 +128,10 @@ describe('BigtableClient', () => {
       };
 
       // Mock Grpc layer
-      client._innerApiCalls.sampleRowKeys = mockServerStreamingGrpcMethod(request, expectedResponse);
+      client._innerApiCalls.sampleRowKeys = mockServerStreamingGrpcMethod(
+        request,
+        expectedResponse
+      );
 
       var stream = client.sampleRowKeys(request);
       stream.on('data', response => {
@@ -130,13 +152,21 @@ describe('BigtableClient', () => {
       });
 
       // Mock request
-      var formattedTableName = client.tablePath('[PROJECT]', '[INSTANCE]', '[TABLE]');
+      var formattedTableName = client.tablePath(
+        '[PROJECT]',
+        '[INSTANCE]',
+        '[TABLE]'
+      );
       var request = {
         tableName: formattedTableName,
       };
 
       // Mock Grpc layer
-      client._innerApiCalls.sampleRowKeys = mockServerStreamingGrpcMethod(request, null, error);
+      client._innerApiCalls.sampleRowKeys = mockServerStreamingGrpcMethod(
+        request,
+        null,
+        error
+      );
 
       var stream = client.sampleRowKeys(request);
       stream.on('data', () => {
@@ -160,7 +190,11 @@ describe('BigtableClient', () => {
       });
 
       // Mock request
-      var formattedTableName = client.tablePath('[PROJECT]', '[INSTANCE]', '[TABLE]');
+      var formattedTableName = client.tablePath(
+        '[PROJECT]',
+        '[INSTANCE]',
+        '[TABLE]'
+      );
       var rowKey = '122';
       var mutations = [];
       var request = {
@@ -192,7 +226,11 @@ describe('BigtableClient', () => {
       });
 
       // Mock request
-      var formattedTableName = client.tablePath('[PROJECT]', '[INSTANCE]', '[TABLE]');
+      var formattedTableName = client.tablePath(
+        '[PROJECT]',
+        '[INSTANCE]',
+        '[TABLE]'
+      );
       var rowKey = '122';
       var mutations = [];
       var request = {
@@ -225,7 +263,11 @@ describe('BigtableClient', () => {
       });
 
       // Mock request
-      var formattedTableName = client.tablePath('[PROJECT]', '[INSTANCE]', '[TABLE]');
+      var formattedTableName = client.tablePath(
+        '[PROJECT]',
+        '[INSTANCE]',
+        '[TABLE]'
+      );
       var entries = [];
       var request = {
         tableName: formattedTableName,
@@ -236,7 +278,10 @@ describe('BigtableClient', () => {
       var expectedResponse = {};
 
       // Mock Grpc layer
-      client._innerApiCalls.mutateRows = mockServerStreamingGrpcMethod(request, expectedResponse);
+      client._innerApiCalls.mutateRows = mockServerStreamingGrpcMethod(
+        request,
+        expectedResponse
+      );
 
       var stream = client.mutateRows(request);
       stream.on('data', response => {
@@ -257,7 +302,11 @@ describe('BigtableClient', () => {
       });
 
       // Mock request
-      var formattedTableName = client.tablePath('[PROJECT]', '[INSTANCE]', '[TABLE]');
+      var formattedTableName = client.tablePath(
+        '[PROJECT]',
+        '[INSTANCE]',
+        '[TABLE]'
+      );
       var entries = [];
       var request = {
         tableName: formattedTableName,
@@ -265,7 +314,11 @@ describe('BigtableClient', () => {
       };
 
       // Mock Grpc layer
-      client._innerApiCalls.mutateRows = mockServerStreamingGrpcMethod(request, null, error);
+      client._innerApiCalls.mutateRows = mockServerStreamingGrpcMethod(
+        request,
+        null,
+        error
+      );
 
       var stream = client.mutateRows(request);
       stream.on('data', () => {
@@ -289,7 +342,11 @@ describe('BigtableClient', () => {
       });
 
       // Mock request
-      var formattedTableName = client.tablePath('[PROJECT]', '[INSTANCE]', '[TABLE]');
+      var formattedTableName = client.tablePath(
+        '[PROJECT]',
+        '[INSTANCE]',
+        '[TABLE]'
+      );
       var rowKey = '122';
       var request = {
         tableName: formattedTableName,
@@ -322,7 +379,11 @@ describe('BigtableClient', () => {
       });
 
       // Mock request
-      var formattedTableName = client.tablePath('[PROJECT]', '[INSTANCE]', '[TABLE]');
+      var formattedTableName = client.tablePath(
+        '[PROJECT]',
+        '[INSTANCE]',
+        '[TABLE]'
+      );
       var rowKey = '122';
       var request = {
         tableName: formattedTableName,
@@ -353,7 +414,11 @@ describe('BigtableClient', () => {
       });
 
       // Mock request
-      var formattedTableName = client.tablePath('[PROJECT]', '[INSTANCE]', '[TABLE]');
+      var formattedTableName = client.tablePath(
+        '[PROJECT]',
+        '[INSTANCE]',
+        '[TABLE]'
+      );
       var rowKey = '122';
       var rules = [];
       var request = {
@@ -385,7 +450,11 @@ describe('BigtableClient', () => {
       });
 
       // Mock request
-      var formattedTableName = client.tablePath('[PROJECT]', '[INSTANCE]', '[TABLE]');
+      var formattedTableName = client.tablePath(
+        '[PROJECT]',
+        '[INSTANCE]',
+        '[TABLE]'
+      );
       var rowKey = '122';
       var rules = [];
       var request = {
@@ -409,7 +478,6 @@ describe('BigtableClient', () => {
       });
     });
   });
-
 });
 
 function mockSimpleGrpcMethod(expectedRequest, response, error) {
@@ -431,8 +499,7 @@ function mockServerStreamingGrpcMethod(expectedRequest, response, error) {
     var mockStream = through2.obj((chunk, enc, callback) => {
       if (error) {
         callback(error);
-      }
-      else {
+      } else {
         callback(null, response);
       }
     });


### PR DESCRIPTION
#23: generating GAPIC code. Accessible from `src/index.js` as `.v2` (see `test/gapic-v2.js`).

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
