### PR TITLE
fix: do not require projectId in custom envs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -370,8 +370,10 @@ function Bigtable(options) {
   var defaultBaseUrl = 'bigtable.googleapis.com';
   var defaultAdminBaseUrl = 'bigtableadmin.googleapis.com';
 
-  var customEndpoint = (this.customEndpoint =
-    options.apiEndpoint || process.env.BIGTABLE_EMULATOR_HOST);
+  var customEndpoint =
+    options.apiEndpoint || process.env.BIGTABLE_EMULATOR_HOST;
+  this.customEndpoint = customEndpoint;
+
   var customEndpointBaseUrl;
   var customEndpointPort;
 

--- a/test/index.js
+++ b/test/index.js
@@ -852,7 +852,7 @@ describe('Bigtable', function() {
 
     it('should return any project ID if in custom endpoint', function(done) {
       bigtable.auth.getProjectId = function() {
-        throw new Error('Aut client should not be called.');
+        throw new Error('Auth client should not be called.');
       };
 
       bigtable.projectId = PROJECT_ID_TOKEN;

--- a/test/index.js
+++ b/test/index.js
@@ -659,7 +659,7 @@ describe('Bigtable', function() {
       });
 
       it('should not replace token when project ID not detected', function(done) {
-        replaceProjectIdTokenOverride = function(reqOpts, projectId) {
+        replaceProjectIdTokenOverride = function() {
           throw new Error('Should not have tried to replace token.');
         };
 


### PR DESCRIPTION
Fixes #75 

This will bypass the `authClient.getProjectId()` call:

- When we already have one from the user (we don't want to override theirs)
- When the user provides `apiEndpoint`
- When the user is using the emulator