### PR TITLE
Implemented appProfileId support to bigtable APIs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -421,7 +421,7 @@ function Bigtable(options) {
   this.api = {};
   this.auth = googleAuth(options);
   this.projectId = options.projectId || '{{projectId}}';
-  this.appProfileId = options.appProfileId || undefined;
+  this.appProfileId = options.appProfileId;
   this.projectName = 'projects/' + this.projectId;
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -421,7 +421,7 @@ function Bigtable(options) {
   this.api = {};
   this.auth = googleAuth(options);
   this.projectId = options.projectId || '{{projectId}}';
-  this.appProfileId = options.appProfileId;
+  this.appProfileId = options.appProfileId || undefined;
   this.projectName = 'projects/' + this.projectId;
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -47,6 +47,9 @@ const v2 = require('./v2');
  *     downloaded from the Google Developers Console. If you provide a path to a
  *     JSON file, the `projectId` option above is not necessary. NOTE: .pem and
  *     .p12 require you to specify the `email` option as well.
+ * @property {string} [appProfileId] An application profile ID, a configuration
+ *     string value describing how Cloud Bigtable should treat traffic from a
+ *     particular end user application.
  * @property {string} [email] Account email address. Required when using a .pem
  *     or .p12 keyFilename.
  * @property {object} [credentials] Credentials object.
@@ -418,6 +421,7 @@ function Bigtable(options) {
   this.api = {};
   this.auth = googleAuth(options);
   this.projectId = options.projectId || '{{projectId}}';
+  this.appProfileId = options.appProfileId || null;
   this.projectName = 'projects/' + this.projectId;
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -421,7 +421,7 @@ function Bigtable(options) {
   this.api = {};
   this.auth = googleAuth(options);
   this.projectId = options.projectId || '{{projectId}}';
-  this.appProfileId = options.appProfileId || null;
+  this.appProfileId = options.appProfileId;
   this.projectName = 'projects/' + this.projectId;
 }
 

--- a/src/row.js
+++ b/src/row.js
@@ -361,7 +361,7 @@ Row.prototype.createRules = function(rules, gaxOptions, callback) {
 
   var reqOpts = {
     tableName: this.table.id,
-    appProfileId: this.appProfileId,
+    appProfileId: this.bigtable.appProfileId,
     rowKey: Mutation.convertToBytes(this.id),
     rules: rules,
   };
@@ -591,7 +591,7 @@ Row.prototype.exists = function(gaxOptions, callback) {
 Row.prototype.filter = function(filter, config, callback) {
   var reqOpts = {
     tableName: this.table.id,
-    appProfileId: this.appProfileId,
+    appProfileId: this.bigtable.appProfileId,
     rowKey: Mutation.convertToBytes(this.id),
     predicateFilter: Filter.parse(filter),
     trueMutations: createFlatMutationsList(config.onMatch),

--- a/src/row.js
+++ b/src/row.js
@@ -285,7 +285,6 @@ Row.prototype.create = function(options, callback) {
  * @param {object|object[]} rules The rules to apply to this row.
  * @param {object} [gaxOptions] Request configuration options, outlined here:
  *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
- * @param {string} [gaxOptions.appProfileId] Applicaion Profile Id.
  * @param {function} callback The callback function.
  * @param {?error} callback.err An error returned while making this
  *     request.
@@ -362,7 +361,7 @@ Row.prototype.createRules = function(rules, gaxOptions, callback) {
 
   var reqOpts = {
     tableName: this.table.id,
-    appProfileId: gaxOptions ? gaxOptions.appProfileId : null,
+    appProfileId: this.appProfileId,
     rowKey: Mutation.convertToBytes(this.id),
     rules: rules,
   };
@@ -522,7 +521,6 @@ Row.prototype.exists = function(gaxOptions, callback) {
  *     found.
  * @param {object[]} [config.onNoMatch] A list of entries to be ran if no
  *     matches are found.
- * @param {string} [config.appProfileId] Applicaion Profile Id.
  * @param {object} [config.gaxOptions] Request configuration options, outlined
  *     here: https://googleapis.github.io/gax-nodejs/global.html#CallOptions.
  * @param {function} callback The callback function.
@@ -593,7 +591,7 @@ Row.prototype.exists = function(gaxOptions, callback) {
 Row.prototype.filter = function(filter, config, callback) {
   var reqOpts = {
     tableName: this.table.id,
-    appProfileId: config.appProfileId || null,
+    appProfileId: this.appProfileId,
     rowKey: Mutation.convertToBytes(this.id),
     predicateFilter: Filter.parse(filter),
     trueMutations: createFlatMutationsList(config.onMatch),

--- a/src/row.js
+++ b/src/row.js
@@ -285,6 +285,7 @@ Row.prototype.create = function(options, callback) {
  * @param {object|object[]} rules The rules to apply to this row.
  * @param {object} [gaxOptions] Request configuration options, outlined here:
  *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
+ * @param {string} [gaxOptions.appProfileId] Applicaion Profile Id.
  * @param {function} callback The callback function.
  * @param {?error} callback.err An error returned while making this
  *     request.
@@ -361,6 +362,7 @@ Row.prototype.createRules = function(rules, gaxOptions, callback) {
 
   var reqOpts = {
     tableName: this.table.id,
+    appProfileId: gaxOptions ? gaxOptions.appProfileId : null,
     rowKey: Mutation.convertToBytes(this.id),
     rules: rules,
   };
@@ -520,6 +522,7 @@ Row.prototype.exists = function(gaxOptions, callback) {
  *     found.
  * @param {object[]} [config.onNoMatch] A list of entries to be ran if no
  *     matches are found.
+ * @param {string} [config.appProfileId] Applicaion Profile Id.
  * @param {object} [config.gaxOptions] Request configuration options, outlined
  *     here: https://googleapis.github.io/gax-nodejs/global.html#CallOptions.
  * @param {function} callback The callback function.
@@ -590,6 +593,7 @@ Row.prototype.exists = function(gaxOptions, callback) {
 Row.prototype.filter = function(filter, config, callback) {
   var reqOpts = {
     tableName: this.table.id,
+    appProfileId: config.appProfileId || null,
     rowKey: Mutation.convertToBytes(this.id),
     predicateFilter: Filter.parse(filter),
     trueMutations: createFlatMutationsList(config.onMatch),

--- a/src/table.js
+++ b/src/table.js
@@ -415,7 +415,7 @@ Table.prototype.createReadStream = function(options) {
 
     var reqOpts = {
       tableName: this.id,
-      appProfileId: this.appProfileId,
+      appProfileId: this.bigtable.appProfileId,
     };
 
     var retryOpts = {
@@ -1162,7 +1162,7 @@ Table.prototype.mutate = function(entries, gaxOptions, callback) {
 
     var reqOpts = {
       tableName: self.id,
-      appProfileId: self.appProfileId,
+      appProfileId: self.bigtable.appProfileId,
       entries: entryBatch.map(Mutation.parse),
     };
 
@@ -1306,7 +1306,7 @@ Table.prototype.sampleRowKeys = function(gaxOptions, callback) {
 Table.prototype.sampleRowKeysStream = function(gaxOptions) {
   var reqOpts = {
     tableName: this.id,
-    appProfileId: this.appProfileId,
+    appProfileId: this.bigtable.appProfileId,
   };
 
   return pumpify.obj([

--- a/src/table.js
+++ b/src/table.js
@@ -279,7 +279,6 @@ Table.prototype.createFamily = function(name, options, callback) {
  * @param {boolean} [options.decode=true] If set to `false` it will not decode
  *     Buffer values returned from Bigtable.
  * @param {string} [options.end] End value for key range.
- * @param {string} [options.appProfileId] Applicaion Profile Id
  * @param {Filter} [options.filter] Row filters allow you to
  *     both make advanced queries and format how the data is returned.
  * @param {object} [options.gaxOptions] Request configuration options, outlined
@@ -416,11 +415,8 @@ Table.prototype.createReadStream = function(options) {
 
     var reqOpts = {
       tableName: this.id,
+      appProfileId: this.appProfileId,
     };
-
-    if (options.appProfileId) {
-      reqOpts.appProfileId = options.appProfileId;
-    }
 
     var retryOpts = {
       currentRetryAttempt: numRequestsMade,
@@ -888,7 +884,6 @@ Table.prototype.getMetadata = function(options, callback) {
  *     {@link Table#createReadStream} for a complete list of options.
  * @param {object} [options.gaxOptions] Request configuration options, outlined
  *     here: https://googleapis.github.io/gax-nodejs/CallSettings.html.
- * @param {string} [options.appProfileId] Applicaion Profile Id
  * @param {function} callback The callback function.
  * @param {?error} callback.err An error returned while making this request.
  * @param {Row[]} callback.rows List of Row objects.
@@ -936,7 +931,6 @@ Table.prototype.getRows = function(options, callback) {
  *     See {@link Table#mutate}.
  * @param {object} [gaxOptions] Request configuration options, outlined here:
  *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
- * @param {string} [gaxOptions.appProfileId] Applicaion Profile Id
  * @param {function} callback The callback function.
  * @param {?error} callback.err An error returned while making this request.
  * @param {object[]} callback.err.errors If present, these represent partial
@@ -1024,7 +1018,6 @@ Table.prototype.insert = function(entries, gaxOptions, callback) {
  *     deleted.
  * @param {object} [gaxOptions] Request configuration options, outlined here:
  *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
- * @param {string} [gaxOptions.appProfileId] Applicaion Profile Id.
  * @param {function} callback The callback function.
  * @param {?error} callback.err An error returned while making this request.
  * @param {object[]} callback.err.errors If present, these represent partial
@@ -1169,7 +1162,7 @@ Table.prototype.mutate = function(entries, gaxOptions, callback) {
 
     var reqOpts = {
       tableName: self.id,
-      appProfileId: gaxOptions ? gaxOptions.appProfileId : null,
+      appProfileId: self.appProfileId,
       entries: entryBatch.map(Mutation.parse),
     };
 
@@ -1248,7 +1241,6 @@ Table.prototype.row = function(key) {
  *
  * @param {object} [gaxOptions] Request configuration options, outlined here:
  *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
- * @param {string} [gaxOptions.appProfileId] Applicaion Profile Id.
  * @param {function} [callback] The callback function.
  * @param {?error} callback.err An error returned while making this request.
  * @param {object[]} callback.keys The list of keys.
@@ -1293,7 +1285,6 @@ Table.prototype.sampleRowKeys = function(gaxOptions, callback) {
  *
  * @param {object} [gaxOptions] Request configuration options, outlined here:
  *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
- * @param {string} [gaxOptions.appProfileId] Applicaion Profile Id.
  * @returns {stream}
  *
  * @example
@@ -1315,7 +1306,7 @@ Table.prototype.sampleRowKeys = function(gaxOptions, callback) {
 Table.prototype.sampleRowKeysStream = function(gaxOptions) {
   var reqOpts = {
     tableName: this.id,
-    appProfileId: gaxOptions ? gaxOptions.appProfileId : null,
+    appProfileId: this.appProfileId,
   };
 
   return pumpify.obj([

--- a/src/table.js
+++ b/src/table.js
@@ -279,6 +279,7 @@ Table.prototype.createFamily = function(name, options, callback) {
  * @param {boolean} [options.decode=true] If set to `false` it will not decode
  *     Buffer values returned from Bigtable.
  * @param {string} [options.end] End value for key range.
+ * @param {string} [options.appProfileId] Applicaion Profile Id
  * @param {Filter} [options.filter] Row filters allow you to
  *     both make advanced queries and format how the data is returned.
  * @param {object} [options.gaxOptions] Request configuration options, outlined
@@ -416,6 +417,10 @@ Table.prototype.createReadStream = function(options) {
     var reqOpts = {
       tableName: this.id,
     };
+
+    if (options.appProfileId) {
+      reqOpts.appProfileId = options.appProfileId;
+    }
 
     var retryOpts = {
       currentRetryAttempt: numRequestsMade,
@@ -883,6 +888,7 @@ Table.prototype.getMetadata = function(options, callback) {
  *     {@link Table#createReadStream} for a complete list of options.
  * @param {object} [options.gaxOptions] Request configuration options, outlined
  *     here: https://googleapis.github.io/gax-nodejs/CallSettings.html.
+ * @param {string} [options.appProfileId] Applicaion Profile Id
  * @param {function} callback The callback function.
  * @param {?error} callback.err An error returned while making this request.
  * @param {Row[]} callback.rows List of Row objects.
@@ -930,6 +936,7 @@ Table.prototype.getRows = function(options, callback) {
  *     See {@link Table#mutate}.
  * @param {object} [gaxOptions] Request configuration options, outlined here:
  *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
+ * @param {string} [gaxOptions.appProfileId] Applicaion Profile Id
  * @param {function} callback The callback function.
  * @param {?error} callback.err An error returned while making this request.
  * @param {object[]} callback.err.errors If present, these represent partial
@@ -1017,6 +1024,7 @@ Table.prototype.insert = function(entries, gaxOptions, callback) {
  *     deleted.
  * @param {object} [gaxOptions] Request configuration options, outlined here:
  *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
+ * @param {string} [gaxOptions.appProfileId] Applicaion Profile Id.
  * @param {function} callback The callback function.
  * @param {?error} callback.err An error returned while making this request.
  * @param {object[]} callback.err.errors If present, these represent partial
@@ -1161,6 +1169,7 @@ Table.prototype.mutate = function(entries, gaxOptions, callback) {
 
     var reqOpts = {
       tableName: self.id,
+      appProfileId: gaxOptions ? gaxOptions.appProfileId : null,
       entries: entryBatch.map(Mutation.parse),
     };
 
@@ -1239,6 +1248,7 @@ Table.prototype.row = function(key) {
  *
  * @param {object} [gaxOptions] Request configuration options, outlined here:
  *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
+ * @param {string} [gaxOptions.appProfileId] Applicaion Profile Id.
  * @param {function} [callback] The callback function.
  * @param {?error} callback.err An error returned while making this request.
  * @param {object[]} callback.keys The list of keys.
@@ -1283,6 +1293,7 @@ Table.prototype.sampleRowKeys = function(gaxOptions, callback) {
  *
  * @param {object} [gaxOptions] Request configuration options, outlined here:
  *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
+ * @param {string} [gaxOptions.appProfileId] Applicaion Profile Id.
  * @returns {stream}
  *
  * @example
@@ -1304,6 +1315,7 @@ Table.prototype.sampleRowKeys = function(gaxOptions, callback) {
 Table.prototype.sampleRowKeysStream = function(gaxOptions) {
   var reqOpts = {
     tableName: this.id,
+    appProfileId: gaxOptions ? gaxOptions.appProfileId : null,
   };
 
   return pumpify.obj([

--- a/test/index.js
+++ b/test/index.js
@@ -321,6 +321,16 @@ describe('Bigtable', function() {
     it('should set the projectName', function() {
       assert.strictEqual(bigtable.projectName, 'projects/' + PROJECT_ID);
     });
+
+    it('should set the appProfileId', function() {
+      var options = {
+        appProfileId: 'app-profile-id-12345',
+      };
+
+      var bigtable = new Bigtable(options);
+
+      assert.strictEqual(bigtable.appProfileId, 'app-profile-id-12345');
+    });
   });
 
   describe('createInstance', function() {

--- a/test/row.js
+++ b/test/row.js
@@ -629,11 +629,14 @@ describe('Bigtable/Row', function() {
 
     it('should accept appProfileId', function(done) {
       var gaxOptions = {
-        appProfileId: "app-profile-id-12345",
+        appProfileId: 'app-profile-id-12345',
       };
 
       row.bigtable.request = function(config) {
-        assert.strictEqual(config.gaxOpts.appProfileId, gaxOptions.appProfileId);
+        assert.strictEqual(
+          config.gaxOpts.appProfileId,
+          gaxOptions.appProfileId
+        );
         done();
       };
 

--- a/test/row.js
+++ b/test/row.js
@@ -616,6 +616,21 @@ describe('Bigtable/Row', function() {
       row.createRules(rules, done);
     });
 
+    it('should use an appProfileId', function(done) {
+      var bigtableInstance = row.bigtable;
+      bigtableInstance.appProfileId = 'app-profile-id-12345';
+
+      bigtableInstance.request = function(config) {
+        assert.strictEqual(
+          config.reqOpts.appProfileId,
+          bigtableInstance.appProfileId
+        );
+        done();
+      };
+
+      row.createRules(rules, assert.ifError);
+    });
+
     it('should accept gaxOptions', function(done) {
       var gaxOptions = {};
 
@@ -827,6 +842,25 @@ describe('Bigtable/Row', function() {
       };
 
       row.filter(filter, {gaxOptions}, assert.ifError);
+    });
+
+    it('should use an appProfileId', function(done) {
+      var filter = {
+        column: 'a',
+      };
+
+      var bigtableInstance = row.bigtable;
+      bigtableInstance.appProfileId = 'app-profile-id-12345';
+
+      bigtableInstance.request = function(config) {
+        assert.strictEqual(
+          config.reqOpts.appProfileId,
+          bigtableInstance.appProfileId
+        );
+        done();
+      };
+
+      row.filter(filter, assert.ifError);
     });
 
     it('should return an error to the callback', function(done) {

--- a/test/row.js
+++ b/test/row.js
@@ -626,22 +626,6 @@ describe('Bigtable/Row', function() {
 
       row.createRules(rules, gaxOptions, assert.ifError);
     });
-
-    it('should accept appProfileId', function(done) {
-      var gaxOptions = {
-        appProfileId: 'app-profile-id-12345',
-      };
-
-      row.bigtable.request = function(config) {
-        assert.strictEqual(
-          config.gaxOpts.appProfileId,
-          gaxOptions.appProfileId
-        );
-        done();
-      };
-
-      row.createRules(rules, gaxOptions, assert.ifError);
-    });
   });
 
   describe('delete', function() {
@@ -843,20 +827,6 @@ describe('Bigtable/Row', function() {
       };
 
       row.filter(filter, {gaxOptions}, assert.ifError);
-    });
-
-    it('should accept appProfileId', function(done) {
-      var filter = {
-        column: 'a',
-      };
-      var appProfileId = 'app-profile-id-12345';
-
-      row.bigtable.request = function(config) {
-        assert.strictEqual(config.reqOpts.appProfileId, appProfileId);
-        done();
-      };
-
-      row.filter(filter, {appProfileId}, assert.ifError);
     });
 
     it('should return an error to the callback', function(done) {

--- a/test/row.js
+++ b/test/row.js
@@ -626,6 +626,19 @@ describe('Bigtable/Row', function() {
 
       row.createRules(rules, gaxOptions, assert.ifError);
     });
+
+    it('should accept appProfileId', function(done) {
+      var gaxOptions = {
+        appProfileId: "app-profile-id-12345",
+      };
+
+      row.bigtable.request = function(config) {
+        assert.strictEqual(config.gaxOpts.appProfileId, gaxOptions.appProfileId);
+        done();
+      };
+
+      row.createRules(rules, gaxOptions, assert.ifError);
+    });
   });
 
   describe('delete', function() {
@@ -827,6 +840,20 @@ describe('Bigtable/Row', function() {
       };
 
       row.filter(filter, {gaxOptions}, assert.ifError);
+    });
+
+    it('should accept appProfileId', function(done) {
+      var filter = {
+        column: 'a',
+      };
+      var appProfileId = 'app-profile-id-12345';
+
+      row.bigtable.request = function(config) {
+        assert.strictEqual(config.reqOpts.appProfileId, appProfileId);
+        done();
+      };
+
+      row.filter(filter, {appProfileId}, assert.ifError);
     });
 
     it('should return an error to the callback', function(done) {

--- a/test/table.js
+++ b/test/table.js
@@ -1458,7 +1458,7 @@ describe('Bigtable/Table', function() {
           done();
         };
 
-        table.getRows({appProfileId}, function(err, rows) {
+        table.getRows({appProfileId}, function() {
           done();
         });
       });

--- a/test/table.js
+++ b/test/table.js
@@ -377,14 +377,27 @@ describe('Bigtable/Table', function() {
 
   describe('createReadStream', function() {
     it('should provide the proper request options', function(done) {
-      table.bigtable.appProfileId = 'app-profile-id-12345';
-
       table.bigtable.request = function(config) {
         assert.strictEqual(config.client, 'BigtableClient');
         assert.strictEqual(config.method, 'readRows');
         assert.strictEqual(config.reqOpts.tableName, TABLE_NAME);
-        assert.strictEqual(config.reqOpts.appProfileId, 'app-profile-id-12345');
+        assert.strictEqual(config.reqOpts.appProfileId, undefined);
         assert.strictEqual(config.gaxOpts, undefined);
+        done();
+      };
+
+      table.createReadStream();
+    });
+    
+    it('should use an appProfileId', function(done) {
+      var bigtableInstance = table.bigtable;
+      bigtableInstance.appProfileId = 'app-profile-id-12345';
+
+      bigtableInstance.request = function(config) {
+        assert.strictEqual(
+          config.reqOpts.appProfileId,
+          bigtableInstance.appProfileId
+        );
         done();
       };
 
@@ -401,21 +414,6 @@ describe('Bigtable/Table', function() {
         };
 
         table.createReadStream({gaxOptions});
-      });
-
-      it('should use an appProfileId', function(done) {
-        var bigtableInstance = table.bigtable;
-        bigtableInstance.appProfileId = 'app-profile-id-12345';
-
-        bigtableInstance.request = function(config) {
-          assert.strictEqual(
-            config.reqOpts.appProfileId,
-            bigtableInstance.appProfileId
-          );
-          done();
-        };
-
-        table.createReadStream();
       });
 
       it('should retrieve a range of rows', function(done) {

--- a/test/table.js
+++ b/test/table.js
@@ -400,17 +400,6 @@ describe('Bigtable/Table', function() {
         table.createReadStream({gaxOptions});
       });
 
-      it('should accept appProfileId', function(done) {
-        var appProfileId = 'app-profile-id-12345';
-
-        table.bigtable.request = function(config) {
-          assert.strictEqual(config.reqOpts.appProfileId, appProfileId);
-          done();
-        };
-
-        table.createReadStream({appProfileId});
-      });
-
       it('should retrieve a range of rows', function(done) {
         var options = {
           start: 'gwashington',
@@ -1449,19 +1438,6 @@ describe('Bigtable/Table', function() {
           done();
         });
       });
-
-      it('should accept appProfileId', function(done) {
-        var appProfileId = 'app-profile-id-12345';
-
-        table.bigtable.request = function(config) {
-          assert.strictEqual(config.appProfileId, appProfileId);
-          done();
-        };
-
-        table.getRows({appProfileId}, function() {
-          done();
-        });
-      });
     });
 
     describe('error', function() {
@@ -1531,17 +1507,6 @@ describe('Bigtable/Table', function() {
       };
 
       table.insert([], gaxOptions, assert.ifError);
-    });
-
-    it('should accept appProfileId', function(done) {
-      var appProfileId = 'app-profile-id-12345';
-
-      table.mutate = function(entries, gaxOptions_) {
-        assert.strictEqual(gaxOptions_.appProfileId, appProfileId);
-        done();
-      };
-
-      table.insert([], {appProfileId}, assert.ifError);
     });
   });
 
@@ -1824,17 +1789,6 @@ describe('Bigtable/Table', function() {
       };
 
       table.sampleRowKeys(gaxOptions);
-    });
-
-    it('should accept appProfileId', function(done) {
-      var appProfileId = 'app-profile-id-12345';
-
-      table.sampleRowKeysStream = function(gaxOptions_) {
-        assert.strictEqual(gaxOptions_.appProfileId, appProfileId);
-        done();
-      };
-
-      table.sampleRowKeys({appProfileId});
     });
 
     describe('success', function() {

--- a/test/table.js
+++ b/test/table.js
@@ -94,10 +94,7 @@ var FakeFilter = {
 
 describe('Bigtable/Table', function() {
   var TABLE_ID = 'my-table';
-  var INSTANCE = {
-    bigtable: {},
-    id: 'a/b/c/d',
-  };
+  var INSTANCE;
 
   var TABLE_NAME = INSTANCE.id + '/tables/' + TABLE_ID;
 
@@ -122,6 +119,10 @@ describe('Bigtable/Table', function() {
   });
 
   beforeEach(function() {
+    INSTANCE = {
+      bigtable: {},
+      id: 'a/b/c/d',
+    };
     table = new Table(INSTANCE, TABLE_ID);
   });
 

--- a/test/table.js
+++ b/test/table.js
@@ -1438,6 +1438,19 @@ describe('Bigtable/Table', function() {
           done();
         });
       });
+
+      it('should make the correct request', function(done) {
+        table.bigtable.request = function(config) {
+          assert.strictEqual(config.client, 'BigtableClient');
+          assert.strictEqual(config.method, 'readRows');
+
+          assert.deepEqual(config.reqOpts, {
+            tableName: table.id,
+            appProfileId: table.bigtable.appProfileId,
+          });
+        };
+        table.getRows(done);
+      });
     });
 
     describe('error', function() {
@@ -1759,6 +1772,18 @@ describe('Bigtable/Table', function() {
         });
       });
     });
+
+    it('should use an appProfileId', function(done) {
+      var bigtableInstance = table.bigtable;
+      bigtableInstance.appProfileId = 'app-profile-id-12345';
+
+      bigtableInstance.request = function(config) {
+        assert.strictEqual(config.reqOpts.appProfileId, bigtableInstance.appProfileId);
+        done();
+      };
+
+      table.mutate(done);
+    })
   });
 
   describe('row', function() {
@@ -1853,6 +1878,18 @@ describe('Bigtable/Table', function() {
           done();
         });
       });
+    });
+
+    it('should use an appProfileId', function(done) {
+      var bigtableInstance = table.bigtable;
+      bigtableInstance.appProfileId = 'app-profile-id-12345';
+
+      bigtableInstance.request = function(config) {
+        assert.strictEqual(config.reqOpts.appProfileId, bigtableInstance.appProfileId);
+        done();
+      };
+
+      table.sampleRowKeys(done);
     });
   });
 

--- a/test/table.js
+++ b/test/table.js
@@ -377,10 +377,13 @@ describe('Bigtable/Table', function() {
 
   describe('createReadStream', function() {
     it('should provide the proper request options', function(done) {
+      table.bigtable.appProfileId = 'app-profile-id-12345';
+
       table.bigtable.request = function(config) {
         assert.strictEqual(config.client, 'BigtableClient');
         assert.strictEqual(config.method, 'readRows');
         assert.strictEqual(config.reqOpts.tableName, TABLE_NAME);
+        assert.strictEqual(config.reqOpts.appProfileId, 'app-profile-id-12345');
         assert.strictEqual(config.gaxOpts, undefined);
         done();
       };
@@ -398,6 +401,21 @@ describe('Bigtable/Table', function() {
         };
 
         table.createReadStream({gaxOptions});
+      });
+
+      it('should use an appProfileId', function(done) {
+        var bigtableInstance = table.bigtable;
+        bigtableInstance.appProfileId = 'app-profile-id-12345';
+
+        bigtableInstance.request = function(config) {
+          assert.strictEqual(
+            config.reqOpts.appProfileId,
+            bigtableInstance.appProfileId
+          );
+          done();
+        };
+
+        table.createReadStream();
       });
 
       it('should retrieve a range of rows', function(done) {
@@ -1438,19 +1456,6 @@ describe('Bigtable/Table', function() {
           done();
         });
       });
-
-      it('should make the correct request', function(done) {
-        table.bigtable.request = function(config) {
-          assert.strictEqual(config.client, 'BigtableClient');
-          assert.strictEqual(config.method, 'readRows');
-
-          assert.deepEqual(config.reqOpts, {
-            tableName: table.id,
-            appProfileId: table.bigtable.appProfileId,
-          });
-        };
-        table.getRows(done);
-      });
     });
 
     describe('error', function() {
@@ -1537,12 +1542,14 @@ describe('Bigtable/Table', function() {
 
     it('should provide the proper request options', function(done) {
       var stream = through.obj();
+      table.bigtable.appProfileId = 'app-profile-id-12345';
 
       table.bigtable.request = function(config) {
         assert.strictEqual(config.client, 'BigtableClient');
         assert.strictEqual(config.method, 'mutateRows');
 
         assert.strictEqual(config.reqOpts.tableName, TABLE_NAME);
+        assert.strictEqual(config.reqOpts.appProfileId, 'app-profile-id-12345');
         assert.deepEqual(config.reqOpts.entries, fakeEntries);
 
         assert.strictEqual(parseSpy.callCount, 2);
@@ -1555,6 +1562,21 @@ describe('Bigtable/Table', function() {
       };
 
       table.mutate(entries, assert.ifError);
+    });
+
+    it('should use an appProfileId', function(done) {
+      var bigtableInstance = table.bigtable;
+      bigtableInstance.appProfileId = 'app-profile-id-12345';
+
+      bigtableInstance.request = function(config) {
+        assert.strictEqual(
+          config.reqOpts.appProfileId,
+          bigtableInstance.appProfileId
+        );
+        done();
+      };
+
+      table.mutate(done);
     });
 
     describe('error', function() {
@@ -1772,18 +1794,6 @@ describe('Bigtable/Table', function() {
         });
       });
     });
-
-    it('should use an appProfileId', function(done) {
-      var bigtableInstance = table.bigtable;
-      bigtableInstance.appProfileId = 'app-profile-id-12345';
-
-      bigtableInstance.request = function(config) {
-        assert.strictEqual(config.reqOpts.appProfileId, bigtableInstance.appProfileId);
-        done();
-      };
-
-      table.mutate(done);
-    })
   });
 
   describe('row', function() {
@@ -1879,18 +1889,6 @@ describe('Bigtable/Table', function() {
         });
       });
     });
-
-    it('should use an appProfileId', function(done) {
-      var bigtableInstance = table.bigtable;
-      bigtableInstance.appProfileId = 'app-profile-id-12345';
-
-      bigtableInstance.request = function(config) {
-        assert.strictEqual(config.reqOpts.appProfileId, bigtableInstance.appProfileId);
-        done();
-      };
-
-      table.sampleRowKeys(done);
-    });
   });
 
   describe('sampleRowKeysStream', function() {
@@ -1909,6 +1907,21 @@ describe('Bigtable/Table', function() {
       };
 
       table.sampleRowKeysStream();
+    });
+
+    it('should use an appProfileId', function(done) {
+      var bigtableInstance = table.bigtable;
+      bigtableInstance.appProfileId = 'app-profile-id-12345';
+
+      bigtableInstance.request = function(config) {
+        assert.strictEqual(
+          config.reqOpts.appProfileId,
+          bigtableInstance.appProfileId
+        );
+        done();
+      };
+
+      table.sampleRowKeysStream(done);
     });
 
     it('should accept gaxOptions', function(done) {

--- a/test/table.js
+++ b/test/table.js
@@ -95,8 +95,7 @@ var FakeFilter = {
 describe('Bigtable/Table', function() {
   var TABLE_ID = 'my-table';
   var INSTANCE;
-
-  var TABLE_NAME = INSTANCE.id + '/tables/' + TABLE_ID;
+  var TABLE_NAME;
 
   var Table;
   var table;
@@ -123,6 +122,7 @@ describe('Bigtable/Table', function() {
       bigtable: {},
       id: 'a/b/c/d',
     };
+    TABLE_NAME = INSTANCE.id + '/tables/' + TABLE_ID;
     table = new Table(INSTANCE, TABLE_ID);
   });
 

--- a/test/table.js
+++ b/test/table.js
@@ -389,7 +389,7 @@ describe('Bigtable/Table', function() {
 
       table.createReadStream();
     });
-    
+
     it('should use an appProfileId', function(done) {
       var bigtableInstance = table.bigtable;
       bigtableInstance.appProfileId = 'app-profile-id-12345';

--- a/test/table.js
+++ b/test/table.js
@@ -1540,14 +1540,13 @@ describe('Bigtable/Table', function() {
 
     it('should provide the proper request options', function(done) {
       var stream = through.obj();
-      table.bigtable.appProfileId = 'app-profile-id-12345';
 
       table.bigtable.request = function(config) {
         assert.strictEqual(config.client, 'BigtableClient');
         assert.strictEqual(config.method, 'mutateRows');
 
         assert.strictEqual(config.reqOpts.tableName, TABLE_NAME);
-        assert.strictEqual(config.reqOpts.appProfileId, 'app-profile-id-12345');
+        assert.strictEqual(config.reqOpts.appProfileId, undefined);
         assert.deepEqual(config.reqOpts.entries, fakeEntries);
 
         assert.strictEqual(parseSpy.callCount, 2);

--- a/test/table.js
+++ b/test/table.js
@@ -400,6 +400,17 @@ describe('Bigtable/Table', function() {
         table.createReadStream({gaxOptions});
       });
 
+      it('should accept appProfileId', function(done) {
+        var appProfileId = 'app-profile-id-12345';
+
+        table.bigtable.request = function(config) {
+          assert.strictEqual(config.reqOpts.appProfileId, appProfileId);
+          done();
+        };
+
+        table.createReadStream({appProfileId});
+      });
+
       it('should retrieve a range of rows', function(done) {
         var options = {
           start: 'gwashington',
@@ -1438,6 +1449,19 @@ describe('Bigtable/Table', function() {
           done();
         });
       });
+
+      it('should accept appProfileId', function(done) {
+        var appProfileId = 'app-profile-id-12345';
+
+        table.bigtable.request = function(config) {
+          assert.strictEqual(config.appProfileId, appProfileId);
+          done();
+        };
+
+        table.getRows({appProfileId}, function(err, rows) {
+          done();
+        });
+      });
     });
 
     describe('error', function() {
@@ -1507,6 +1531,17 @@ describe('Bigtable/Table', function() {
       };
 
       table.insert([], gaxOptions, assert.ifError);
+    });
+
+    it('should accept appProfileId', function(done) {
+      var appProfileId = 'app-profile-id-12345';
+
+      table.mutate = function(entries, gaxOptions_) {
+        assert.strictEqual(gaxOptions_.appProfileId, appProfileId);
+        done();
+      };
+
+      table.insert([], {appProfileId}, assert.ifError);
     });
   });
 
@@ -1789,6 +1824,17 @@ describe('Bigtable/Table', function() {
       };
 
       table.sampleRowKeys(gaxOptions);
+    });
+
+    it('should accept appProfileId', function(done) {
+      var appProfileId = 'app-profile-id-12345';
+
+      table.sampleRowKeysStream = function(gaxOptions_) {
+        assert.strictEqual(gaxOptions_.appProfileId, appProfileId);
+        done();
+      };
+
+      table.sampleRowKeys({appProfileId});
     });
 
     describe('success', function() {


### PR DESCRIPTION
## Blocked by public feature release

Implement appProfileId support for APIs
- [ ] Tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)
