### PR TITLE
Fix read retires.

### DIFF
--- a/src/chunktransformer.js
+++ b/src/chunktransformer.js
@@ -87,8 +87,8 @@ ChunkTransformer.prototype._transform = function(data, enc, next) {
       return;
     }
   }
-  if (data.lastScannedRowKey) {
-    this.lastRowKey = data.lastScannedRowKey;
+  if (data.lastScannedRowKey && data.lastScannedRowKey.length > 0) {
+    this.lastRowKey = Mutation.convertFromBytes(data.lastScannedRowKey);
   }
   next();
 };

--- a/src/table.js
+++ b/src/table.js
@@ -34,10 +34,7 @@ const ChunkTransformer = require('./chunktransformer.js');
 
 // See protos/google/rpc/code.proto
 // (4=DEADLINE_EXCEEDED, 10=ABORTED, 14=UNAVAILABLE)
-const GRPC_RETRYABLE_STATUS_CODES = new Set([4, 10, 14]);
-
-// (409=ABORTED, 503=UNAVAILABLE, 14=DEADLINE_EXCEEDED)
-const HTTP_RETRYABLE_STATUS_CODES = new Set([409, 503, 504]);
+const RETRYABLE_STATUS_CODES = new Set([4, 10, 14]);
 
 /**
  * Create a Table object to interact with a Cloud Bigtable table.
@@ -527,7 +524,7 @@ Table.prototype.createReadStream = function(options) {
       rowStream.unpipe(userStream);
       if (
         numRequestsMade <= maxRetries &&
-        HTTP_RETRYABLE_STATUS_CODES.has(error.code)
+        RETRYABLE_STATUS_CODES.has(error.code)
       ) {
         makeNewRequest();
       } else {
@@ -1200,7 +1197,7 @@ Table.prototype.mutate = function(entries, gaxOptions, callback) {
             return;
           }
 
-          if (!GRPC_RETRYABLE_STATUS_CODES.has(entry.status.code)) {
+          if (!RETRYABLE_STATUS_CODES.has(entry.status.code)) {
             pendingEntryIndices.delete(originalEntriesIndex);
           }
 

--- a/system-test/data/read-rows-retry-test.json
+++ b/system-test/data/read-rows-retry-test.json
@@ -26,7 +26,7 @@
         { "rowRanges": [ { "startKeyOpen": "b" } ] }
       ],
       "responses": [
-        { "row_keys": [ "a", "b" ], "end_with_error": 503 },
+        { "row_keys": [ "a", "b" ], "end_with_error": 4 },
         { "row_keys": [ "c" ] }
       ],
       "row_keys_read": [
@@ -44,15 +44,15 @@
         {}, {}, {}, {}
       ],
       "responses": [
-        { "end_with_error": 503 },
-        { "end_with_error": 503 },
-        { "end_with_error": 503 },
-        { "end_with_error": 503 }
+        { "end_with_error": 4 },
+        { "end_with_error": 4 },
+        { "end_with_error": 4 },
+        { "end_with_error": 4 }
       ],
       "row_keys_read": [
         [], [], [], []
       ],
-      "error": 503
+      "error": 4
     },
 
 
@@ -72,13 +72,13 @@
         { "rowRanges": [ { "startKeyOpen": "b" } ] }
       ],
       "responses": [
-        { "row_keys": [ "a" ], "end_with_error": 503 },
-        { "end_with_error": 503 },
-        { "end_with_error": 503 },
-        { "end_with_error": 503 },
-        { "row_keys": [ "b" ], "end_with_error": 503 },
-        { "end_with_error": 503 },
-        { "end_with_error": 503 },
+        { "row_keys": [ "a" ], "end_with_error": 4 },
+        { "end_with_error": 4 },
+        { "end_with_error": 4 },
+        { "end_with_error": 4 },
+        { "row_keys": [ "b" ], "end_with_error": 4 },
+        { "end_with_error": 4 },
+        { "end_with_error": 4 },
         { "row_keys": [ "c" ] }
       ],
       "row_keys_read": [
@@ -102,7 +102,7 @@
         { "rowRanges": [ { "startKeyOpen": "b", "endKeyClosed": "z" } ] }
       ],
       "responses": [
-        { "row_keys": [ "a", "b" ], "end_with_error": 503 },
+        { "row_keys": [ "a", "b" ], "end_with_error": 4 },
         { "row_keys": [ "c" ] }
       ],
       "row_keys_read": [
@@ -133,7 +133,7 @@
         { "rowRanges": [ { "startKeyClosed": "x", "endKeyClosed": "z" } ] }
       ],
       "responses": [
-        { "row_keys": [ "a", "b", "c" ], "end_with_error": 503 },
+        { "row_keys": [ "a", "b", "c" ], "end_with_error": 4 },
         { "row_keys": [ "x" ] }
       ],
       "row_keys_read": [
@@ -155,7 +155,7 @@
         { "rowKeys": [ "x" ], "rowRanges": [ { "startKeyOpen": "c" } ] }
       ],
       "responses": [
-        { "row_keys": [ "a", "b", "c" ], "end_with_error": 503 },
+        { "row_keys": [ "a", "b", "c" ], "end_with_error": 4 },
         { "row_keys": [ "x" ] }
       ],
       "row_keys_read": [
@@ -176,7 +176,7 @@
         { "rowsLimit": 8, "rowRanges": [ { "startKeyOpen": "b" } ] }
       ],
       "responses": [
-        { "row_keys": [ "a", "b" ], "end_with_error": 503 },
+        { "row_keys": [ "a", "b" ], "end_with_error": 4 },
         { "row_keys": [ "x" ] }
       ],
       "row_keys_read": [
@@ -285,14 +285,14 @@
         }
       ],
       "responses": [
-        { "row_keys": [ "a" ], "end_with_error": 503 },
-        { "row_keys": [ "b" ], "end_with_error": 503 },
-        { "end_with_error": 503 },
-        { "end_with_error": 503 },
-        { "end_with_error": 503 },
-        { "row_keys": [ "c" ], "end_with_error": 503 },
-        { "row_keys": [ "p", "q", "r", "s", "x" ], "end_with_error": 503 },
-        { "row_keys": [ "y" ], "end_with_error": 503 },
+        { "row_keys": [ "a" ], "end_with_error": 4 },
+        { "row_keys": [ "b" ], "end_with_error": 4 },
+        { "end_with_error": 4 },
+        { "end_with_error": 4 },
+        { "end_with_error": 4 },
+        { "row_keys": [ "c" ], "end_with_error": 4 },
+        { "row_keys": [ "p", "q", "r", "s", "x" ], "end_with_error": 4 },
+        { "row_keys": [ "y" ], "end_with_error": 4 },
         { "row_keys": [ "z" ] }
       ],
       "row_keys_read": [

--- a/system-test/read-rows.js
+++ b/system-test/read-rows.js
@@ -131,22 +131,20 @@ describe('Bigtable/Table', () => {
           .on('error', err => (error = err));
         clock.runAll();
 
-        setImmediate(function() {
-          if (test.error) {
-            assert(!endCalled, `.on('end') should not have been invoked`);
-            assert.strictEqual(error.code, test.error);
-          } else {
-            assert(endCalled, `.on('end') shoud have been invoked`);
-            assert.ifError(error);
-          }
-          assert.deepStrictEqual(rowKeysRead, test.row_keys_read);
-          assert.strictEqual(
-            responses.length,
-            0,
-            'not all the responses were used'
-          );
-          assert.deepStrictEqual(requestedOptions, test.request_options);
-        });
+        if (test.error) {
+          assert(!endCalled, `.on('end') should not have been invoked`);
+          assert.strictEqual(error.code, test.error);
+        } else {
+          assert(endCalled, `.on('end') shoud have been invoked`);
+          assert.ifError(error);
+        }
+        assert.deepStrictEqual(rowKeysRead, test.row_keys_read);
+        assert.strictEqual(
+          responses.length,
+          0,
+          'not all the responses were used'
+        );
+        assert.deepStrictEqual(requestedOptions, test.request_options);
       });
     });
   });

--- a/test/table.js
+++ b/test/table.js
@@ -796,7 +796,7 @@ describe('Bigtable/Table', function() {
 
         makeRetryableError = () => {
           var error = new Error('retry me!');
-          error.code = 409;
+          error.code = 4;
           return error;
         };
 


### PR DESCRIPTION
Fix broken read row retries

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
~Appropriate docs were updated (if necessary)~

I used the following to generate some heavy rows:

```js
const bigtable = require('./');

const TABLE_NAME = 'Hello-Bigtable-my-perf';
const COLUMN_FAMILY_NAME = 'cf1';
const COLUMN_NAME = 'greeting';
const INSTANCE_ID = 'helloworld';

const measure = title => {
  console.log(`measuring task: ${title}`);
  console.time(title);
  return () => console.timeEnd(title);
}

let done;
(async () => {
  try {
    const bigtableClient = bigtable();
    const instance = bigtableClient.instance(INSTANCE_ID);

    const table = instance.table(TABLE_NAME);
    const [tableExists] = await table.exists();
    if (tableExists) {
      done = measure('Table already exists, delete the table');
      await table.delete();
      done();
    }
    const options = {
      families: [COLUMN_FAMILY_NAME],
    };
    done = measure('Creating table');
    await table.create(options);
    done()

    console.log('begin inserting rows');

    const bytes =
      '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef' +
      '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef' +
      '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef' +
      '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef' +
      '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef' +
      '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef' +
      '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef' +
      '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef' +
      '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef' +
      '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef' +
      '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef' +
      '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef' +
      '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef' +
      '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef' +
      '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef' +
      '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'


    let rowsToInsert = [];
    for (let index = 0; index < 1000000; index++) {
      if (index != 0 && index % 100000 === 0) {
        done = measure('inserting 100000 rows');
        await table.insert(rowsToInsert);
        done()
        rowsToInsert = [];
      }
      rowsToInsert.push({
        key: `row${index}`,
        data: {
          [COLUMN_FAMILY_NAME]: {
            [COLUMN_NAME]: bytes,
          },
        },
      });
    }
    done = measure('inserting 100000 rows');
    await table.insert(rowsToInsert);
    done();

  } catch (error) {
    console.error('Something went wrong:', error);
  }
})();
```

And the following to read it:

```js
const bigtable = require('./');
const throttle = require('lodash').throttle;

const TABLE_NAME = 'Hello-Bigtable-my-perf';
const COLUMN_FAMILY_NAME = 'cf1';
const COLUMN_NAME = 'greeting';
const INSTANCE_ID = 'helloworld';

const log = throttle(msg => console.log(msg), 1000, { leading: true });

(async () => {
  try {
    const bigtableClient = bigtable();
    const instance = bigtableClient.instance(INSTANCE_ID);

    const table = instance.table(TABLE_NAME);
    let index = 0;
    table.createReadStream().on('data', row => {
      index++
      if (index % 10000 === 0) console.log('got row ' + row.id)
      // log('Got row ' + row.id);
    })

  } catch (error) {
    console.error('Something went wrong:', error);
  }
})();

```

Before this change an error would not be retried, after this change it retries from the row it was up to