### PR TITLE
Switch src/ to use ES classes

### DIFF
--- a/src/app-profile.js
+++ b/src/app-profile.js
@@ -14,13 +14,11 @@
  * limitations under the License.
  */
 
-'use strict';
+const common = require('@google-cloud/common');
+const is = require('is');
+const snakeCase = require('lodash.snakecase');
 
-var common = require('@google-cloud/common');
-var is = require('is');
-var snakeCase = require('lodash.snakecase');
-
-var Cluster = require('./cluster.js');
+const Cluster = require('./cluster.js');
 
 /**
  * Create an app profile object to interact with your app profile.
@@ -35,18 +33,298 @@ var Cluster = require('./cluster.js');
  * const instance = bigtable.instance('my-instance');
  * const appProfile = instance.appProfile('my-app-profile');
  */
-function AppProfile(instance, name) {
-  this.bigtable = instance.bigtable;
-  this.instance = instance;
+class AppProfile {
+  constructor(instance, name) {
+    this.bigtable = instance.bigtable;
+    this.instance = instance;
 
-  var id = name;
+    let id = name;
 
-  if (id.indexOf('/') === -1) {
-    id = `${instance.id}/appProfiles/${name}`;
+    if (!id.includes('/')) {
+      id = `${instance.id}/appProfiles/${name}`;
+    }
+
+    this.id = id;
+    this.name = id.split('/').pop();
   }
 
-  this.id = id;
-  this.name = id.split('/').pop();
+  /**
+   * Create an app profile.
+   *
+   * @param {object} [options] See {@link Instance#createAppProfile}.
+   *
+   * @example
+   * const Bigtable = require('@google-cloud/bigtable');
+   * const bigtable = new Bigtable();
+   * const instance = bigtable.instance('my-instance');
+   * const appProfile = instance.appProfile('my-appProfile');
+   *
+   * appProfile.create(function(err, appProfile, apiResponse) {
+   *   if (!err) {
+   *     // The app profile was created successfully.
+   *   }
+   * });
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * appProfile.create().then(function(data) {
+   *   const appProfile = data[0];
+   *   const apiResponse = data[1];
+   * });
+   */
+  create(options, callback) {
+    if (is.fn(options)) {
+      callback = options;
+      options = {};
+    }
+    this.instance.createAppProfile(this.name, options, callback);
+  }
+
+  /**
+   * Delete the app profile.
+   *
+   * @param {object} [options] Cluster creation options.
+   * @param {object} [options.gaxOptions] Request configuration options, outlined
+   *     here: https://googleapis.github.io/gax-nodejs/global.html#CallOptions.
+   * @param {boolean} [options.ignoreWarnings] Whether to ignore safety checks
+   *     when deleting the app profile.
+   * @param {function} [callback] The callback function.
+   * @param {?error} callback.err An error returned while making this
+   *     request.
+   * @param {object} callback.apiResponse The full API response.
+   *
+   * @example
+   * appProfile.delete(function(err, apiResponse) {});
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * appProfile.delete().then(function(data) {
+   *   var apiResponse = data[0];
+   * });
+   */
+  delete(options, callback) {
+    if (is.fn(options)) {
+      callback = options;
+      options = {};
+    }
+
+    const reqOpts = {
+      name: this.id,
+    };
+
+    if (is.boolean(options.ignoreWarnings)) {
+      reqOpts.ignoreWarnings = options.ignoreWarnings;
+    }
+
+    this.bigtable.request(
+      {
+        client: 'BigtableInstanceAdminClient',
+        method: 'deleteAppProfile',
+        reqOpts,
+        gaxOpts: options.gaxOptions,
+      },
+      callback
+    );
+  }
+
+  /**
+   * Check if an app profile exists.
+   *
+   * @param {object} [gaxOptions] Request configuration options, outlined here:
+   *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
+   * @param {function} callback The callback function.
+   * @param {?error} callback.err An error returned while making this
+   *     request.
+   * @param {boolean} callback.exists Whether the app profile exists or not.
+   *
+   * @example
+   * appProfile.exists(function(err, exists) {});
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * appProfile.exists().then(function(data) {
+   *   var exists = data[0];
+   * });
+   */
+  exists(gaxOptions, callback) {
+    if (is.fn(gaxOptions)) {
+      callback = gaxOptions;
+      gaxOptions = {};
+    }
+
+    this.getMetadata(gaxOptions, err => {
+      if (err) {
+        if (err.code === 5) {
+          callback(null, false);
+          return;
+        }
+
+        callback(err);
+        return;
+      }
+
+      callback(null, true);
+    });
+  }
+
+  /**
+   * Get a appProfile if it exists.
+   *
+   * @param {object} [gaxOptions] Request configuration options, outlined here:
+   *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
+   *
+   * @example
+   * appProfile.get(function(err, appProfile, apiResponse) {
+   *   // The `appProfile` data has been populated.
+   * });
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * appProfile.get().then(function(data) {
+   *   var appProfile = data[0];
+   *   var apiResponse = data[1];
+   * });
+   */
+  get(gaxOptions, callback) {
+    const self = this;
+
+    if (is.fn(gaxOptions)) {
+      callback = gaxOptions;
+      gaxOptions = {};
+    }
+
+    this.getMetadata(gaxOptions, (err, metadata) => {
+      callback(err, err ? null : self, metadata);
+    });
+  }
+
+  /**
+   * Get the app profile metadata.
+   *
+   * @param {object} [gaxOptions] Request configuration options, outlined
+   *     here: https://googleapis.github.io/gax-nodejs/CallSettings.html.
+   * @param {function} callback The callback function.
+   * @param {?error} callback.err An error returned while making this
+   *     request.
+   * @param {object} callback.metadata The metadata.
+   * @param {object} callback.apiResponse The full API response.
+   *
+   * @example
+   * appProfile.getMetadata(function(err, metadata, apiResponse) {});
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * appProfile.getMetadata().then(function(data) {
+   *   var metadata = data[0];
+   *   var apiResponse = data[1];
+   * });
+   */
+  getMetadata(gaxOptions, callback) {
+    const self = this;
+
+    if (is.fn(gaxOptions)) {
+      callback = gaxOptions;
+      gaxOptions = {};
+    }
+
+    this.bigtable.request(
+      {
+        client: 'BigtableInstanceAdminClient',
+        method: 'getAppProfile',
+        reqOpts: {
+          name: this.id,
+        },
+        gaxOpts: gaxOptions,
+      },
+      (...args) => {
+        if (args[1]) {
+          self.metadata = args[1];
+        }
+
+        callback(...args);
+      }
+    );
+  }
+
+  /**
+   * Set the app profile metadata.
+   *
+   * @param {object} metadata See {@link Instance#createAppProfile} for the
+   *     available metadata options.
+   * @param {object} [gaxOptions] Request configuration options, outlined here:
+   *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
+   * @param {function} callback The callback function.
+   * @param {?error} callback.err An error returned while making this request.
+   * @param {object} callback.apiResponse The full API response.
+   *
+   * @example
+   * const Bigtable = require('@google-cloud/bigtable');
+   * const bigtable = new Bigtable();
+   * const instance = bigtable.instance('my-instance');
+   * const cluster = instance.cluster('my-cluster');
+   * const appProfile = instance.appProfile('my-appProfile');
+   *
+   * const metadata = {
+   *   description: 'My Updated App Profile',
+   *   routing: cluster,
+   *   allowTransactionalWrites: true,
+   * };
+   *
+   * appProfile.setMetadata(metadata, callback);
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * appProfile.setMetadata(metadata).then(function(data) {
+   *   const apiResponse = data[0];
+   * });
+   */
+  setMetadata(metadata, gaxOptions, callback) {
+    if (is.fn(gaxOptions)) {
+      callback = gaxOptions;
+      gaxOptions = {};
+    }
+
+    const reqOpts = {
+      appProfile: AppProfile.formatAppProfile_(metadata),
+      updateMask: {
+        paths: [],
+      },
+    };
+    reqOpts.appProfile.name = this.id;
+
+    const fieldsForMask = [
+      'description',
+      'singleClusterRouting',
+      'multiClusterRoutingUseAny',
+      'allowTransactionalWrites',
+    ];
+
+    fieldsForMask.forEach(field => {
+      if (reqOpts.appProfile[field]) {
+        reqOpts.updateMask.paths.push(snakeCase(field));
+      }
+    });
+
+    if (is.boolean(metadata.ignoreWarnings)) {
+      reqOpts.ignoreWarnings = metadata.ignoreWarnings;
+    }
+
+    this.bigtable.request(
+      {
+        client: 'BigtableInstanceAdminClient',
+        method: 'updateAppProfile',
+        reqOpts,
+        gaxOpts: gaxOptions,
+      },
+      callback
+    );
+  }
 }
 
 /**
@@ -83,19 +361,19 @@ function AppProfile(instance, name) {
  * //   description: 'My App Profile',
  * // }
  */
-AppProfile.formatAppProfile_ = function(options) {
+AppProfile.formatAppProfile_ = ({routing, allowTransactionalWrites, description}) => {
   const appProfile = {};
 
-  if (options.routing) {
-    if (options.routing === 'any') {
+  if (routing) {
+    if (routing === 'any') {
       appProfile.multiClusterRoutingUseAny = {};
-    } else if (options.routing instanceof Cluster) {
+    } else if (routing instanceof Cluster) {
       appProfile.singleClusterRouting = {
-        clusterId: options.routing.name,
+        clusterId: routing.name,
       };
-      if (is.boolean(options.allowTransactionalWrites)) {
+      if (is.boolean(allowTransactionalWrites)) {
         appProfile.singleClusterRouting.allowTransactionalWrites =
-          options.allowTransactionalWrites;
+          allowTransactionalWrites;
       }
     } else {
       throw new Error(
@@ -104,289 +382,11 @@ AppProfile.formatAppProfile_ = function(options) {
     }
   }
 
-  if (is.string(options.description)) {
-    appProfile.description = options.description;
+  if (is.string(description)) {
+    appProfile.description = description;
   }
 
   return appProfile;
-};
-
-/**
- * Create an app profile.
- *
- * @param {object} [options] See {@link Instance#createAppProfile}.
- *
- * @example
- * const Bigtable = require('@google-cloud/bigtable');
- * const bigtable = new Bigtable();
- * const instance = bigtable.instance('my-instance');
- * const appProfile = instance.appProfile('my-appProfile');
- *
- * appProfile.create(function(err, appProfile, apiResponse) {
- *   if (!err) {
- *     // The app profile was created successfully.
- *   }
- * });
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * appProfile.create().then(function(data) {
- *   const appProfile = data[0];
- *   const apiResponse = data[1];
- * });
- */
-AppProfile.prototype.create = function(options, callback) {
-  if (is.fn(options)) {
-    callback = options;
-    options = {};
-  }
-  this.instance.createAppProfile(this.name, options, callback);
-};
-
-/**
- * Delete the app profile.
- *
- * @param {object} [options] Cluster creation options.
- * @param {object} [options.gaxOptions] Request configuration options, outlined
- *     here: https://googleapis.github.io/gax-nodejs/global.html#CallOptions.
- * @param {boolean} [options.ignoreWarnings] Whether to ignore safety checks
- *     when deleting the app profile.
- * @param {function} [callback] The callback function.
- * @param {?error} callback.err An error returned while making this
- *     request.
- * @param {object} callback.apiResponse The full API response.
- *
- * @example
- * appProfile.delete(function(err, apiResponse) {});
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * appProfile.delete().then(function(data) {
- *   var apiResponse = data[0];
- * });
- */
-AppProfile.prototype.delete = function(options, callback) {
-  if (is.fn(options)) {
-    callback = options;
-    options = {};
-  }
-
-  const reqOpts = {
-    name: this.id,
-  };
-
-  if (is.boolean(options.ignoreWarnings)) {
-    reqOpts.ignoreWarnings = options.ignoreWarnings;
-  }
-
-  this.bigtable.request(
-    {
-      client: 'BigtableInstanceAdminClient',
-      method: 'deleteAppProfile',
-      reqOpts,
-      gaxOpts: options.gaxOptions,
-    },
-    callback
-  );
-};
-
-/**
- * Check if an app profile exists.
- *
- * @param {object} [gaxOptions] Request configuration options, outlined here:
- *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
- * @param {function} callback The callback function.
- * @param {?error} callback.err An error returned while making this
- *     request.
- * @param {boolean} callback.exists Whether the app profile exists or not.
- *
- * @example
- * appProfile.exists(function(err, exists) {});
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * appProfile.exists().then(function(data) {
- *   var exists = data[0];
- * });
- */
-AppProfile.prototype.exists = function(gaxOptions, callback) {
-  if (is.fn(gaxOptions)) {
-    callback = gaxOptions;
-    gaxOptions = {};
-  }
-
-  this.getMetadata(gaxOptions, function(err) {
-    if (err) {
-      if (err.code === 5) {
-        callback(null, false);
-        return;
-      }
-
-      callback(err);
-      return;
-    }
-
-    callback(null, true);
-  });
-};
-
-/**
- * Get a appProfile if it exists.
- *
- * @param {object} [gaxOptions] Request configuration options, outlined here:
- *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
- *
- * @example
- * appProfile.get(function(err, appProfile, apiResponse) {
- *   // The `appProfile` data has been populated.
- * });
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * appProfile.get().then(function(data) {
- *   var appProfile = data[0];
- *   var apiResponse = data[1];
- * });
- */
-AppProfile.prototype.get = function(gaxOptions, callback) {
-  var self = this;
-
-  if (is.fn(gaxOptions)) {
-    callback = gaxOptions;
-    gaxOptions = {};
-  }
-
-  this.getMetadata(gaxOptions, function(err, metadata) {
-    callback(err, err ? null : self, metadata);
-  });
-};
-
-/**
- * Get the app profile metadata.
- *
- * @param {object} [gaxOptions] Request configuration options, outlined
- *     here: https://googleapis.github.io/gax-nodejs/CallSettings.html.
- * @param {function} callback The callback function.
- * @param {?error} callback.err An error returned while making this
- *     request.
- * @param {object} callback.metadata The metadata.
- * @param {object} callback.apiResponse The full API response.
- *
- * @example
- * appProfile.getMetadata(function(err, metadata, apiResponse) {});
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * appProfile.getMetadata().then(function(data) {
- *   var metadata = data[0];
- *   var apiResponse = data[1];
- * });
- */
-AppProfile.prototype.getMetadata = function(gaxOptions, callback) {
-  var self = this;
-
-  if (is.fn(gaxOptions)) {
-    callback = gaxOptions;
-    gaxOptions = {};
-  }
-
-  this.bigtable.request(
-    {
-      client: 'BigtableInstanceAdminClient',
-      method: 'getAppProfile',
-      reqOpts: {
-        name: this.id,
-      },
-      gaxOpts: gaxOptions,
-    },
-    function() {
-      if (arguments[1]) {
-        self.metadata = arguments[1];
-      }
-
-      callback.apply(null, arguments);
-    }
-  );
-};
-
-/**
- * Set the app profile metadata.
- *
- * @param {object} metadata See {@link Instance#createAppProfile} for the
- *     available metadata options.
- * @param {object} [gaxOptions] Request configuration options, outlined here:
- *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
- * @param {function} callback The callback function.
- * @param {?error} callback.err An error returned while making this request.
- * @param {object} callback.apiResponse The full API response.
- *
- * @example
- * const Bigtable = require('@google-cloud/bigtable');
- * const bigtable = new Bigtable();
- * const instance = bigtable.instance('my-instance');
- * const cluster = instance.cluster('my-cluster');
- * const appProfile = instance.appProfile('my-appProfile');
- *
- * const metadata = {
- *   description: 'My Updated App Profile',
- *   routing: cluster,
- *   allowTransactionalWrites: true,
- * };
- *
- * appProfile.setMetadata(metadata, callback);
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * appProfile.setMetadata(metadata).then(function(data) {
- *   const apiResponse = data[0];
- * });
- */
-AppProfile.prototype.setMetadata = function(metadata, gaxOptions, callback) {
-  if (is.fn(gaxOptions)) {
-    callback = gaxOptions;
-    gaxOptions = {};
-  }
-
-  var reqOpts = {
-    appProfile: AppProfile.formatAppProfile_(metadata),
-    updateMask: {
-      paths: [],
-    },
-  };
-  reqOpts.appProfile.name = this.id;
-
-  const fieldsForMask = [
-    'description',
-    'singleClusterRouting',
-    'multiClusterRoutingUseAny',
-    'allowTransactionalWrites',
-  ];
-
-  fieldsForMask.forEach(field => {
-    if (reqOpts.appProfile[field]) {
-      reqOpts.updateMask.paths.push(snakeCase(field));
-    }
-  });
-
-  if (is.boolean(metadata.ignoreWarnings)) {
-    reqOpts.ignoreWarnings = metadata.ignoreWarnings;
-  }
-
-  this.bigtable.request(
-    {
-      client: 'BigtableInstanceAdminClient',
-      method: 'updateAppProfile',
-      reqOpts: reqOpts,
-      gaxOpts: gaxOptions,
-    },
-    callback
-  );
 };
 
 /*! Developer Documentation

--- a/src/chunktransformer.js
+++ b/src/chunktransformer.js
@@ -13,15 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-'use strict';
 const Mutation = require('./mutation.js');
 const stream = require('stream');
 const util = require('util');
 const Transform = stream.Transform;
 const createErrorClass = require('create-error-class');
 
-const TransformError = createErrorClass('TransformError', function(props) {
-  this.message = `${props.message}: ${JSON.stringify(props.chunk)}`;
+const TransformError = createErrorClass('TransformError', function({message, chunk}) {
+  this.message = `${message}: ${JSON.stringify(chunk)}`;
 });
 
 /**
@@ -35,267 +34,310 @@ const RowStateEnum = Object.freeze({
   ROW_IN_PROGRESS: 2,
   CELL_IN_PROGRESS: 3,
 });
+
 /**
  * ChunkTransformer formats all incoming chunks in to row
  * keeps all intermediate state until end of stream.
  * Should use new instance for each request.
  */
-function ChunkTransformer(options) {
-  if (!(this instanceof ChunkTransformer)) {
-    return new ChunkTransformer(options);
-  }
-  this.options = options || {};
-  this.options.objectMode = true; // forcing object mode
-  Transform.call(this, options);
-  this._destroyed = false;
-  this.lastRowKey = undefined;
-  this.reset();
-}
-util.inherits(ChunkTransformer, Transform);
-/**
- * transform the readrowsresponse chunks into friendly format. Chunks contain 3 properties:
- *
- * `rowContents` The row contents, this essentially is all data pertaining
- *     to a single family.
- *
- * `commitRow` This is a boolean telling us the all previous chunks for this
- *     row are ok to consume.
- *
- * `resetRow` This is a boolean telling us that all the previous chunks are to
- *     be discarded.
- *
- * @public
- *
- * @param {object} data readrows response containing array of chunks.
- * @param {object} [enc] encoding options.
- * @param {callback} next callback will be called once data is processed, with error if any error in processing
- */
-ChunkTransformer.prototype._transform = function(data, enc, next) {
-  for (const chunk of data.chunks) {
-    switch (this.state) {
-      case RowStateEnum.NEW_ROW:
-        this.processNewRow(chunk);
-        break;
-      case RowStateEnum.ROW_IN_PROGRESS:
-        this.processRowInProgress(chunk);
-        break;
-      case RowStateEnum.CELL_IN_PROGRESS:
-        this.processCellInProgress(chunk);
-        break;
+class ChunkTransformer extends Transform {
+  constructor(options) {
+    if (!(this instanceof ChunkTransformer)) {
+      return new ChunkTransformer(options);
     }
-    if (this._destroyed) {
-      return;
+    this.options = options || {};
+    this.options.objectMode = true; // forcing object mode
+    super(options);
+    this._destroyed = false;
+    this.lastRowKey = undefined;
+    this.reset();
+  }
+
+  /**
+   * transform the readrowsresponse chunks into friendly format. Chunks contain 3 properties:
+   *
+   * `rowContents` The row contents, this essentially is all data pertaining
+   *     to a single family.
+   *
+   * `commitRow` This is a boolean telling us the all previous chunks for this
+   *     row are ok to consume.
+   *
+   * `resetRow` This is a boolean telling us that all the previous chunks are to
+   *     be discarded.
+   *
+   * @public
+   *
+   * @param {object} data readrows response containing array of chunks.
+   * @param {object} [enc] encoding options.
+   * @param {callback} next callback will be called once data is processed, with error if any error in processing
+   */
+  _transform({chunks, lastScannedRowKey}, enc, next) {
+    for (const chunk of chunks) {
+      switch (this.state) {
+        case RowStateEnum.NEW_ROW:
+          this.processNewRow(chunk);
+          break;
+        case RowStateEnum.ROW_IN_PROGRESS:
+          this.processRowInProgress(chunk);
+          break;
+        case RowStateEnum.CELL_IN_PROGRESS:
+          this.processCellInProgress(chunk);
+          break;
+      }
+      if (this._destroyed) {
+        return;
+      }
     }
+    if (lastScannedRowKey && lastScannedRowKey.length > 0) {
+      this.lastRowKey = Mutation.convertFromBytes(lastScannedRowKey);
+    }
+    next();
   }
-  if (data.lastScannedRowKey && data.lastScannedRowKey.length > 0) {
-    this.lastRowKey = Mutation.convertFromBytes(data.lastScannedRowKey);
-  }
-  next();
-};
 
-/**
- * called at end of the stream.
- * @public
- * @param {callback} cb callback will be called with error if there is any uncommitted row
- */
-ChunkTransformer.prototype._flush = function(cb) {
-  if (typeof this.row.key !== 'undefined') {
-    this.destroy(
-      new TransformError({
-        message: 'Response ended with pending row without commit',
-        chunk: null,
-      })
-    );
-    return;
-  }
-  cb();
-};
-
-/**
- * called when stream is destroyed.
- * @public
- * @param {error} err error if any
- */
-ChunkTransformer.prototype.destroy = function(err) {
-  if (this._destroyed) return;
-  this._destroyed = true;
-  var self = this;
-  if (err) {
-    self.emit('error', err);
-  }
-  self.emit('close');
-};
-
-/**
- * Resets state of formatter
- * @private
- */
-ChunkTransformer.prototype.reset = function() {
-  this.prevRowKey = '';
-  this.family = {};
-  this.qualifiers = [];
-  this.qualifier = {};
-  this.row = {};
-  this.state = RowStateEnum.NEW_ROW;
-};
-/**
- * sets prevRowkey and calls reset when row is committed.
- * @private
- */
-ChunkTransformer.prototype.commit = function() {
-  const row = this.row;
-  this.reset();
-  this.prevRowKey = row.key;
-};
-/**
- * Validates valuesize and commitrow in a chunk
- * @private
- * @param {chunk} chunk chunk to validate for valuesize and commitRow
- */
-ChunkTransformer.prototype.validateValueSizeAndCommitRow = function(chunk) {
-  if (chunk.valueSize > 0 && chunk.commitRow) {
-    this.destroy(
-      new TransformError({
-        message: 'A row cannot be have a value size and be a commit row',
-        chunk: chunk,
-      })
-    );
-  }
-};
-/**
- * Validates resetRow condition for chunk
- * @private
- * @param {chunk} chunk chunk to validate for resetrow
- */
-ChunkTransformer.prototype.validateResetRow = function(chunk) {
-  const containsData =
-    (chunk.rowKey && chunk.rowKey.toString() !== '') ||
-    chunk.familyName ||
-    chunk.qualifier ||
-    (chunk.value && chunk.value.toString() !== '') ||
-    chunk.timestampMicros > 0;
-  if (chunk.resetRow && containsData) {
-    this.destroy(
-      new TransformError({
-        message: 'A reset should have no data',
-        chunk: chunk,
-      })
-    );
-  }
-};
-/**
- * Validates state for new row.
- * @private
- * @param {chunk} chunk chunk to validate
- * @param {newRowKey} newRowKey newRowKey of the new row
- */
-ChunkTransformer.prototype.validateNewRow = function(chunk, newRowKey) {
-  const row = this.row;
-  const prevRowKey = this.prevRowKey;
-  let errorMessage;
-
-  if (typeof row.key !== 'undefined') {
-    errorMessage = 'A new row cannot have existing state';
-  } else if (
-    typeof chunk.rowKey === 'undefined' ||
-    chunk.rowKey === '' ||
-    newRowKey === ''
-  ) {
-    errorMessage = 'A row key must be set';
-  } else if (chunk.resetRow) {
-    errorMessage = 'A new row cannot be reset';
-  } else if (prevRowKey === newRowKey) {
-    errorMessage = 'A commit happened but the same key followed';
-  } else if (!chunk.familyName) {
-    errorMessage = 'A family must be set';
-  } else if (!chunk.qualifier) {
-    errorMessage = 'A column qualifier must be set';
-  }
-  if (errorMessage) {
-    this.destroy(new TransformError({message: errorMessage, chunk}));
-    return;
-  }
-  this.validateValueSizeAndCommitRow(chunk);
-};
-/**
- * Validates state for rowInProgress
- * @private
- * @param {chunk} chunk chunk to validate
- */
-ChunkTransformer.prototype.validateRowInProgress = function(chunk) {
-  const row = this.row;
-  if (chunk.rowKey && chunk.rowKey.length) {
-    const newRowKey = Mutation.convertFromBytes(chunk.rowKey);
-    if (
-      newRowKey &&
-      chunk.rowKey &&
-      newRowKey !== '' &&
-      newRowKey !== row.key
-    ) {
+  /**
+   * called at end of the stream.
+   * @public
+   * @param {callback} cb callback will be called with error if there is any uncommitted row
+   */
+  _flush(cb) {
+    if (typeof this.row.key !== 'undefined') {
       this.destroy(
         new TransformError({
-          message: 'A commit is required between row keys',
+          message: 'Response ended with pending row without commit',
+          chunk: null,
+        })
+      );
+      return;
+    }
+    cb();
+  }
+
+  /**
+   * called when stream is destroyed.
+   * @public
+   * @param {error} err error if any
+   */
+  destroy(err) {
+    if (this._destroyed) return;
+    this._destroyed = true;
+    const self = this;
+    if (err) {
+      self.emit('error', err);
+    }
+    self.emit('close');
+  }
+
+  /**
+   * Resets state of formatter
+   * @private
+   */
+  reset() {
+    this.prevRowKey = '';
+    this.family = {};
+    this.qualifiers = [];
+    this.qualifier = {};
+    this.row = {};
+    this.state = RowStateEnum.NEW_ROW;
+  }
+
+  /**
+   * sets prevRowkey and calls reset when row is committed.
+   * @private
+   */
+  commit() {
+    const row = this.row;
+    this.reset();
+    this.prevRowKey = row.key;
+  }
+
+  /**
+   * Validates valuesize and commitrow in a chunk
+   * @private
+   * @param {chunk} chunk chunk to validate for valuesize and commitRow
+   */
+  validateValueSizeAndCommitRow(chunk) {
+    if (chunk.valueSize > 0 && chunk.commitRow) {
+      this.destroy(
+        new TransformError({
+          message: 'A row cannot be have a value size and be a commit row',
+          chunk,
+        })
+      );
+    }
+  }
+
+  /**
+   * Validates resetRow condition for chunk
+   * @private
+   * @param {chunk} chunk chunk to validate for resetrow
+   */
+  validateResetRow(chunk) {
+    const containsData =
+      (chunk.rowKey && chunk.rowKey.toString() !== '') ||
+      chunk.familyName ||
+      chunk.qualifier ||
+      (chunk.value && chunk.value.toString() !== '') ||
+      chunk.timestampMicros > 0;
+    if (chunk.resetRow && containsData) {
+      this.destroy(
+        new TransformError({
+          message: 'A reset should have no data',
+          chunk,
+        })
+      );
+    }
+  }
+
+  /**
+   * Validates state for new row.
+   * @private
+   * @param {chunk} chunk chunk to validate
+   * @param {newRowKey} newRowKey newRowKey of the new row
+   */
+  validateNewRow(chunk, newRowKey) {
+    const row = this.row;
+    const prevRowKey = this.prevRowKey;
+    let errorMessage;
+
+    if (typeof row.key !== 'undefined') {
+      errorMessage = 'A new row cannot have existing state';
+    } else if (
+      typeof chunk.rowKey === 'undefined' ||
+      chunk.rowKey === '' ||
+      newRowKey === ''
+    ) {
+      errorMessage = 'A row key must be set';
+    } else if (chunk.resetRow) {
+      errorMessage = 'A new row cannot be reset';
+    } else if (prevRowKey === newRowKey) {
+      errorMessage = 'A commit happened but the same key followed';
+    } else if (!chunk.familyName) {
+      errorMessage = 'A family must be set';
+    } else if (!chunk.qualifier) {
+      errorMessage = 'A column qualifier must be set';
+    }
+    if (errorMessage) {
+      this.destroy(new TransformError({message: errorMessage, chunk}));
+      return;
+    }
+    this.validateValueSizeAndCommitRow(chunk);
+  }
+
+  /**
+   * Validates state for rowInProgress
+   * @private
+   * @param {chunk} chunk chunk to validate
+   */
+  validateRowInProgress(chunk) {
+    const row = this.row;
+    if (chunk.rowKey && chunk.rowKey.length) {
+      const newRowKey = Mutation.convertFromBytes(chunk.rowKey);
+      if (
+        newRowKey &&
+        chunk.rowKey &&
+        newRowKey !== '' &&
+        newRowKey !== row.key
+      ) {
+        this.destroy(
+          new TransformError({
+            message: 'A commit is required between row keys',
+            chunk,
+          })
+        );
+        return;
+      }
+    }
+    if (chunk.familyName && !chunk.qualifier) {
+      this.destroy(
+        new TransformError({
+          message: 'A qualifier must be specified',
           chunk,
         })
       );
       return;
     }
+    this.validateResetRow(chunk);
+    this.validateValueSizeAndCommitRow(chunk);
   }
-  if (chunk.familyName && !chunk.qualifier) {
-    this.destroy(
-      new TransformError({
-        message: 'A qualifier must be specified',
-        chunk,
-      })
-    );
-    return;
+
+  /**
+   * Validates chunk for cellInProgress state.
+   * @private
+   * @param {chunk} chunk chunk to validate
+   */
+  validateCellInProgress(chunk) {
+    this.validateResetRow(chunk);
+    this.validateValueSizeAndCommitRow(chunk);
   }
-  this.validateResetRow(chunk);
-  this.validateValueSizeAndCommitRow(chunk);
-};
-/**
- * Validates chunk for cellInProgress state.
- * @private
- * @param {chunk} chunk chunk to validate
- */
-ChunkTransformer.prototype.validateCellInProgress = function(chunk) {
-  this.validateResetRow(chunk);
-  this.validateValueSizeAndCommitRow(chunk);
-};
-/**
- * Moves to next state in processing.
- * @private
- * @param {chunk} chunk chunk in process
- */
-ChunkTransformer.prototype.moveToNextState = function(chunk) {
-  const row = this.row;
-  if (chunk.commitRow) {
-    this.push(row);
-    this.commit();
-    this.lastRowKey = row.key;
-  } else {
-    if (chunk.valueSize > 0) {
-      this.state = RowStateEnum.CELL_IN_PROGRESS;
+
+  /**
+   * Moves to next state in processing.
+   * @private
+   * @param {chunk} chunk chunk in process
+   */
+  moveToNextState({commitRow, valueSize}) {
+    const row = this.row;
+    if (commitRow) {
+      this.push(row);
+      this.commit();
+      this.lastRowKey = row.key;
     } else {
-      this.state = RowStateEnum.ROW_IN_PROGRESS;
+      if (valueSize > 0) {
+        this.state = RowStateEnum.CELL_IN_PROGRESS;
+      } else {
+        this.state = RowStateEnum.ROW_IN_PROGRESS;
+      }
     }
   }
-};
-/**
- * Process chunk when in NEW_ROW state.
- * @private
- * @param {chunks} chunk chunk to process
- */
-ChunkTransformer.prototype.processNewRow = function(chunk) {
-  const newRowKey = Mutation.convertFromBytes(chunk.rowKey);
-  this.validateNewRow(chunk, newRowKey);
-  if (chunk.familyName && chunk.qualifier) {
+
+  /**
+   * Process chunk when in NEW_ROW state.
+   * @private
+   * @param {chunks} chunk chunk to process
+   */
+  processNewRow(chunk) {
+    const newRowKey = Mutation.convertFromBytes(chunk.rowKey);
+    this.validateNewRow(chunk, newRowKey);
+    if (chunk.familyName && chunk.qualifier) {
+      const row = this.row;
+      row.key = newRowKey;
+      row.data = {};
+      this.family = row.data[chunk.familyName.value] = {};
+      const qualifierName = Mutation.convertFromBytes(chunk.qualifier.value);
+      this.qualifiers = this.family[qualifierName] = [];
+      this.qualifier = {
+        value: Mutation.convertFromBytes(chunk.value, {
+          userOptions: this.options,
+          isPossibleNumber: true,
+        }),
+        labels: chunk.labels,
+        timestamp: chunk.timestampMicros,
+      };
+      this.qualifiers.push(this.qualifier);
+      this.moveToNextState(chunk);
+    }
+  }
+
+  /**
+   * Process chunk when in ROW_IN_PROGRESS state.
+   * @private
+   * @param {chunk} chunk chunk to process
+   */
+  processRowInProgress(chunk) {
+    this.validateRowInProgress(chunk);
+    if (chunk.resetRow) {
+      return this.reset();
+    }
     const row = this.row;
-    row.key = newRowKey;
-    row.data = {};
-    this.family = row.data[chunk.familyName.value] = {};
-    const qualifierName = Mutation.convertFromBytes(chunk.qualifier.value);
-    this.qualifiers = this.family[qualifierName] = [];
+    if (chunk.familyName) {
+      this.family = row.data[chunk.familyName.value] =
+        row.data[chunk.familyName.value] || {};
+    }
+    if (chunk.qualifier) {
+      const qualifierName = Mutation.convertFromBytes(chunk.qualifier.value);
+      this.qualifiers = this.family[qualifierName] =
+        this.family[qualifierName] || [];
+    }
     this.qualifier = {
       value: Mutation.convertFromBytes(chunk.value, {
         userOptions: this.options,
@@ -307,65 +349,35 @@ ChunkTransformer.prototype.processNewRow = function(chunk) {
     this.qualifiers.push(this.qualifier);
     this.moveToNextState(chunk);
   }
-};
-/**
- * Process chunk when in ROW_IN_PROGRESS state.
- * @private
- * @param {chunk} chunk chunk to process
- */
-ChunkTransformer.prototype.processRowInProgress = function(chunk) {
-  this.validateRowInProgress(chunk);
-  if (chunk.resetRow) {
-    return this.reset();
-  }
-  const row = this.row;
-  if (chunk.familyName) {
-    this.family = row.data[chunk.familyName.value] =
-      row.data[chunk.familyName.value] || {};
-  }
-  if (chunk.qualifier) {
-    const qualifierName = Mutation.convertFromBytes(chunk.qualifier.value);
-    this.qualifiers = this.family[qualifierName] =
-      this.family[qualifierName] || [];
-  }
-  this.qualifier = {
-    value: Mutation.convertFromBytes(chunk.value, {
-      userOptions: this.options,
-      isPossibleNumber: true,
-    }),
-    labels: chunk.labels,
-    timestamp: chunk.timestampMicros,
-  };
-  this.qualifiers.push(this.qualifier);
-  this.moveToNextState(chunk);
-};
-/**
- * Process chunk when in CELl_IN_PROGRESS state.
- * @private
- * @param {chunk} chunk chunk to process
- */
-ChunkTransformer.prototype.processCellInProgress = function(chunk) {
-  this.validateCellInProgress(chunk);
-  if (chunk.resetRow) {
-    return this.reset();
-  }
-  const chunkQualifierValue = Mutation.convertFromBytes(chunk.value, {
-    userOptions: this.options,
-  });
 
-  if (
-    chunkQualifierValue instanceof Buffer &&
-    this.qualifier.value instanceof Buffer
-  ) {
-    this.qualifier.value = Buffer.concat([
-      this.qualifier.value,
-      chunkQualifierValue,
-    ]);
-  } else {
-    this.qualifier.value += chunkQualifierValue;
+  /**
+   * Process chunk when in CELl_IN_PROGRESS state.
+   * @private
+   * @param {chunk} chunk chunk to process
+   */
+  processCellInProgress(chunk) {
+    this.validateCellInProgress(chunk);
+    if (chunk.resetRow) {
+      return this.reset();
+    }
+    const chunkQualifierValue = Mutation.convertFromBytes(chunk.value, {
+      userOptions: this.options,
+    });
+
+    if (
+      chunkQualifierValue instanceof Buffer &&
+      this.qualifier.value instanceof Buffer
+    ) {
+      this.qualifier.value = Buffer.concat([
+        this.qualifier.value,
+        chunkQualifierValue,
+      ]);
+    } else {
+      this.qualifier.value += chunkQualifierValue;
+    }
+    this.moveToNextState(chunk);
   }
-  this.moveToNextState(chunk);
-};
+}
 
 module.exports = ChunkTransformer;
 module.exports.RowStateEnum = RowStateEnum;

--- a/src/family.js
+++ b/src/family.js
@@ -14,17 +14,15 @@
  * limitations under the License.
  */
 
-'use strict';
-
-var common = require('@google-cloud/common');
-var createErrorClass = require('create-error-class');
-var is = require('is');
+const common = require('@google-cloud/common');
+const createErrorClass = require('create-error-class');
+const is = require('is');
 
 /**
  * @private
  */
-var FamilyError = createErrorClass('FamilyError', function(name) {
-  this.message = 'Column family not found: ' + name + '.';
+const FamilyError = createErrorClass('FamilyError', function(name) {
+  this.message = `Column family not found: ${name}.`;
   this.code = 404;
 });
 
@@ -42,17 +40,315 @@ var FamilyError = createErrorClass('FamilyError', function(name) {
  * const table = instance.table('prezzy');
  * const family = table.family('follows');
  */
-function Family(table, name) {
-  this.bigtable = table.bigtable;
-  this.table = table;
+class Family {
+  constructor(table, name) {
+    this.bigtable = table.bigtable;
+    this.table = table;
 
-  this.id = Family.formatName_(table.id, name);
+    this.id = Family.formatName_(table.id, name);
+
+    /**
+     * @name Family#familyName
+     * @type {string}
+     */
+    this.familyName = name.split('/').pop();
+  }
 
   /**
-   * @name Family#familyName
-   * @type {string}
+   * Create a column family.
+   *
+   * @param {object} [options] See {@link Table#createFamily}.
+   * @param {function} callback The callback function.
+   * @param {?error} callback.err An error returned while making this
+   *     request.
+   * @param {Family} callback.family The metadata.
+   * @param {object} callback.apiResponse The full API response.
+   *
+   * @example
+   * family.create(function(err, family, apiResponse) {
+   *   // The column family was created successfully.
+   * });
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * family.create().then(function(data) {
+   *   const family = data[0];
+   *   const apiResponse = data[1];
+   * });
    */
-  this.familyName = name.split('/').pop();
+  create(options, callback) {
+    if (is.fn(options)) {
+      callback = options;
+      options = {};
+    }
+
+    this.table.createFamily(this.familyName, options, callback);
+  }
+
+  /**
+   * Delete the column family.
+   *
+   * @param {object} [gaxOptions] Request configuration options, outlined here:
+   *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
+   * @param {function} [callback] The callback function.
+   * @param {?error} callback.err An error returned while making this
+   *     request.
+   * @param {object} callback.apiResponse The full API response.
+   *
+   * @example
+   * family.delete(function(err, apiResponse) {});
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * family.delete().then(function(data) {
+   *   const apiResponse = data[0];
+   * });
+   */
+  delete(gaxOptions, callback) {
+    if (is.fn(gaxOptions)) {
+      callback = gaxOptions;
+      gaxOptions = {};
+    }
+
+    this.bigtable.request(
+      {
+        client: 'BigtableTableAdminClient',
+        method: 'modifyColumnFamilies',
+        reqOpts: {
+          name: this.table.id,
+          modifications: [
+            {
+              id: this.familyName,
+              drop: true,
+            },
+          ],
+        },
+        gaxOpts: gaxOptions,
+      },
+      callback
+    );
+  }
+
+  /**
+   * Check if the column family exists.
+   *
+   * @param {object} [gaxOptions] Request configuration options, outlined here:
+   *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
+   * @param {function} callback The callback function.
+   * @param {?error} callback.err An error returned while making this
+   *     request.
+   * @param {boolean} callback.exists Whether the family exists or not.
+   *
+   * @example
+   * family.exists(function(err, exists) {});
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * family.exists().then(function(data) {
+   *   const exists = data[0];
+   * });
+   */
+  exists(gaxOptions, callback) {
+    if (is.fn(gaxOptions)) {
+      callback = gaxOptions;
+      gaxOptions = {};
+    }
+
+    this.getMetadata(gaxOptions, err => {
+      if (err) {
+        if (err instanceof FamilyError) {
+          callback(null, false);
+          return;
+        }
+
+        callback(err);
+        return;
+      }
+
+      callback(null, true);
+    });
+  }
+
+  /**
+   * Get a column family if it exists.
+   *
+   * You may optionally use this to "get or create" an object by providing an
+   * object with `autoCreate` set to `true`. Any extra configuration that is
+   * normally required for the `create` method must be contained within this
+   * object as well.
+   *
+   * @param {object} [options] Configuration object.
+   * @param {boolean} [options.autoCreate=false] Automatically create the
+   *     instance if it does not already exist.
+   * @param {object} [options.gaxOptions] Request configuration options, outlined
+   *     here: https://googleapis.github.io/gax-nodejs/CallSettings.html.
+   * @param {?error} callback.error An error returned while making this request.
+   * @param {Family} callback.family The Family object.
+   * @param {object} callback.apiResponse The resource as it exists in the API.
+   *
+   * @example
+   * family.get(function(err, family, apiResponse) {
+   *   // `family.metadata` has been populated.
+   * });
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * family.get().then(function(data) {
+   *   const family = data[0];
+   *   const apiResponse = data[1];
+   * });
+   */
+  get(options, callback) {
+    const self = this;
+
+    if (is.fn(options)) {
+      callback = options;
+      options = {};
+    }
+
+    const autoCreate = !!options.autoCreate;
+    const gaxOptions = options.gaxOptions;
+
+    this.getMetadata(gaxOptions, (err, metadata) => {
+      if (err) {
+        if (err instanceof FamilyError && autoCreate) {
+          self.create({gaxOptions, rule: options.rule}, callback);
+          return;
+        }
+
+        callback(err);
+        return;
+      }
+
+      callback(null, self, metadata);
+    });
+  }
+
+  /**
+   * Get the column family's metadata.
+   *
+   * @param {object} [gaxOptions] Request configuration options, outlined here:
+   *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
+   * @param {function} callback The callback function.
+   * @param {?error} callback.err An error returned while making this
+   *     request.
+   * @param {object} callback.metadata The metadata.
+   *
+   * @example
+   * family.getMetadata(function(err, metadata, apiResponse) {});
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * family.getMetadata().then(function(data) {
+   *   var metadata = data[0];
+   *   var apiResponse = data[1];
+   * });
+   */
+  getMetadata(gaxOptions, callback) {
+    const self = this;
+
+    if (is.fn(gaxOptions)) {
+      callback = gaxOptions;
+      gaxOptions = {};
+    }
+
+    this.table.getFamilies(gaxOptions, (err, families) => {
+      if (err) {
+        callback(err);
+        return;
+      }
+
+      for (const family of families) {
+        if (family.id === self.id) {
+          self.metadata = family.metadata;
+          callback(null, self.metadata);
+          return;
+        }
+      }
+
+      const error = new FamilyError(self.id);
+      callback(error);
+    });
+  }
+
+  /**
+   * Set the column family's metadata.
+   *
+   * See {@link Table#createFamily} for a detailed explanation of the
+   * arguments.
+   *
+   * @see [Garbage Collection Proto Docs]{@link https://github.com/googleapis/googleapis/blob/3592a7339da5a31a3565870989beb86e9235476e/google/bigtable/admin/table/v1/bigtable_table_data.proto#L59}
+   *
+   * @param {object} metadata Metadata object.
+   * @param {object} [metadata.rule] Garbage collection rule.
+   * @param {object} [gaxOptions] Request configuration options, outlined here:
+   *     https://googleapis.github.io/gax-nodejs/global.html#CallOptions.
+   * @param {function} callback The callback function.
+   * @param {?error} callback.err An error returned while making this
+   *     request.
+   * @param {object} callback.apiResponse The full API response.
+   *
+   * @example
+   * var metadata = {
+   *   rule: {
+   *     versions: 2,
+   *     union: true
+   *   }
+   * };
+   *
+   * family.setMetadata(metadata, function(err, apiResponse) {});
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * family.setMetadata(metadata).then(function(data) {
+   *   var apiResponse = data[0];
+   * });
+   */
+  setMetadata({rule}, gaxOptions, callback) {
+    const self = this;
+
+    if (is.fn(gaxOptions)) {
+      callback = gaxOptions;
+      gaxOptions = {};
+    }
+
+    const mod = {
+      id: this.familyName,
+      update: {},
+    };
+
+    if (rule) {
+      mod.update.gcRule = Family.formatRule_(rule);
+    }
+
+    const reqOpts = {
+      name: this.table.id,
+      modifications: [mod],
+    };
+
+    this.bigtable.request(
+      {
+        client: 'BigtableTableAdminClient',
+        method: 'modifyColumnFamilies',
+        reqOpts,
+        gaxOpts: gaxOptions,
+      },
+      (...args) => {
+        if (args[1]) {
+          self.metadata = args[1].columnFamilies[self.familyName];
+          args.splice(1, 0, self.metadata);
+        }
+
+        callback(...args);
+      }
+    );
+  }
 }
 
 /**
@@ -71,12 +367,12 @@ function Family(table, name) {
  * );
  * // 'projects/p/zones/z/clusters/c/tables/t/columnFamilies/my-family'
  */
-Family.formatName_ = function(tableName, name) {
-  if (name.indexOf('/') > -1) {
+Family.formatName_ = (tableName, name) => {
+  if (name.includes('/')) {
     return name;
   }
 
-  return tableName + '/columnFamilies/' + name;
+  return `${tableName}/columnFamilies/${name}`;
 };
 
 /**
@@ -111,8 +407,8 @@ Family.formatName_ = function(tableName, name) {
  * //   }
  * // }
  */
-Family.formatRule_ = function(ruleObj) {
-  var rules = [];
+Family.formatRule_ = ruleObj => {
+  const rules = [];
 
   if (ruleObj.age) {
     rules.push({
@@ -143,312 +439,14 @@ Family.formatRule_ = function(ruleObj) {
     throw new Error('No garbage collection rules were specified.');
   }
 
-  var rule = {};
-  var ruleType = ruleObj.union ? 'union' : 'intersection';
+  const rule = {};
+  const ruleType = ruleObj.union ? 'union' : 'intersection';
 
   rule[ruleType] = {
-    rules: rules,
+    rules,
   };
 
   return rule;
-};
-
-/**
- * Create a column family.
- *
- * @param {object} [options] See {@link Table#createFamily}.
- * @param {function} callback The callback function.
- * @param {?error} callback.err An error returned while making this
- *     request.
- * @param {Family} callback.family The metadata.
- * @param {object} callback.apiResponse The full API response.
- *
- * @example
- * family.create(function(err, family, apiResponse) {
- *   // The column family was created successfully.
- * });
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * family.create().then(function(data) {
- *   const family = data[0];
- *   const apiResponse = data[1];
- * });
- */
-Family.prototype.create = function(options, callback) {
-  if (is.fn(options)) {
-    callback = options;
-    options = {};
-  }
-
-  this.table.createFamily(this.familyName, options, callback);
-};
-
-/**
- * Delete the column family.
- *
- * @param {object} [gaxOptions] Request configuration options, outlined here:
- *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
- * @param {function} [callback] The callback function.
- * @param {?error} callback.err An error returned while making this
- *     request.
- * @param {object} callback.apiResponse The full API response.
- *
- * @example
- * family.delete(function(err, apiResponse) {});
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * family.delete().then(function(data) {
- *   const apiResponse = data[0];
- * });
- */
-Family.prototype.delete = function(gaxOptions, callback) {
-  if (is.fn(gaxOptions)) {
-    callback = gaxOptions;
-    gaxOptions = {};
-  }
-
-  this.bigtable.request(
-    {
-      client: 'BigtableTableAdminClient',
-      method: 'modifyColumnFamilies',
-      reqOpts: {
-        name: this.table.id,
-        modifications: [
-          {
-            id: this.familyName,
-            drop: true,
-          },
-        ],
-      },
-      gaxOpts: gaxOptions,
-    },
-    callback
-  );
-};
-
-/**
- * Check if the column family exists.
- *
- * @param {object} [gaxOptions] Request configuration options, outlined here:
- *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
- * @param {function} callback The callback function.
- * @param {?error} callback.err An error returned while making this
- *     request.
- * @param {boolean} callback.exists Whether the family exists or not.
- *
- * @example
- * family.exists(function(err, exists) {});
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * family.exists().then(function(data) {
- *   const exists = data[0];
- * });
- */
-Family.prototype.exists = function(gaxOptions, callback) {
-  if (is.fn(gaxOptions)) {
-    callback = gaxOptions;
-    gaxOptions = {};
-  }
-
-  this.getMetadata(gaxOptions, function(err) {
-    if (err) {
-      if (err instanceof FamilyError) {
-        callback(null, false);
-        return;
-      }
-
-      callback(err);
-      return;
-    }
-
-    callback(null, true);
-  });
-};
-
-/**
- * Get a column family if it exists.
- *
- * You may optionally use this to "get or create" an object by providing an
- * object with `autoCreate` set to `true`. Any extra configuration that is
- * normally required for the `create` method must be contained within this
- * object as well.
- *
- * @param {object} [options] Configuration object.
- * @param {boolean} [options.autoCreate=false] Automatically create the
- *     instance if it does not already exist.
- * @param {object} [options.gaxOptions] Request configuration options, outlined
- *     here: https://googleapis.github.io/gax-nodejs/CallSettings.html.
- * @param {?error} callback.error An error returned while making this request.
- * @param {Family} callback.family The Family object.
- * @param {object} callback.apiResponse The resource as it exists in the API.
- *
- * @example
- * family.get(function(err, family, apiResponse) {
- *   // `family.metadata` has been populated.
- * });
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * family.get().then(function(data) {
- *   const family = data[0];
- *   const apiResponse = data[1];
- * });
- */
-Family.prototype.get = function(options, callback) {
-  var self = this;
-
-  if (is.fn(options)) {
-    callback = options;
-    options = {};
-  }
-
-  var autoCreate = !!options.autoCreate;
-  var gaxOptions = options.gaxOptions;
-
-  this.getMetadata(gaxOptions, function(err, metadata) {
-    if (err) {
-      if (err instanceof FamilyError && autoCreate) {
-        self.create({gaxOptions, rule: options.rule}, callback);
-        return;
-      }
-
-      callback(err);
-      return;
-    }
-
-    callback(null, self, metadata);
-  });
-};
-
-/**
- * Get the column family's metadata.
- *
- * @param {object} [gaxOptions] Request configuration options, outlined here:
- *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
- * @param {function} callback The callback function.
- * @param {?error} callback.err An error returned while making this
- *     request.
- * @param {object} callback.metadata The metadata.
- *
- * @example
- * family.getMetadata(function(err, metadata, apiResponse) {});
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * family.getMetadata().then(function(data) {
- *   var metadata = data[0];
- *   var apiResponse = data[1];
- * });
- */
-Family.prototype.getMetadata = function(gaxOptions, callback) {
-  var self = this;
-
-  if (is.fn(gaxOptions)) {
-    callback = gaxOptions;
-    gaxOptions = {};
-  }
-
-  this.table.getFamilies(gaxOptions, function(err, families) {
-    if (err) {
-      callback(err);
-      return;
-    }
-
-    for (var i = 0, l = families.length; i < l; i++) {
-      if (families[i].id === self.id) {
-        self.metadata = families[i].metadata;
-        callback(null, self.metadata);
-        return;
-      }
-    }
-
-    var error = new FamilyError(self.id);
-    callback(error);
-  });
-};
-
-/**
- * Set the column family's metadata.
- *
- * See {@link Table#createFamily} for a detailed explanation of the
- * arguments.
- *
- * @see [Garbage Collection Proto Docs]{@link https://github.com/googleapis/googleapis/blob/3592a7339da5a31a3565870989beb86e9235476e/google/bigtable/admin/table/v1/bigtable_table_data.proto#L59}
- *
- * @param {object} metadata Metadata object.
- * @param {object} [metadata.rule] Garbage collection rule.
- * @param {object} [gaxOptions] Request configuration options, outlined here:
- *     https://googleapis.github.io/gax-nodejs/global.html#CallOptions.
- * @param {function} callback The callback function.
- * @param {?error} callback.err An error returned while making this
- *     request.
- * @param {object} callback.apiResponse The full API response.
- *
- * @example
- * var metadata = {
- *   rule: {
- *     versions: 2,
- *     union: true
- *   }
- * };
- *
- * family.setMetadata(metadata, function(err, apiResponse) {});
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * family.setMetadata(metadata).then(function(data) {
- *   var apiResponse = data[0];
- * });
- */
-Family.prototype.setMetadata = function(metadata, gaxOptions, callback) {
-  var self = this;
-
-  if (is.fn(gaxOptions)) {
-    callback = gaxOptions;
-    gaxOptions = {};
-  }
-
-  var mod = {
-    id: this.familyName,
-    update: {},
-  };
-
-  if (metadata.rule) {
-    mod.update.gcRule = Family.formatRule_(metadata.rule);
-  }
-
-  var reqOpts = {
-    name: this.table.id,
-    modifications: [mod],
-  };
-
-  this.bigtable.request(
-    {
-      client: 'BigtableTableAdminClient',
-      method: 'modifyColumnFamilies',
-      reqOpts: reqOpts,
-      gaxOpts: gaxOptions,
-    },
-    function() {
-      var args = [].slice.call(arguments);
-
-      if (args[1]) {
-        self.metadata = args[1].columnFamilies[self.familyName];
-        args.splice(1, 0, self.metadata);
-      }
-
-      callback.apply(null, args);
-    }
-  );
 };
 
 /*! Developer Documentation

--- a/src/filter.js
+++ b/src/filter.js
@@ -14,21 +14,19 @@
  * limitations under the License.
  */
 
-'use strict';
+const arrify = require('arrify');
+const createErrorClass = require('create-error-class');
+const extend = require('extend');
+const escapeStringRegexp = require('escape-string-regexp');
+const is = require('is');
 
-var arrify = require('arrify');
-var createErrorClass = require('create-error-class');
-var extend = require('extend');
-var escapeStringRegexp = require('escape-string-regexp');
-var is = require('is');
-
-var Mutation = require('./mutation.js');
+const Mutation = require('./mutation.js');
 
 /**
  * @private
  */
-var FilterError = createErrorClass('FilterError', function(filter) {
-  this.message = 'Unknown filter: ' + filter + '.';
+const FilterError = createErrorClass('FilterError', function(filter) {
+  this.message = `Unknown filter: ${filter}.`;
 });
 
 /**
@@ -76,8 +74,700 @@ var FilterError = createErrorClass('FilterError', function(filter) {
  * @class
  * @private
  */
-function Filter() {
-  this.filters_ = [];
+class Filter {
+  constructor() {
+    this.filters_ = [];
+  }
+
+  /**
+   * Sets passAllFilter or blockAllFilter
+   *
+   * @param {boolean} pass Whether to passAllFilter or blockAllFilter
+   *
+   * Assign true for enabling passAllFilter and false for enabling blockAllFilter
+   *
+   * @example
+   * //-
+   * // Matches all cells, regardless of input. Functionally equivalent to
+   * // leaving `filter` unset, but included for completeness.
+   * //-
+   * var filter = {
+   *   all: true
+   * };
+   *
+   * //-
+   * // Does not match any cells, regardless of input. Useful for temporarily
+   * // disabling just part of a filter.
+   * //-
+   * var filter = {
+   *   all: false
+   * };
+   */
+  all(pass) {
+    const filterName = pass ? 'passAllFilter' : 'blockAllFilter';
+
+    this.set(filterName, true);
+  }
+
+  /**
+   * Matches only cells from columns whose qualifiers satisfy the given RE2
+   * regex.
+   * @param {?regex|string|object} column Matching Column to filter with
+   *
+   * Note that, since column qualifiers can contain arbitrary bytes, the '\C'
+   * escape sequence must be used if a true wildcard is desired. The '.'
+   * character will not match the new line character '\n', which may be
+   * present in a binary qualifier.
+   *
+   * @example
+   * //-
+   * // Using the following filter, we would retrieve the `tjefferson` and
+   * // `gwashington` columns.
+   * //-
+   * var filter = [
+   *   {
+   *     column: /[a-z]+on$/
+   *   }
+   * ];
+   *
+   * //-
+   * // You can also provide a string (optionally containing regexp characters)
+   * // for simple column filters.
+   * //-
+   * var filter = [
+   *   {
+   *     column: 'gwashington'
+   *   }
+   * ];
+   *
+   * //-
+   * // Or you can provide an array of strings if you wish to match against
+   * // multiple columns.
+   * //-
+   * var filter = [
+   *   {
+   *     column: [
+   *       'gwashington',
+   *       'tjefferson'
+   *     ]
+   *   }
+   * ];
+   *
+   * //-
+   * // If you wish to use additional column filters, consider using the following
+   * // syntax.
+   * //-
+   * var filter = [
+   *   {
+   *     column: {
+   *       name: 'gwashington'
+   *     }
+   *   }
+   * ];
+   *
+   *
+   * //-
+   * // <h4>Column Cell Limits</h4>
+   * //
+   * // Matches only the most recent number of versions within each column. For
+   * // example, if the `versions` is set to 2, this filter would only match
+   * // columns updated at the two most recent timestamps.
+   * //
+   * // If duplicate cells are present, as is possible when using an
+   * // {@link Filter#interleave} filter, each copy of the cell is
+   * // counted separately.
+   * //-
+   * var filter = [
+   *   {
+   *     column: {
+   *       cellLimit: 2
+   *     }
+   *   }
+   * ];
+   *
+   * //-
+   * // <h4>Column Ranges</h4>
+   * //
+   * // Specifies a contiguous range of columns within a single column family.
+   * // The range spans from <column_family>:<start_qualifier> to
+   * // <column_family>:<end_qualifier>, where both bounds can be either
+   * // inclusive or exclusive. By default both are inclusive.
+   * //
+   * // When the `start` bound is omitted it is interpreted as an empty string.
+   * // When the `end` bound is omitted it is interpreted as Infinity.
+   * //-
+   * var filter = [
+   *   {
+   *     column: {
+   *       family: 'follows',
+   *       start: 'gwashington',
+   *       end: 'tjefferson'
+   *     }
+   *   }
+   * ];
+   *
+   * //-
+   * // By default, both the `start` and `end` bounds are inclusive. You can
+   * // override these by providing an object explicity stating whether or not it
+   * // is `inclusive`.
+   * //-
+   * var filter = [
+   *   {
+   *     column: {
+   *       family: 'follows',
+   *       start: {
+   *         value: 'gwashington',
+   *         inclusive: false
+   *       },
+   *       end: {
+   *         value: 'jadams',
+   *         inclusive: false
+   *       }
+   *     }
+   *   }
+   * ];
+   */
+  column(column) {
+    if (!is.object(column)) {
+      column = {
+        name: column,
+      };
+    }
+
+    if (column.name) {
+      let name = Filter.convertToRegExpString(column.name);
+
+      name = Mutation.convertToBytes(name);
+      this.set('columnQualifierRegexFilter', name);
+    }
+
+    if (is.number(column.cellLimit)) {
+      this.set('cellsPerColumnLimitFilter', column.cellLimit);
+    }
+
+    if (column.start || column.end) {
+      const range = Filter.createRange(column.start, column.end, 'Qualifier');
+
+      range.familyName = column.family;
+      this.set('columnRangeFilter', range);
+    }
+  }
+
+  /**
+   * A filter which evaluates one of two possible filters, depending on
+   * whether or not a `test` filter outputs any cells from the input row.
+   *
+   * IMPORTANT NOTE: The `test` filter does not execute atomically with the
+   * pass and fail filters, which may lead to inconsistent or unexpected
+   * results. Additionally, condition filters have poor performance, especially
+   * when filters are set for the fail condition.
+   *
+   * @param {object} condition Condition to filter.
+   *
+   * @example
+   * //-
+   * // In the following example we're creating a filter that will check if
+   * // `gwashington` follows `tjefferson`. If he does, we'll get all of the
+   * // `gwashington` data. If he does not, we'll instead return all of the
+   * // `tjefferson` data.
+   * //-
+   * var filter = [
+   *   {
+   *     condition: {
+   *       // If `test` outputs any cells, then `pass` will be evaluated on the
+   *       // input row. Otherwise `fail` will be evaluated.
+   *       test: [
+   *         {
+   *           row: 'gwashington'
+   *         },
+   *         {
+   *           family: 'follows'
+   *         },
+   *         {
+   *           column: 'tjefferson'
+   *         }
+   *       ],
+   *
+   *       // If omitted, no results will be returned in the true case.
+   *       pass: [
+   *         {
+   *           row: 'gwashington'
+   *         }
+   *       ],
+   *
+   *       // If omitted, no results will be returned in the false case.
+   *       fail: [
+   *         {
+   *           row: 'tjefferson'
+   *         }
+   *       ]
+   *     }
+   *   }
+   * ];
+   */
+  condition({test, pass, fail}) {
+    this.set('condition', {
+      predicateFilter: Filter.parse(test),
+      trueFilter: Filter.parse(pass),
+      falseFilter: Filter.parse(fail),
+    });
+  }
+
+  /**
+   * Matches only cells from columns whose families satisfy the given RE2
+   * regex. For technical reasons, the regex must not contain the ':'
+   * character, even if it is not being used as a literal.
+   * Note that, since column families cannot contain the new line character
+   * '\n', it is sufficient to use '.' as a full wildcard when matching
+   * column family names.
+   *
+   * @param {regex} family Expression to filter family
+   *
+   * @example
+   * var filter = [
+   *   {
+   *     family: 'follows'
+   *   }
+   * ];
+   */
+  family(family) {
+    family = Filter.convertToRegExpString(family);
+    this.set('familyNameRegexFilter', family);
+  }
+
+  /**
+   * Applies several filters to the data in parallel and combines the results.
+   *
+   * @param {object} filters The elements of "filters" all process a copy of the input row, and the
+   * results are pooled, sorted, and combined into a single output row.
+   * If multiple cells are produced with the same column and timestamp,
+   * they will all appear in the output row in an unspecified mutual order.
+   * All interleaved filters are executed atomically.
+   *
+   * @example
+   * //-
+   * // In the following example, we're creating a filter that will retrieve
+   * // results for entries that were either created between December 17th, 2015
+   * // and March 22nd, 2016 or entries that have data for `follows:tjefferson`.
+   * //-
+   * var filter = [
+   *   {
+   *     interleave: [
+   *       [
+   *         {
+   *           time: {
+   *             start: new Date('December 17, 2015'),
+   *             end: new Date('March 22, 2016')
+   *           }
+   *         }
+   *       ],
+   *       [
+   *         {
+   *           family: 'follows'
+   *         },
+   *         {
+   *           column: 'tjefferson'
+   *         }
+   *       ]
+   *     ]
+   *   }
+   * ];
+   */
+  interleave(filters) {
+    this.set('interleave', {
+      filters: filters.map(Filter.parse),
+    });
+  }
+
+  /**
+   * Applies the given label to all cells in the output row. This allows
+   * the client to determine which results were produced from which part of
+   * the filter.
+   *
+   * @param {string} label Label to determine filter point
+   * Values must be at most 15 characters in length, and match the RE2
+   * pattern [a-z0-9\\-]+
+   *
+   * Due to a technical limitation, it is not currently possible to apply
+   * multiple labels to a cell. As a result, a chain filter may have no more than
+   * one sub-filter which contains a apply label transformer. It is okay for
+   * an {@link Filter#interleave} to contain multiple apply label
+   * transformers, as they will be applied to separate copies of the input. This
+   * may be relaxed in the future.
+   *
+   * @example
+   * var filter = {
+   *   label: 'my-label'
+   * };
+   */
+  label(label) {
+    this.set('applyLabelTransformer', label);
+  }
+
+  /**
+   * Matches only cells from rows whose keys satisfy the given RE2 regex. In
+   * other words, passes through the entire row when the key matches, and
+   * otherwise produces an empty row.
+   *
+   * @param {?regex|string|string[]} row Row format to Filter
+   *
+   * Note that, since row keys can contain arbitrary bytes, the '\C' escape
+   * sequence must be used if a true wildcard is desired. The '.' character
+   * will not match the new line character '\n', which may be present in a
+   * binary key.
+   *
+   * @example
+   * //-
+   * // In the following example we'll use a regular expression to match all
+   * // row keys ending with the letters "on", which would then yield
+   * // `gwashington` and `tjefferson`.
+   * //-
+   * var filter = [
+   *   {
+   *     row: /[a-z]+on$/
+   *   }
+   * ];
+   *
+   * //-
+   * // You can also provide a string (optionally containing regexp characters)
+   * // for simple key filters.
+   * //-
+   * var filter = [
+   *   {
+   *     row: 'gwashington'
+   *   }
+   * ];
+   *
+   * //-
+   * // Or you can provide an array of strings if you wish to match against
+   * // multiple keys.
+   * //-
+   * var filter = [
+   *   {
+   *     row: [
+   *       'gwashington',
+   *       'tjefferson'
+   *     ]
+   *   }
+   * ];
+   *
+   * //-
+   * // If you wish to use additional row filters, consider using the following
+   * // syntax.
+   * //-
+   * var filter = [
+   *   {
+   *     row: {
+   *       key: 'gwashington'
+   *     }
+   *   }
+   * ];
+   *
+   * //-
+   * // <h4>Row Samples</h4>
+   * //
+   * // Matches all cells from a row with probability p, and matches no cells
+   * // from the row with probability 1-p.
+   * //-
+   * var filter = [
+   *   {
+   *     row: {
+   *       sample: 1
+   *     }
+   *   }
+   * ];
+   *
+   * //-
+   * // <h4>Row Cell Offsets</h4>
+   * //
+   * // Skips the first N cells of each row, matching all subsequent cells.
+   * // If duplicate cells are present, as is possible when using an
+   * // {@link Filter#interleave}, each copy of the cell is counted
+   * // separately.
+   * //-
+   * var filter = [
+   *   {
+   *     row: {
+   *       cellOffset: 2
+   *     }
+   *   }
+   * ];
+   *
+   * //-
+   * // <h4>Row Cell Limits</h4>
+   * //
+   * // Matches only the first N cells of each row.
+   * // If duplicate cells are present, as is possible when using an
+   * // {@link Filter#interleave}, each copy of the cell is counted
+   * // separately.
+   * //-
+   * var filter = [
+   *   {
+   *     row: {
+   *       cellLimit: 4
+   *     }
+   *   }
+   * ];
+   */
+  row(row) {
+    if (!is.object(row)) {
+      row = {
+        key: row,
+      };
+    }
+
+    if (row.key) {
+      let key = Filter.convertToRegExpString(row.key);
+
+      key = Mutation.convertToBytes(key);
+      this.set('rowKeyRegexFilter', key);
+    }
+
+    if (row.sample) {
+      this.set('rowSampleFilter', row.sample);
+    }
+
+    if (is.number(row.cellOffset)) {
+      this.set('cellsPerRowOffsetFilter', row.cellOffset);
+    }
+
+    if (is.number(row.cellLimit)) {
+      this.set('cellsPerRowLimitFilter', row.cellLimit);
+    }
+  }
+
+  /**
+   * Stores a filter object.
+   *
+   * @param {string} key Filter name.
+   * @param {*} value Filter value.
+   */
+  set(key, value) {
+    const filter = {};
+
+    filter[key] = value;
+    this.filters_.push(filter);
+  }
+
+  /**
+   * This filter is meant for advanced use only. Hook for introspection into the
+   * filter. Outputs all cells directly to the output of the read rather than to
+   * any parent filter.
+   * Despite being excluded by the qualifier filter, a copy of every cell that
+   * reaches the sink is present in the final result.
+   * As with an {@link Filter#interleave} filter, duplicate cells are
+   * possible, and appear in an unspecified mutual order.
+   *
+   * Cannot be used within {@link Filter#condition} filter.
+   *
+   * @param {boolean} sink
+   *
+   * @example
+   * //-
+   * // Using the following filter, a copy of every cell that reaches the sink is
+   * // present in the final result, despite being excluded by the qualifier
+   * // filter
+   * //-
+   * var filter = [
+   *   {
+   *     family: 'follows'
+   *   },
+   *   {
+   *     interleave: [
+   *       [
+   *         {
+   *           all: true
+   *         }
+   *       ],
+   *       [
+   *         {
+   *           label: 'prezzy'
+   *         },
+   *         {
+   *           sink: true
+   *         }
+   *       ]
+   *     ]
+   *   },
+   *   {
+   *     column: 'gwashington'
+   *   }
+   * ];
+   *
+   * //-
+   * // As with an {@link Filter#interleave} filter, duplicate cells
+   * // are possible, and appear in an unspecified mutual order. In this case we
+   * // have a duplicates with multiple `gwashington` columns because one copy
+   * // passed through the {@link Filter#all} filter while the other was
+   * // passed through the {@link Filter#label} and sink. Note that one
+   * // copy has label "prezzy" while the other does not.
+   * //-
+   */
+  sink(sink) {
+    this.set('sink', sink);
+  }
+
+  /**
+   * Matches only cells with timestamps within the given range.
+   *
+   * @param {object} time Start and End time Object
+   *
+   * @example
+   * var filter = [
+   *   {
+   *     time: {
+   *       start: new Date('December 17, 2006 03:24:00'),
+   *       end: new Date()
+   *     }
+   *   }
+   * ];
+   */
+  time({start, end}) {
+    const range = Mutation.createTimeRange(start, end);
+    this.set('timestampRangeFilter', range);
+  }
+
+  /**
+   * If we detect multiple filters, we'll assume it's a chain filter and the
+   * execution of the filters will be the order in which they were specified.
+   */
+  toProto() {
+    if (!this.filters_.length) {
+      return null;
+    }
+
+    if (this.filters_.length === 1) {
+      return this.filters_[0];
+    }
+
+    return {
+      chain: {
+        filters: this.filters_,
+      },
+    };
+  }
+
+  /**
+   * Matches only cells with values that satisfy the given regular expression.
+   * Note that, since cell values can contain arbitrary bytes, the '\C' escape
+   * sequence must be used if a true wildcard is desired. The '.' character
+   * will not match the new line character '\n', which may be present in a
+   * binary value.
+   *
+   * @param {?string|string[]|object} value Value to filter cells
+   *
+   * @example
+   * var filter = [
+   *   {
+   *     value: /[0-9]/
+   *   }
+   * ];
+   *
+   * //-
+   * // You can also provide a string (optionally containing regexp characters)
+   * // for value filters.
+   * //-
+   * var filter = [
+   *   {
+   *     value: '1'
+   *   }
+   * ];
+   *
+   * //-
+   * // You can also provide an array of strings if you wish to match against
+   * // multiple values.
+   * //-
+   * var filter = [
+   *   {
+   *     value: ['1', '9']
+   *   }
+   * ];
+   *
+   * //-
+   * // Or you can provide a Buffer or an array of Buffers if you wish to match
+   * // against specfic binary value(s).
+   * //-
+   * var userInputedFaces = [Buffer.from('.|.'), Buffer.from(':-)')];
+   * var filter = [
+   *   {
+   *     value: userInputedFaces
+   *   }
+   * ];
+   *
+   * //-
+   * // <h4>Value Ranges</h4>
+   * //
+   * // Specifies a contigous range of values.
+   * //
+   * // When the `start` bound is omitted it is interpreted as an empty string.
+   * // When the `end` bound is omitted it is interpreted as Infinity.
+   * //-
+   * var filter = [
+   *   {
+   *     value: {
+   *       start: '1',
+   *       end: '9'
+   *     }
+   *   }
+   * ];
+   *
+   * //-
+   * // By default, both the `start` and `end` bounds are inclusive. You can
+   * // override these by providing an object explicity stating whether or not it
+   * // is `inclusive`.
+   * //-
+   * var filter = [
+   *   {
+   *     value: {
+   *       start: {
+   *         value: '1',
+   *         inclusive: false
+   *       },
+   *       end: {
+   *         value: '9',
+   *         inclusive: false
+   *       }
+   *     }
+   *   }
+   * ];
+   *
+   * //-
+   * // <h4>Strip Values</h4>
+   * //
+   * // Replaces each cell's value with an emtpy string.
+   * //-
+   * var filter = [
+   *   {
+   *     value: {
+   *       strip: true
+   *     }
+   *   }
+   * ];
+   */
+  value(value) {
+    if (!is.object(value)) {
+      value = {
+        value,
+      };
+    }
+
+    if (value.value) {
+      let valueReg = Filter.convertToRegExpString(value.value);
+
+      valueReg = Mutation.convertToBytes(valueReg);
+      this.set('valueRegexFilter', valueReg);
+    }
+
+    if (value.start || value.end) {
+      const range = Filter.createRange(value.start, value.end, 'Value');
+
+      this.set('valueRangeFilter', range);
+    }
+
+    if (value.strip) {
+      this.set('stripValueTransformer', value.strip);
+    }
+  }
 }
 
 /**
@@ -95,13 +785,13 @@ function Filter() {
  * var regexString = Filter.convertToRegExpString(['a', 'b', 'c']);
  * // => '(a|b|c)'
  */
-Filter.convertToRegExpString = function(regex) {
+Filter.convertToRegExpString = regex => {
   if (is.regexp(regex)) {
     return regex.toString().replace(/^\/|\/$/g, '');
   }
 
   if (is.array(regex)) {
-    return '(' + regex.map(Filter.convertToRegExpString).join('|') + ')';
+    return `(${regex.map(Filter.convertToRegExpString).join('|')})`;
   }
 
   if (is.string(regex)) {
@@ -152,8 +842,8 @@ Filter.convertToRegExpString = function(regex) {
  * //   startTest2Exclusive: 'value3'
  * // }
  */
-Filter.createRange = function(start, end, key) {
-  var range = {};
+Filter.createRange = (start, end, key) => {
+  const range = {};
 
   if (start) {
     extend(range, createBound('start', start, key));
@@ -166,9 +856,9 @@ Filter.createRange = function(start, end, key) {
   return range;
 
   function createBound(boundName, boundData, key) {
-    var isInclusive = boundData.inclusive !== false;
-    var boundKey = boundName + key + (isInclusive ? 'Closed' : 'Open');
-    var bound = {};
+    const isInclusive = boundData.inclusive !== false;
+    const boundKey = boundName + key + (isInclusive ? 'Closed' : 'Open');
+    const bound = {};
 
     bound[boundKey] = Mutation.convertToBytes(boundData.value || boundData);
     return bound;
@@ -205,11 +895,11 @@ Filter.createRange = function(start, end, key) {
  * //   }
  * // }
  */
-Filter.parse = function(filters) {
-  var filter = new Filter();
+Filter.parse = filters => {
+  const filter = new Filter();
 
-  arrify(filters).forEach(function(filterObj) {
-    var key = Object.keys(filterObj)[0];
+  arrify(filters).forEach(filterObj => {
+    const key = Object.keys(filterObj)[0];
 
     if (!is.function(filter[key])) {
       throw new FilterError(key);
@@ -219,696 +909,6 @@ Filter.parse = function(filters) {
   });
 
   return filter.toProto();
-};
-
-/**
- * Sets passAllFilter or blockAllFilter
- *
- * @param {boolean} pass Whether to passAllFilter or blockAllFilter
- *
- * Assign true for enabling passAllFilter and false for enabling blockAllFilter
- *
- * @example
- * //-
- * // Matches all cells, regardless of input. Functionally equivalent to
- * // leaving `filter` unset, but included for completeness.
- * //-
- * var filter = {
- *   all: true
- * };
- *
- * //-
- * // Does not match any cells, regardless of input. Useful for temporarily
- * // disabling just part of a filter.
- * //-
- * var filter = {
- *   all: false
- * };
- */
-Filter.prototype.all = function(pass) {
-  var filterName = pass ? 'passAllFilter' : 'blockAllFilter';
-
-  this.set(filterName, true);
-};
-
-/**
- * Matches only cells from columns whose qualifiers satisfy the given RE2
- * regex.
- * @param {?regex|string|object} column Matching Column to filter with
- *
- * Note that, since column qualifiers can contain arbitrary bytes, the '\C'
- * escape sequence must be used if a true wildcard is desired. The '.'
- * character will not match the new line character '\n', which may be
- * present in a binary qualifier.
- *
- * @example
- * //-
- * // Using the following filter, we would retrieve the `tjefferson` and
- * // `gwashington` columns.
- * //-
- * var filter = [
- *   {
- *     column: /[a-z]+on$/
- *   }
- * ];
- *
- * //-
- * // You can also provide a string (optionally containing regexp characters)
- * // for simple column filters.
- * //-
- * var filter = [
- *   {
- *     column: 'gwashington'
- *   }
- * ];
- *
- * //-
- * // Or you can provide an array of strings if you wish to match against
- * // multiple columns.
- * //-
- * var filter = [
- *   {
- *     column: [
- *       'gwashington',
- *       'tjefferson'
- *     ]
- *   }
- * ];
- *
- * //-
- * // If you wish to use additional column filters, consider using the following
- * // syntax.
- * //-
- * var filter = [
- *   {
- *     column: {
- *       name: 'gwashington'
- *     }
- *   }
- * ];
- *
- *
- * //-
- * // <h4>Column Cell Limits</h4>
- * //
- * // Matches only the most recent number of versions within each column. For
- * // example, if the `versions` is set to 2, this filter would only match
- * // columns updated at the two most recent timestamps.
- * //
- * // If duplicate cells are present, as is possible when using an
- * // {@link Filter#interleave} filter, each copy of the cell is
- * // counted separately.
- * //-
- * var filter = [
- *   {
- *     column: {
- *       cellLimit: 2
- *     }
- *   }
- * ];
- *
- * //-
- * // <h4>Column Ranges</h4>
- * //
- * // Specifies a contiguous range of columns within a single column family.
- * // The range spans from <column_family>:<start_qualifier> to
- * // <column_family>:<end_qualifier>, where both bounds can be either
- * // inclusive or exclusive. By default both are inclusive.
- * //
- * // When the `start` bound is omitted it is interpreted as an empty string.
- * // When the `end` bound is omitted it is interpreted as Infinity.
- * //-
- * var filter = [
- *   {
- *     column: {
- *       family: 'follows',
- *       start: 'gwashington',
- *       end: 'tjefferson'
- *     }
- *   }
- * ];
- *
- * //-
- * // By default, both the `start` and `end` bounds are inclusive. You can
- * // override these by providing an object explicity stating whether or not it
- * // is `inclusive`.
- * //-
- * var filter = [
- *   {
- *     column: {
- *       family: 'follows',
- *       start: {
- *         value: 'gwashington',
- *         inclusive: false
- *       },
- *       end: {
- *         value: 'jadams',
- *         inclusive: false
- *       }
- *     }
- *   }
- * ];
- */
-Filter.prototype.column = function(column) {
-  if (!is.object(column)) {
-    column = {
-      name: column,
-    };
-  }
-
-  if (column.name) {
-    var name = Filter.convertToRegExpString(column.name);
-
-    name = Mutation.convertToBytes(name);
-    this.set('columnQualifierRegexFilter', name);
-  }
-
-  if (is.number(column.cellLimit)) {
-    this.set('cellsPerColumnLimitFilter', column.cellLimit);
-  }
-
-  if (column.start || column.end) {
-    var range = Filter.createRange(column.start, column.end, 'Qualifier');
-
-    range.familyName = column.family;
-    this.set('columnRangeFilter', range);
-  }
-};
-
-/**
- * A filter which evaluates one of two possible filters, depending on
- * whether or not a `test` filter outputs any cells from the input row.
- *
- * IMPORTANT NOTE: The `test` filter does not execute atomically with the
- * pass and fail filters, which may lead to inconsistent or unexpected
- * results. Additionally, condition filters have poor performance, especially
- * when filters are set for the fail condition.
- *
- * @param {object} condition Condition to filter.
- *
- * @example
- * //-
- * // In the following example we're creating a filter that will check if
- * // `gwashington` follows `tjefferson`. If he does, we'll get all of the
- * // `gwashington` data. If he does not, we'll instead return all of the
- * // `tjefferson` data.
- * //-
- * var filter = [
- *   {
- *     condition: {
- *       // If `test` outputs any cells, then `pass` will be evaluated on the
- *       // input row. Otherwise `fail` will be evaluated.
- *       test: [
- *         {
- *           row: 'gwashington'
- *         },
- *         {
- *           family: 'follows'
- *         },
- *         {
- *           column: 'tjefferson'
- *         }
- *       ],
- *
- *       // If omitted, no results will be returned in the true case.
- *       pass: [
- *         {
- *           row: 'gwashington'
- *         }
- *       ],
- *
- *       // If omitted, no results will be returned in the false case.
- *       fail: [
- *         {
- *           row: 'tjefferson'
- *         }
- *       ]
- *     }
- *   }
- * ];
- */
-Filter.prototype.condition = function(condition) {
-  this.set('condition', {
-    predicateFilter: Filter.parse(condition.test),
-    trueFilter: Filter.parse(condition.pass),
-    falseFilter: Filter.parse(condition.fail),
-  });
-};
-
-/**
- * Matches only cells from columns whose families satisfy the given RE2
- * regex. For technical reasons, the regex must not contain the ':'
- * character, even if it is not being used as a literal.
- * Note that, since column families cannot contain the new line character
- * '\n', it is sufficient to use '.' as a full wildcard when matching
- * column family names.
- *
- * @param {regex} family Expression to filter family
- *
- * @example
- * var filter = [
- *   {
- *     family: 'follows'
- *   }
- * ];
- */
-Filter.prototype.family = function(family) {
-  family = Filter.convertToRegExpString(family);
-  this.set('familyNameRegexFilter', family);
-};
-
-/**
- * Applies several filters to the data in parallel and combines the results.
- *
- * @param {object} filters The elements of "filters" all process a copy of the input row, and the
- * results are pooled, sorted, and combined into a single output row.
- * If multiple cells are produced with the same column and timestamp,
- * they will all appear in the output row in an unspecified mutual order.
- * All interleaved filters are executed atomically.
- *
- * @example
- * //-
- * // In the following example, we're creating a filter that will retrieve
- * // results for entries that were either created between December 17th, 2015
- * // and March 22nd, 2016 or entries that have data for `follows:tjefferson`.
- * //-
- * var filter = [
- *   {
- *     interleave: [
- *       [
- *         {
- *           time: {
- *             start: new Date('December 17, 2015'),
- *             end: new Date('March 22, 2016')
- *           }
- *         }
- *       ],
- *       [
- *         {
- *           family: 'follows'
- *         },
- *         {
- *           column: 'tjefferson'
- *         }
- *       ]
- *     ]
- *   }
- * ];
- */
-Filter.prototype.interleave = function(filters) {
-  this.set('interleave', {
-    filters: filters.map(Filter.parse),
-  });
-};
-
-/**
- * Applies the given label to all cells in the output row. This allows
- * the client to determine which results were produced from which part of
- * the filter.
- *
- * @param {string} label Label to determine filter point
- * Values must be at most 15 characters in length, and match the RE2
- * pattern [a-z0-9\\-]+
- *
- * Due to a technical limitation, it is not currently possible to apply
- * multiple labels to a cell. As a result, a chain filter may have no more than
- * one sub-filter which contains a apply label transformer. It is okay for
- * an {@link Filter#interleave} to contain multiple apply label
- * transformers, as they will be applied to separate copies of the input. This
- * may be relaxed in the future.
- *
- * @example
- * var filter = {
- *   label: 'my-label'
- * };
- */
-Filter.prototype.label = function(label) {
-  this.set('applyLabelTransformer', label);
-};
-
-/**
- * Matches only cells from rows whose keys satisfy the given RE2 regex. In
- * other words, passes through the entire row when the key matches, and
- * otherwise produces an empty row.
- *
- * @param {?regex|string|string[]} row Row format to Filter
- *
- * Note that, since row keys can contain arbitrary bytes, the '\C' escape
- * sequence must be used if a true wildcard is desired. The '.' character
- * will not match the new line character '\n', which may be present in a
- * binary key.
- *
- * @example
- * //-
- * // In the following example we'll use a regular expression to match all
- * // row keys ending with the letters "on", which would then yield
- * // `gwashington` and `tjefferson`.
- * //-
- * var filter = [
- *   {
- *     row: /[a-z]+on$/
- *   }
- * ];
- *
- * //-
- * // You can also provide a string (optionally containing regexp characters)
- * // for simple key filters.
- * //-
- * var filter = [
- *   {
- *     row: 'gwashington'
- *   }
- * ];
- *
- * //-
- * // Or you can provide an array of strings if you wish to match against
- * // multiple keys.
- * //-
- * var filter = [
- *   {
- *     row: [
- *       'gwashington',
- *       'tjefferson'
- *     ]
- *   }
- * ];
- *
- * //-
- * // If you wish to use additional row filters, consider using the following
- * // syntax.
- * //-
- * var filter = [
- *   {
- *     row: {
- *       key: 'gwashington'
- *     }
- *   }
- * ];
- *
- * //-
- * // <h4>Row Samples</h4>
- * //
- * // Matches all cells from a row with probability p, and matches no cells
- * // from the row with probability 1-p.
- * //-
- * var filter = [
- *   {
- *     row: {
- *       sample: 1
- *     }
- *   }
- * ];
- *
- * //-
- * // <h4>Row Cell Offsets</h4>
- * //
- * // Skips the first N cells of each row, matching all subsequent cells.
- * // If duplicate cells are present, as is possible when using an
- * // {@link Filter#interleave}, each copy of the cell is counted
- * // separately.
- * //-
- * var filter = [
- *   {
- *     row: {
- *       cellOffset: 2
- *     }
- *   }
- * ];
- *
- * //-
- * // <h4>Row Cell Limits</h4>
- * //
- * // Matches only the first N cells of each row.
- * // If duplicate cells are present, as is possible when using an
- * // {@link Filter#interleave}, each copy of the cell is counted
- * // separately.
- * //-
- * var filter = [
- *   {
- *     row: {
- *       cellLimit: 4
- *     }
- *   }
- * ];
- */
-Filter.prototype.row = function(row) {
-  if (!is.object(row)) {
-    row = {
-      key: row,
-    };
-  }
-
-  if (row.key) {
-    var key = Filter.convertToRegExpString(row.key);
-
-    key = Mutation.convertToBytes(key);
-    this.set('rowKeyRegexFilter', key);
-  }
-
-  if (row.sample) {
-    this.set('rowSampleFilter', row.sample);
-  }
-
-  if (is.number(row.cellOffset)) {
-    this.set('cellsPerRowOffsetFilter', row.cellOffset);
-  }
-
-  if (is.number(row.cellLimit)) {
-    this.set('cellsPerRowLimitFilter', row.cellLimit);
-  }
-};
-
-/**
- * Stores a filter object.
- *
- * @param {string} key Filter name.
- * @param {*} value Filter value.
- */
-Filter.prototype.set = function(key, value) {
-  var filter = {};
-
-  filter[key] = value;
-  this.filters_.push(filter);
-};
-
-/**
- * This filter is meant for advanced use only. Hook for introspection into the
- * filter. Outputs all cells directly to the output of the read rather than to
- * any parent filter.
- * Despite being excluded by the qualifier filter, a copy of every cell that
- * reaches the sink is present in the final result.
- * As with an {@link Filter#interleave} filter, duplicate cells are
- * possible, and appear in an unspecified mutual order.
- *
- * Cannot be used within {@link Filter#condition} filter.
- *
- * @param {boolean} sink
- *
- * @example
- * //-
- * // Using the following filter, a copy of every cell that reaches the sink is
- * // present in the final result, despite being excluded by the qualifier
- * // filter
- * //-
- * var filter = [
- *   {
- *     family: 'follows'
- *   },
- *   {
- *     interleave: [
- *       [
- *         {
- *           all: true
- *         }
- *       ],
- *       [
- *         {
- *           label: 'prezzy'
- *         },
- *         {
- *           sink: true
- *         }
- *       ]
- *     ]
- *   },
- *   {
- *     column: 'gwashington'
- *   }
- * ];
- *
- * //-
- * // As with an {@link Filter#interleave} filter, duplicate cells
- * // are possible, and appear in an unspecified mutual order. In this case we
- * // have a duplicates with multiple `gwashington` columns because one copy
- * // passed through the {@link Filter#all} filter while the other was
- * // passed through the {@link Filter#label} and sink. Note that one
- * // copy has label "prezzy" while the other does not.
- * //-
- */
-Filter.prototype.sink = function(sink) {
-  this.set('sink', sink);
-};
-
-/**
- * Matches only cells with timestamps within the given range.
- *
- * @param {object} time Start and End time Object
- *
- * @example
- * var filter = [
- *   {
- *     time: {
- *       start: new Date('December 17, 2006 03:24:00'),
- *       end: new Date()
- *     }
- *   }
- * ];
- */
-Filter.prototype.time = function(time) {
-  var range = Mutation.createTimeRange(time.start, time.end);
-  this.set('timestampRangeFilter', range);
-};
-
-/**
- * If we detect multiple filters, we'll assume it's a chain filter and the
- * execution of the filters will be the order in which they were specified.
- */
-Filter.prototype.toProto = function() {
-  if (!this.filters_.length) {
-    return null;
-  }
-
-  if (this.filters_.length === 1) {
-    return this.filters_[0];
-  }
-
-  return {
-    chain: {
-      filters: this.filters_,
-    },
-  };
-};
-
-/**
- * Matches only cells with values that satisfy the given regular expression.
- * Note that, since cell values can contain arbitrary bytes, the '\C' escape
- * sequence must be used if a true wildcard is desired. The '.' character
- * will not match the new line character '\n', which may be present in a
- * binary value.
- *
- * @param {?string|string[]|object} value Value to filter cells
- *
- * @example
- * var filter = [
- *   {
- *     value: /[0-9]/
- *   }
- * ];
- *
- * //-
- * // You can also provide a string (optionally containing regexp characters)
- * // for value filters.
- * //-
- * var filter = [
- *   {
- *     value: '1'
- *   }
- * ];
- *
- * //-
- * // You can also provide an array of strings if you wish to match against
- * // multiple values.
- * //-
- * var filter = [
- *   {
- *     value: ['1', '9']
- *   }
- * ];
- *
- * //-
- * // Or you can provide a Buffer or an array of Buffers if you wish to match
- * // against specfic binary value(s).
- * //-
- * var userInputedFaces = [Buffer.from('.|.'), Buffer.from(':-)')];
- * var filter = [
- *   {
- *     value: userInputedFaces
- *   }
- * ];
- *
- * //-
- * // <h4>Value Ranges</h4>
- * //
- * // Specifies a contigous range of values.
- * //
- * // When the `start` bound is omitted it is interpreted as an empty string.
- * // When the `end` bound is omitted it is interpreted as Infinity.
- * //-
- * var filter = [
- *   {
- *     value: {
- *       start: '1',
- *       end: '9'
- *     }
- *   }
- * ];
- *
- * //-
- * // By default, both the `start` and `end` bounds are inclusive. You can
- * // override these by providing an object explicity stating whether or not it
- * // is `inclusive`.
- * //-
- * var filter = [
- *   {
- *     value: {
- *       start: {
- *         value: '1',
- *         inclusive: false
- *       },
- *       end: {
- *         value: '9',
- *         inclusive: false
- *       }
- *     }
- *   }
- * ];
- *
- * //-
- * // <h4>Strip Values</h4>
- * //
- * // Replaces each cell's value with an emtpy string.
- * //-
- * var filter = [
- *   {
- *     value: {
- *       strip: true
- *     }
- *   }
- * ];
- */
-Filter.prototype.value = function(value) {
-  if (!is.object(value)) {
-    value = {
-      value: value,
-    };
-  }
-
-  if (value.value) {
-    var valueReg = Filter.convertToRegExpString(value.value);
-
-    valueReg = Mutation.convertToBytes(valueReg);
-    this.set('valueRegexFilter', valueReg);
-  }
-
-  if (value.start || value.end) {
-    var range = Filter.createRange(value.start, value.end, 'Value');
-
-    this.set('valueRangeFilter', range);
-  }
-
-  if (value.strip) {
-    this.set('stripValueTransformer', value.strip);
-  }
 };
 
 module.exports = Filter;

--- a/src/index.js
+++ b/src/index.js
@@ -14,22 +14,20 @@
  * limitations under the License.
  */
 
-'use strict';
+const arrify = require('arrify');
+const common = require('@google-cloud/common');
+const extend = require('extend');
+const GrpcService = require('@google-cloud/common-grpc').Service;
+const googleAuth = require('google-auto-auth');
+const grpc = require('google-gax').grpc().grpc;
+const is = require('is');
+const retryRequest = require('retry-request');
+const streamEvents = require('stream-events');
+const through = require('through2');
 
-var arrify = require('arrify');
-var common = require('@google-cloud/common');
-var extend = require('extend');
-var GrpcService = require('@google-cloud/common-grpc').Service;
-var googleAuth = require('google-auto-auth');
-var grpc = require('google-gax').grpc().grpc;
-var is = require('is');
-var retryRequest = require('retry-request');
-var streamEvents = require('stream-events');
-var through = require('through2');
-
-var AppProfile = require('./app-profile');
-var Cluster = require('./cluster.js');
-var Instance = require('./instance.js');
+const AppProfile = require('./app-profile');
+const Cluster = require('./cluster.js');
+const Instance = require('./instance.js');
 
 const PKG = require('../package.json');
 const v2 = require('./v2');
@@ -336,438 +334,437 @@ const v2 = require('./v2');
  *   }
  * });
  */
-function Bigtable(options) {
-  if (!(this instanceof Bigtable)) {
-    return new Bigtable(options);
-  }
+class Bigtable {
+  constructor(options) {
+    if (!(this instanceof Bigtable)) {
+      return new Bigtable(options);
+    }
 
-  options = common.util.normalizeArguments(this, options);
+    options = common.util.normalizeArguments(this, options);
 
-  // Determine what scopes are needed.
-  // It is the union of the scopes on all three clients.
-  let scopes = [];
-  let clientClasses = [
-    v2.BigtableClient,
-    v2.BigtableInstanceAdminClient,
-    v2.BigtableTableAdminClient,
-  ];
-  for (let clientClass of clientClasses) {
-    for (let scope of clientClass.scopes) {
-      if (scopes.indexOf(scope) === -1) {
-        scopes.push(scope);
+    // Determine what scopes are needed.
+    // It is the union of the scopes on all three clients.
+    let scopes = [];
+    let clientClasses = [
+      v2.BigtableClient,
+      v2.BigtableInstanceAdminClient,
+      v2.BigtableTableAdminClient,
+    ];
+    for (let clientClass of clientClasses) {
+      for (let scope of clientClass.scopes) {
+        if (!scopes.includes(scope)) {
+          scopes.push(scope);
+        }
       }
     }
-  }
 
-  options = extend(
-    {
-      libName: 'gccl',
-      libVersion: PKG.version,
-      scopes: scopes,
-      'grpc.max_send_message_length': -1,
-      'grpc.max_receive_message_length': -1,
-    },
-    options
-  );
-
-  var defaultBaseUrl = 'bigtable.googleapis.com';
-  var defaultAdminBaseUrl = 'bigtableadmin.googleapis.com';
-
-  var customEndpoint =
-    options.apiEndpoint || process.env.BIGTABLE_EMULATOR_HOST;
-  this.customEndpoint = customEndpoint;
-
-  var customEndpointBaseUrl;
-  var customEndpointPort;
-
-  if (customEndpoint) {
-    var customEndpointParts = customEndpoint.split(':');
-    customEndpointBaseUrl = customEndpointParts[0];
-    customEndpointPort = customEndpointParts[1];
-  }
-
-  this.options = {
-    BigtableClient: extend(
+    options = extend(
       {
-        servicePath: customEndpoint ? customEndpointBaseUrl : defaultBaseUrl,
-        port: customEndpoint ? parseInt(customEndpointPort, 10) : 443,
-        sslCreds: customEndpoint
-          ? grpc.credentials.createInsecure()
-          : undefined,
+        libName: 'gccl',
+        libVersion: PKG.version,
+        scopes,
+        'grpc.max_send_message_length': -1,
+        'grpc.max_receive_message_length': -1,
       },
       options
-    ),
-    BigtableInstanceAdminClient: extend(
-      {
-        servicePath: customEndpoint
-          ? customEndpointBaseUrl
-          : defaultAdminBaseUrl,
-        port: customEndpoint ? parseInt(customEndpointPort, 10) : 443,
-        sslCreds: customEndpoint
-          ? grpc.credentials.createInsecure()
-          : undefined,
-      },
-      options
-    ),
-    BigtableTableAdminClient: extend(
-      {
-        servicePath: customEndpoint
-          ? customEndpointBaseUrl
-          : defaultAdminBaseUrl,
-        port: customEndpoint ? parseInt(customEndpointPort, 10) : 443,
-        sslCreds: customEndpoint
-          ? grpc.credentials.createInsecure()
-          : undefined,
-      },
-      options
-    ),
-  };
+    );
 
-  this.api = {};
-  this.auth = googleAuth(options);
-  this.projectId = options.projectId || '{{projectId}}';
-  this.appProfileId = options.appProfileId;
-  this.projectName = 'projects/' + this.projectId;
-}
+    const defaultBaseUrl = 'bigtable.googleapis.com';
+    const defaultAdminBaseUrl = 'bigtableadmin.googleapis.com';
 
-/**
- * Create a Compute instance.
- *
- * @see [Creating a Compute Instance]{@link https://cloud.google.com/bigtable/docs/creating-compute-instance}
- *
- * @param {string} name The unique name of the instance.
- * @param {object} [options] Instance creation options.
- * @param {object[]} [options.clusters] The clusters to be created within the
- *     instance.
- * @param {string} [options.displayName] The descriptive name for this instance
- *     as it appears in UIs.
- * @param {Object.<string, string>} [options.labels] Labels are a flexible and
- *     lightweight mechanism for organizing cloud resources into groups that
- *     reflect a customer's organizational needs and deployment strategies.
- *     They can be used to filter resources and aggregate metrics.
- *
- *   * Label keys must be between 1 and 63 characters long and must conform to
- *     the regular expression: `[\p{Ll}\p{Lo}][\p{Ll}\p{Lo}\p{N}_-]{0,62}`.
- *   * Label values must be between 0 and 63 characters long and must conform to
- *     the regular expression: `[\p{Ll}\p{Lo}\p{N}_-]{0,63}`.
- *   * No more than 64 labels can be associated with a given resource.
- *   * Keys and values must both be under 128 bytes.
- * @param {string} [options.type] The type of the instance. Options are
- *     'production' or 'development'.
- * @param {object} [options.gaxOptions] Request configuration options, outlined
- *     here: https://googleapis.github.io/gax-nodejs/CallSettings.html.
- * @param {function} callback The callback function.
- * @param {?error} callback.err An error returned while making this request.
- * @param {Instance} callback.instance The newly created
- *     instance.
- * @param {Operation} callback.operation An operation object that can be used
- *     to check the status of the request.
- * @param {object} callback.apiResponse The full API response.
- *
- * @example
- * const Bigtable = require('@google-cloud/bigtable');
- * const bigtable = new Bigtable();
- *
- * const callback = function(err, instance, operation, apiResponse) {
- *   if (err) {
- *     // Error handling omitted.
- *   }
- *
- *   operation
- *     .on('error', console.log)
- *     .on('complete', function() {
- *       // The instance was created successfully.
- *     });
- * };
- *
- * const options = {
- *   displayName: 'my-sweet-instance',
- *   labels: {env: 'prod'},
- *   clusters: [
- *     {
- *       name: 'my-sweet-cluster',
- *       nodes: 3,
- *       location: 'us-central1-b',
- *       storage: 'ssd'
- *     }
- *   ]
- * };
- *
- * bigtable.createInstance('my-instance', options, callback);
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * bigtable.createInstance('my-instance', options).then(function(data) {
- *   const instance = data[0];
- *   const operation = data[1];
- *   const apiResponse = data[2];
- * });
- */
-Bigtable.prototype.createInstance = function(name, options, callback) {
-  var self = this;
+    const customEndpoint =
+      options.apiEndpoint || process.env.BIGTABLE_EMULATOR_HOST;
+    this.customEndpoint = customEndpoint;
 
-  if (is.function(options)) {
-    callback = options;
-    options = {};
-  }
+    let customEndpointBaseUrl;
+    let customEndpointPort;
 
-  var reqOpts = {
-    parent: this.projectName,
-    instanceId: name,
-    instance: {
-      displayName: options.displayName || name,
-      labels: options.labels,
-    },
-  };
-
-  if (options.type) {
-    reqOpts.instance.type = Instance.getTypeType_(options.type);
-  }
-
-  reqOpts.clusters = arrify(options.clusters).reduce(function(
-    clusters,
-    cluster
-  ) {
-    clusters[cluster.name] = {
-      location: Cluster.getLocation_(self.projectId, cluster.location),
-      serveNodes: cluster.nodes,
-      defaultStorageType: Cluster.getStorageType_(cluster.storage),
-    };
-
-    return clusters;
-  },
-  {});
-
-  this.request(
-    {
-      client: 'BigtableInstanceAdminClient',
-      method: 'createInstance',
-      reqOpts: reqOpts,
-      gaxOpts: options.gaxOptions,
-    },
-    function(err) {
-      var args = [].slice.call(arguments);
-
-      if (!err) {
-        args.splice(1, 0, self.instance(name));
-      }
-
-      callback.apply(null, args);
+    if (customEndpoint) {
+      const customEndpointParts = customEndpoint.split(':');
+      customEndpointBaseUrl = customEndpointParts[0];
+      customEndpointPort = customEndpointParts[1];
     }
-  );
-};
 
-/**
- * Get Instance objects for all of your Compute instances.
- *
- * @param {object} [gaxOptions] Request configuration options, outlined here:
- *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
- * @param {function} callback The callback function.
- * @param {?error} callback.error An error returned while making this request.
- * @param {Instance[]} callback.instances List of all
- *     instances.
- * @param {object} callback.apiResponse The full API response.
- *
- * @example
- * const Bigtable = require('@google-cloud/bigtable');
- * const bigtable = new Bigtable();
- *
- * bigtable.getInstances(function(err, instances) {
- *   if (!err) {
- *     // `instances` is an array of Instance objects.
- *   }
- * });
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * bigtable.getInstances().then(function(data) {
- *   const instances = data[0];
- * });
- */
-Bigtable.prototype.getInstances = function(gaxOptions, callback) {
-  var self = this;
-
-  if (is.function(gaxOptions)) {
-    callback = gaxOptions;
-    gaxOptions = {};
-  }
-
-  var reqOpts = {
-    parent: this.projectName,
-  };
-
-  this.request(
-    {
-      client: 'BigtableInstanceAdminClient',
-      method: 'listInstances',
-      reqOpts: reqOpts,
-      gaxOpts: gaxOptions,
-    },
-    function(err, resp) {
-      if (err) {
-        callback(err);
-        return;
-      }
-
-      var instances = resp.instances.map(function(instanceData) {
-        var instance = self.instance(instanceData.name);
-        instance.metadata = instanceData;
-        return instance;
-      });
-
-      callback(null, instances, resp);
-    }
-  );
-};
-
-/**
- * Get a reference to a Compute instance.
- *
- * @param {string} name The name of the instance.
- * @returns {Instance}
- */
-Bigtable.prototype.instance = function(name) {
-  return new Instance(this, name);
-};
-
-/**
- * Funnel all API requests through this method, to be sure we have a project ID.
- *
- * @param {object} config Configuration object.
- * @param {object} config.gaxOpts GAX options.
- * @param {function} config.method The gax method to call.
- * @param {object} config.reqOpts Request options.
- * @param {function} [callback] Callback function.
- */
-Bigtable.prototype.request = function(config, callback) {
-  var self = this;
-  var isStreamMode = !callback;
-
-  var gaxStream;
-  var stream;
-
-  if (isStreamMode) {
-    stream = streamEvents(through.obj());
-
-    stream.abort = function() {
-      if (gaxStream && gaxStream.cancel) {
-        gaxStream.cancel();
-      }
-    };
-
-    stream.once('reading', makeRequestStream);
-
-    return stream;
-  } else {
-    makeRequestCallback();
-  }
-
-  function prepareGaxRequest(callback) {
-    self.getProjectId_(function(err, projectId) {
-      if (err) {
-        callback(err);
-        return;
-      }
-
-      var gaxClient = self.api[config.client];
-
-      if (!gaxClient) {
-        // Lazily instantiate client.
-        gaxClient = new v2[config.client](self.options[config.client]);
-        self.api[config.client] = gaxClient;
-      }
-
-      var reqOpts = extend(true, {}, config.reqOpts);
-
-      if (projectId !== '{{projectId}}') {
-        reqOpts = common.util.replaceProjectIdToken(reqOpts, projectId);
-      }
-
-      var requestFn = gaxClient[config.method].bind(
-        gaxClient,
-        reqOpts,
-        config.gaxOpts
-      );
-
-      callback(null, requestFn);
-    });
-  }
-
-  function makeRequestCallback() {
-    prepareGaxRequest(function(err, requestFn) {
-      if (err) {
-        callback(err);
-        return;
-      }
-
-      requestFn(callback);
-    });
-  }
-
-  function makeRequestStream() {
-    prepareGaxRequest(function(err, requestFn) {
-      if (err) {
-        stream.destroy(err);
-        return;
-      }
-
-      // @TODO: remove `retry-request` when gax supports retryable streams.
-      // https://github.com/googleapis/gax-nodejs/blob/ec0c8b0805c31d8a91ea69cb19fe50f42a38bf87/lib/streaming.js#L230
-      var retryOpts = extend(
+    this.options = {
+      BigtableClient: extend(
         {
-          currentRetryAttempt: 0,
-          objectMode: true,
-          shouldRetryFn: GrpcService.shouldRetryRequest_,
-          request: function() {
-            gaxStream = requestFn();
-            return gaxStream;
-          },
+          servicePath: customEndpoint ? customEndpointBaseUrl : defaultBaseUrl,
+          port: customEndpoint ? parseInt(customEndpointPort, 10) : 443,
+          sslCreds: customEndpoint
+            ? grpc.credentials.createInsecure()
+            : undefined,
         },
-        config.retryOpts
-      );
+        options
+      ),
+      BigtableInstanceAdminClient: extend(
+        {
+          servicePath: customEndpoint
+            ? customEndpointBaseUrl
+            : defaultAdminBaseUrl,
+          port: customEndpoint ? parseInt(customEndpointPort, 10) : 443,
+          sslCreds: customEndpoint
+            ? grpc.credentials.createInsecure()
+            : undefined,
+        },
+        options
+      ),
+      BigtableTableAdminClient: extend(
+        {
+          servicePath: customEndpoint
+            ? customEndpointBaseUrl
+            : defaultAdminBaseUrl,
+          port: customEndpoint ? parseInt(customEndpointPort, 10) : 443,
+          sslCreds: customEndpoint
+            ? grpc.credentials.createInsecure()
+            : undefined,
+        },
+        options
+      ),
+    };
 
-      retryRequest(null, retryOpts)
-        .on('error', stream.destroy.bind(stream))
-        .on('request', stream.emit.bind(stream, 'request'))
-        .pipe(stream);
-    });
+    this.api = {};
+    this.auth = googleAuth(options);
+    this.projectId = options.projectId || '{{projectId}}';
+    this.appProfileId = options.appProfileId;
+    this.projectName = `projects/${this.projectId}`;
   }
-};
 
-/**
- * Determine and localize the project ID. If a user provides an ID, we bypass
- * checking with the auth client for an ID.
- *
- * @private
- *
- * @param {function} callback Callback function.
- * @param {?error} callback.err An error returned from the auth client.
- * @param {string} callback.projectId The detected project ID.
- */
-Bigtable.prototype.getProjectId_ = function(callback) {
-  var self = this;
+  /**
+   * Create a Compute instance.
+   *
+   * @see [Creating a Compute Instance]{@link https://cloud.google.com/bigtable/docs/creating-compute-instance}
+   *
+   * @param {string} name The unique name of the instance.
+   * @param {object} [options] Instance creation options.
+   * @param {object[]} [options.clusters] The clusters to be created within the
+   *     instance.
+   * @param {string} [options.displayName] The descriptive name for this instance
+   *     as it appears in UIs.
+   * @param {Object.<string, string>} [options.labels] Labels are a flexible and
+   *     lightweight mechanism for organizing cloud resources into groups that
+   *     reflect a customer's organizational needs and deployment strategies.
+   *     They can be used to filter resources and aggregate metrics.
+   *
+   *   * Label keys must be between 1 and 63 characters long and must conform to
+   *     the regular expression: `[\p{Ll}\p{Lo}][\p{Ll}\p{Lo}\p{N}_-]{0,62}`.
+   *   * Label values must be between 0 and 63 characters long and must conform to
+   *     the regular expression: `[\p{Ll}\p{Lo}\p{N}_-]{0,63}`.
+   *   * No more than 64 labels can be associated with a given resource.
+   *   * Keys and values must both be under 128 bytes.
+   * @param {string} [options.type] The type of the instance. Options are
+   *     'production' or 'development'.
+   * @param {object} [options.gaxOptions] Request configuration options, outlined
+   *     here: https://googleapis.github.io/gax-nodejs/CallSettings.html.
+   * @param {function} callback The callback function.
+   * @param {?error} callback.err An error returned while making this request.
+   * @param {Instance} callback.instance The newly created
+   *     instance.
+   * @param {Operation} callback.operation An operation object that can be used
+   *     to check the status of the request.
+   * @param {object} callback.apiResponse The full API response.
+   *
+   * @example
+   * const Bigtable = require('@google-cloud/bigtable');
+   * const bigtable = new Bigtable();
+   *
+   * const callback = function(err, instance, operation, apiResponse) {
+   *   if (err) {
+   *     // Error handling omitted.
+   *   }
+   *
+   *   operation
+   *     .on('error', console.log)
+   *     .on('complete', function() {
+   *       // The instance was created successfully.
+   *     });
+   * };
+   *
+   * const options = {
+   *   displayName: 'my-sweet-instance',
+   *   labels: {env: 'prod'},
+   *   clusters: [
+   *     {
+   *       name: 'my-sweet-cluster',
+   *       nodes: 3,
+   *       location: 'us-central1-b',
+   *       storage: 'ssd'
+   *     }
+   *   ]
+   * };
+   *
+   * bigtable.createInstance('my-instance', options, callback);
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * bigtable.createInstance('my-instance', options).then(function(data) {
+   *   const instance = data[0];
+   *   const operation = data[1];
+   *   const apiResponse = data[2];
+   * });
+   */
+  createInstance(name, options, callback) {
+    const self = this;
 
-  var projectIdRequired =
-    this.projectId === '{{projectId}}' && !this.customEndpoint;
+    if (is.function(options)) {
+      callback = options;
+      options = {};
+    }
 
-  if (!projectIdRequired) {
-    setImmediate(callback, null, this.projectId);
-    return;
+    const reqOpts = {
+      parent: this.projectName,
+      instanceId: name,
+      instance: {
+        displayName: options.displayName || name,
+        labels: options.labels,
+      },
+    };
+
+    if (options.type) {
+      reqOpts.instance.type = Instance.getTypeType_(options.type);
+    }
+
+    reqOpts.clusters = arrify(options.clusters).reduce((clusters, cluster) => {
+      clusters[cluster.name] = {
+        location: Cluster.getLocation_(self.projectId, cluster.location),
+        serveNodes: cluster.nodes,
+        defaultStorageType: Cluster.getStorageType_(cluster.storage),
+      };
+
+      return clusters;
+    },
+    {});
+
+    this.request(
+      {
+        client: 'BigtableInstanceAdminClient',
+        method: 'createInstance',
+        reqOpts,
+        gaxOpts: options.gaxOptions,
+      },
+      (...args) => {
+        const err = args[0];
+
+        if (!err) {
+          args.splice(1, 0, self.instance(name));
+        }
+
+        callback(...args);
+      }
+    );
   }
 
-  this.auth.getProjectId(function(err, projectId) {
-    if (err) {
-      callback(err);
+  /**
+   * Get Instance objects for all of your Compute instances.
+   *
+   * @param {object} [gaxOptions] Request configuration options, outlined here:
+   *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
+   * @param {function} callback The callback function.
+   * @param {?error} callback.error An error returned while making this request.
+   * @param {Instance[]} callback.instances List of all
+   *     instances.
+   * @param {object} callback.apiResponse The full API response.
+   *
+   * @example
+   * const Bigtable = require('@google-cloud/bigtable');
+   * const bigtable = new Bigtable();
+   *
+   * bigtable.getInstances(function(err, instances) {
+   *   if (!err) {
+   *     // `instances` is an array of Instance objects.
+   *   }
+   * });
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * bigtable.getInstances().then(function(data) {
+   *   const instances = data[0];
+   * });
+   */
+  getInstances(gaxOptions, callback) {
+    const self = this;
+
+    if (is.function(gaxOptions)) {
+      callback = gaxOptions;
+      gaxOptions = {};
+    }
+
+    const reqOpts = {
+      parent: this.projectName,
+    };
+
+    this.request(
+      {
+        client: 'BigtableInstanceAdminClient',
+        method: 'listInstances',
+        reqOpts,
+        gaxOpts: gaxOptions,
+      },
+      (err, resp) => {
+        if (err) {
+          callback(err);
+          return;
+        }
+
+        const instances = resp.instances.map(instanceData => {
+          const instance = self.instance(instanceData.name);
+          instance.metadata = instanceData;
+          return instance;
+        });
+
+        callback(null, instances, resp);
+      }
+    );
+  }
+
+  /**
+   * Get a reference to a Compute instance.
+   *
+   * @param {string} name The name of the instance.
+   * @returns {Instance}
+   */
+  instance(name) {
+    return new Instance(this, name);
+  }
+
+  /**
+   * Funnel all API requests through this method, to be sure we have a project ID.
+   *
+   * @param {object} config Configuration object.
+   * @param {object} config.gaxOpts GAX options.
+   * @param {function} config.method The gax method to call.
+   * @param {object} config.reqOpts Request options.
+   * @param {function} [callback] Callback function.
+   */
+  request(config, callback) {
+    const self = this;
+    const isStreamMode = !callback;
+
+    let gaxStream;
+    let stream;
+
+    if (isStreamMode) {
+      stream = streamEvents(through.obj());
+
+      stream.abort = () => {
+        if (gaxStream && gaxStream.cancel) {
+          gaxStream.cancel();
+        }
+      };
+
+      stream.once('reading', makeRequestStream);
+
+      return stream;
+    } else {
+      makeRequestCallback();
+    }
+
+    function prepareGaxRequest(callback) {
+      self.getProjectId_((err, projectId) => {
+        if (err) {
+          callback(err);
+          return;
+        }
+
+        let gaxClient = self.api[config.client];
+
+        if (!gaxClient) {
+          // Lazily instantiate client.
+          gaxClient = new v2[config.client](self.options[config.client]);
+          self.api[config.client] = gaxClient;
+        }
+
+        let reqOpts = extend(true, {}, config.reqOpts);
+
+        if (projectId !== '{{projectId}}') {
+          reqOpts = common.util.replaceProjectIdToken(reqOpts, projectId);
+        }
+
+        const requestFn = gaxClient[config.method].bind(
+          gaxClient,
+          reqOpts,
+          config.gaxOpts
+        );
+
+        callback(null, requestFn);
+      });
+    }
+
+    function makeRequestCallback() {
+      prepareGaxRequest((err, requestFn) => {
+        if (err) {
+          callback(err);
+          return;
+        }
+
+        requestFn(callback);
+      });
+    }
+
+    function makeRequestStream() {
+      prepareGaxRequest((err, requestFn) => {
+        if (err) {
+          stream.destroy(err);
+          return;
+        }
+
+        // @TODO: remove `retry-request` when gax supports retryable streams.
+        // https://github.com/googleapis/gax-nodejs/blob/ec0c8b0805c31d8a91ea69cb19fe50f42a38bf87/lib/streaming.js#L230
+        const retryOpts = extend(
+          {
+            currentRetryAttempt: 0,
+            objectMode: true,
+            shouldRetryFn: GrpcService.shouldRetryRequest_,
+            request() {
+              gaxStream = requestFn();
+              return gaxStream;
+            },
+          },
+          config.retryOpts
+        );
+
+        retryRequest(null, retryOpts)
+          .on('error', stream.destroy.bind(stream))
+          .on('request', stream.emit.bind(stream, 'request'))
+          .pipe(stream);
+      });
+    }
+  }
+
+  /**
+   * Determine and localize the project ID. If a user provides an ID, we bypass
+   * checking with the auth client for an ID.
+   *
+   * @private
+   *
+   * @param {function} callback Callback function.
+   * @param {?error} callback.err An error returned from the auth client.
+   * @param {string} callback.projectId The detected project ID.
+   */
+  getProjectId_(callback) {
+    const self = this;
+
+    const projectIdRequired =
+      this.projectId === '{{projectId}}' && !this.customEndpoint;
+
+    if (!projectIdRequired) {
+      setImmediate(callback, null, this.projectId);
       return;
     }
 
-    self.projectId = projectId;
+    this.auth.getProjectId((err, projectId) => {
+      if (err) {
+        callback(err);
+        return;
+      }
 
-    callback(null, self.projectId);
-  });
-};
+      self.projectId = projectId;
+
+      callback(null, self.projectId);
+    });
+  }
+}
 
 /*! Developer Documentation
  *

--- a/src/instance.js
+++ b/src/instance.js
@@ -14,16 +14,14 @@
  * limitations under the License.
  */
 
-'use strict';
+const common = require('@google-cloud/common');
+const extend = require('extend');
+const is = require('is');
 
-var common = require('@google-cloud/common');
-var extend = require('extend');
-var is = require('is');
-
-var AppProfile = require('./app-profile.js');
-var Cluster = require('./cluster.js');
-var Family = require('./family.js');
-var Table = require('./table.js');
+const AppProfile = require('./app-profile.js');
+const Cluster = require('./cluster.js');
+const Family = require('./family.js');
+const Table = require('./table.js');
 
 /**
  * Create an Instance object to interact with a Compute instance.
@@ -38,17 +36,911 @@ var Table = require('./table.js');
  * const bigtable = new Bigtable();
  * const instance = bigtable.instance('my-instance');
  */
-function Instance(bigtable, name) {
-  this.bigtable = bigtable;
+class Instance {
+  constructor(bigtable, name) {
+    this.bigtable = bigtable;
 
-  var id = name;
+    let id = name;
 
-  if (id.indexOf('/') === -1) {
-    id = bigtable.projectName + '/instances/' + name;
+    if (!id.includes('/')) {
+      id = `${bigtable.projectName}/instances/${name}`;
+    }
+
+    this.id = id;
+    this.name = id.split('/').pop();
   }
 
-  this.id = id;
-  this.name = id.split('/').pop();
+  /**
+   * Get a reference to a Bigtable App Profile.
+   *
+   * @param {string} name The name of the app profile.
+   * @returns {AppProfile}
+   */
+  appProfile(name) {
+    return new AppProfile(this, name);
+  }
+
+  /**
+   * Create an instance.
+   *
+   * @param {object} [options] See {@link Bigtable#createInstance}.
+   * @param {object} [options.gaxOptions]  Request configuration options, outlined
+   *     here: https://googleapis.github.io/gax-nodejs/global.html#CallOptions.
+   * @param {function} callback The callback function.
+   * @param {?error} callback.err An error returned while making this
+   *     request.
+   * @param {Instance} callback.instance The newly created
+   *     instance.
+   * @param {Operation} callback.operation An operation object that can be used
+   *     to check the status of the request.
+   * @param {object} callback.apiResponse The full API response.
+   *
+   * @example
+   * const Bigtable = require('@google-cloud/bigtable');
+   * const bigtable = new Bigtable();
+   * const instance = bigtable.instance('my-instance');
+   *
+   * instance.create(function(err, instance, operation, apiResponse) {
+   *   if (err) {
+   *     // Error handling omitted.
+   *   }
+   *
+   *   operation
+   *     .on('error', console.error)
+   *     .on('complete', function() {
+   *       // The instance was created successfully.
+   *     });
+   * });
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * instance.create().then(function(data) {
+   *   var instance = data[0];
+   *   var operation = data[1];
+   *   var apiResponse = data[2];
+   * });
+   */
+  create(options, callback) {
+    if (is.fn(options)) {
+      callback = options;
+      options = {};
+    }
+
+    this.bigtable.createInstance(this.name, options, callback);
+  }
+
+  /**
+   * Create an app profile.
+   *
+   * @param {string} name The name to be used when referring to the new
+   *     app profile within its instance.
+   * @param {object} options AppProfile creation options.
+   * @param {'any'|Cluster} options.routing  The routing policy for all
+   *     read/write requests which use this app profile. This can be either the
+   *     string 'any' or a cluster of an instance. This value is required when
+   *     creating the app profile and optional when setting the metadata.
+   * @param {object} [options.gaxOptions]  Request configuration options, outlined
+   *     here: https://googleapis.github.io/gax-nodejs/global.html#CallOptions.
+   * @param {boolean} [options.allowTransactionalWrites] Whether or not
+   *     CheckAndMutateRow and ReadModifyWriteRow requests are allowed by this
+   *     app profile. It is unsafe to send these requests to the same
+   *     table/row/column in multiple clusters. This is only used when the
+   *     routing value is a cluster.
+   * @param {string} [options.description] The long form description of the use
+   *     case for this AppProfile.
+   * @param {string} [options.ignoreWarnings] Whether to ignore safety checks
+   *     when creating the app profile
+   * @param {function} callback The callback function.
+   * @param {?error} callback.err An error returned while making this request.
+   * @param {Cluster} callback.appProfile The newly created app profile.
+   *
+   * @example
+   * const Bigtable = require('@google-cloud/bigtable');
+   * const bigtable = new Bigtable();
+   * const instance = bigtable.instance('my-instance');
+   * const cluster = instance.cluster('my-cluster');
+   *
+   * const callback = function(err, appProfile, apiResponse) {
+   *   // `appProfile` is an AppProfile object.
+   * };
+   *
+   * const options = {
+   *   routing: cluster,
+   *   allowTransactionalWrites: true,
+   *   ignoreWarnings: true,
+   * };
+   *
+   * instance.createAppProfile('my-app-profile', options, callback);
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * instance.createAppProfile('my-app-profile', options).then(function(data) {
+   *   const appProfile = data[0];
+   *   const apiResponse = data[1];
+   * });
+   */
+  createAppProfile(name, options, callback) {
+    const self = this;
+
+    if (is.function(options)) {
+      callback = options;
+      options = {};
+    }
+
+    if (!options.routing) {
+      throw new Error('An app profile must contain a routing policy.');
+    }
+
+    const appProfile = AppProfile.formatAppProfile_(options);
+
+    const reqOpts = {
+      parent: this.id,
+      appProfileId: name,
+      appProfile,
+    };
+
+    if (is.boolean(options.ignoreWarnings)) {
+      reqOpts.ignoreWarnings = options.ignoreWarnings;
+    }
+
+    this.bigtable.request(
+      {
+        client: 'BigtableInstanceAdminClient',
+        method: 'createAppProfile',
+        reqOpts,
+        gaxOpts: options.gaxOptions,
+      },
+      (...args) => {
+        if (args[1]) {
+          args.splice(1, 0, self.appProfile(name));
+        }
+
+        callback(...args);
+      }
+    );
+  }
+
+  /**
+   * Create a cluster.
+   *
+   * @param {string} name The name to be used when referring to the new
+   *     cluster within its instance.
+   * @param {object} [options] Cluster creation options.
+   * @param {object} [options.gaxOptions]  Request configuration options, outlined
+   *     here: https://googleapis.github.io/gax-nodejs/global.html#CallOptions.
+   * @param {string} [options.location] The location where this cluster's nodes
+   *     and storage reside. For best performance clients should be located as
+   *     as close as possible to this cluster. Currently only zones are
+   *     supported.
+   * @param {number} [options.nodes] The number of nodes allocated to this
+   *     cluster. More nodes enable higher throughput and more consistent
+   *     performance.
+   * @param {string} [options.storage] The type of storage used by this cluster
+   *     to serve its parent instance's tables. Options are 'hdd' or 'ssd'.
+   * @param {function} callback The callback function.
+   * @param {?error} callback.err An error returned while making this request.
+   * @param {Cluster} callback.cluster The newly created
+   *     cluster.
+   * @param {Operation} callback.operation An operation object that can be used
+   *     to check the status of the request.
+   *
+   * @example
+   * const Bigtable = require('@google-cloud/bigtable');
+   * const bigtable = new Bigtable();
+   * const instance = bigtable.instance('my-instance');
+   *
+   * const callback = function(err, cluster, operation, apiResponse) {
+   *   if (err) {
+   *     // Error handling omitted.
+   *   }
+   *
+   *   operation
+   *     .on('error', console.log)
+   *     .on('complete', function() {
+   *       // The cluster was created successfully.
+   *     });
+   * };
+   *
+   * const options = {
+   *   location: 'us-central1-b',
+   *   nodes: 3,
+   *   storage: 'ssd'
+   * };
+   *
+   * instance.createCluster('my-cluster', options, callback);
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * instance.createCluster('my-cluster', options).then(function(data) {
+   *   const cluster = data[0];
+   *   const operation = data[1];
+   *   const apiResponse = data[2];
+   * });
+   */
+  createCluster(name, options, callback) {
+    const self = this;
+
+    if (is.function(options)) {
+      callback = options;
+      options = {};
+    }
+
+    const reqOpts = {
+      parent: this.id,
+      clusterId: name,
+    };
+
+    if (!is.empty(options)) {
+      reqOpts.cluster = {};
+    }
+
+    if (options.location) {
+      reqOpts.cluster.location = Cluster.getLocation_(
+        this.bigtable.projectId,
+        options.location
+      );
+    }
+
+    if (options.nodes) {
+      reqOpts.cluster.serveNodes = options.nodes;
+    }
+
+    if (options.storage) {
+      const storageType = Cluster.getStorageType_(options.storage);
+      reqOpts.cluster.defaultStorageType = storageType;
+    }
+
+    this.bigtable.request(
+      {
+        client: 'BigtableInstanceAdminClient',
+        method: 'createCluster',
+        reqOpts,
+        gaxOpts: options.gaxOptions,
+      },
+      (...args) => {
+        if (args[1]) {
+          args.splice(1, 0, self.cluster(name));
+        }
+
+        callback(...args);
+      }
+    );
+  }
+
+  /**
+   * Create a table on your Bigtable instance.
+   *
+   * @see [Designing Your Schema]{@link https://cloud.google.com/bigtable/docs/schema-design}
+   * @see [Splitting Keys]{@link https://cloud.google.com/bigtable/docs/managing-tables#splits}
+   *
+   * @throws {error} If a name is not provided.
+   *
+   * @param {string} name The name of the table.
+   * @param {object} [options] Table creation options.
+   * @param {object|string[]} [options.families] Column families to be created
+   *     within the table.
+   * @param {object} [options.gaxOptions] Request configuration options, outlined
+   *     here: https://googleapis.github.io/gax-nodejs/CallSettings.html.
+   * @param {string[]} [options.splits] Initial
+   *    [split keys](https://cloud.google.com/bigtable/docs/managing-tables#splits).
+   * @param {function} callback The callback function.
+   * @param {?error} callback.err An error returned while making this request.
+   * @param {Table} callback.table The newly created table.
+   * @param {object} callback.apiResponse The full API response.
+   *
+   * @example
+   * const Bigtable = require('@google-cloud/bigtable');
+   * const bigtable = new Bigtable();
+   * const instance = bigtable.instance('my-instance');
+   *
+   * const callback = function(err, table, apiResponse) {
+   *   // `table` is a Table object.
+   * };
+   *
+   * instance.createTable('prezzy', callback);
+   *
+   * //-
+   * // Optionally specify column families to be created within the table.
+   * //-
+   * const options = {
+   *   families: ['follows']
+   * };
+   *
+   * instance.createTable('prezzy', options, callback);
+   *
+   * //-
+   * // You can also specify garbage collection rules for your column families.
+   * // See {@link Table#createFamily} for more information about
+   * // column families and garbage collection rules.
+   * //-
+   * const options = {
+   *   families: [
+   *     {
+   *       name: 'follows',
+   *       rule:  {
+   *         age: {
+   *           seconds: 0,
+   *           nanos: 5000
+   *         },
+   *         versions: 3,
+   *         union: true
+   *       }
+   *     }
+   *   ]
+   * };
+   *
+   * instance.createTable('prezzy', options, callback);
+   *
+   * //-
+   * // Pre-split the table based on the row key to spread the load across
+   * // multiple Cloud Bigtable nodes.
+   * //-
+   * const options = {
+   *   splits: ['10', '20']
+   * };
+   *
+   * instance.createTable('prezzy', options, callback);
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * instance.createTable('prezzy', options).then(function(data) {
+   *   const table = data[0];
+   *   const apiResponse = data[1];
+   * });
+   */
+  createTable(name, options, callback) {
+    const self = this;
+
+    if (!name) {
+      throw new Error('A name is required to create a table.');
+    }
+
+    options = options || {};
+
+    if (is.function(options)) {
+      callback = options;
+      options = {};
+    }
+
+    const reqOpts = {
+      parent: this.id,
+      tableId: name,
+      table: {
+        // The granularity at which timestamps are stored in the table.
+        // Currently only milliseconds is supported, so it's not configurable.
+        granularity: 0,
+      },
+    };
+
+    if (options.splits) {
+      reqOpts.initialSplits = options.splits.map(key => ({
+        key
+      }));
+    }
+
+    if (options.families) {
+      const columnFamilies = options.families.reduce((families, family) => {
+        if (is.string(family)) {
+          family = {
+            name: family,
+          };
+        }
+
+        const columnFamily = (families[family.name] = {});
+
+        if (family.rule) {
+          columnFamily.gcRule = Family.formatRule_(family.rule);
+        }
+
+        return families;
+      }, {});
+
+      reqOpts.table.columnFamilies = columnFamilies;
+    }
+
+    this.bigtable.request(
+      {
+        client: 'BigtableTableAdminClient',
+        method: 'createTable',
+        reqOpts,
+        gaxOpts: options.gaxOptions,
+      },
+      (...args) => {
+        if (args[1]) {
+          const table = self.table(args[1].name);
+          table.metadata = args[1];
+          args.splice(1, 0, table);
+        }
+
+        callback(...args);
+      }
+    );
+  }
+
+  /**
+   * Get a reference to a Bigtable Cluster.
+   *
+   * @param {string} name The name of the cluster.
+   * @returns {Cluster}
+   */
+  cluster(name) {
+    return new Cluster(this, name);
+  }
+
+  /**
+   * Delete the instance.
+   *
+   * @param {object} [gaxOptions] Request configuration options, outlined here:
+   *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
+   * @param {function} [callback] The callback function.
+   * @param {?error} callback.err An error returned while making this
+   *     request.
+   * @param {object} callback.apiResponse The full API response.
+   *
+   * @example
+   * const Bigtable = require('@google-cloud/bigtable');
+   * const bigtable = new Bigtable();
+   * const instance = bigtable.instance('my-instance');
+   *
+   * instance.delete(function(err, apiResponse) {});
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * instance.delete().then(function(data) {
+   *   var apiResponse = data[0];
+   * });
+   */
+  delete(gaxOptions, callback) {
+    if (is.fn(gaxOptions)) {
+      callback = gaxOptions;
+      gaxOptions = {};
+    }
+
+    this.bigtable.request(
+      {
+        client: 'BigtableInstanceAdminClient',
+        method: 'deleteInstance',
+        reqOpts: {
+          name: this.id,
+        },
+        gaxOpts: gaxOptions,
+      },
+      callback
+    );
+  }
+
+  /**
+   * Check if an instance exists.
+   *
+   * @param {object} [gaxOptions] Request configuration options, outlined
+   *     here: https://googleapis.github.io/gax-nodejs/CallSettings.html.
+   * @param {function} callback The callback function.
+   * @param {?error} callback.err An error returned while making this
+   *     request.
+   * @param {boolean} callback.exists Whether the instance exists or not.
+   *
+   * @example
+   * const Bigtable = require('@google-cloud/bigtable');
+   * const bigtable = new Bigtable();
+   * const instance = bigtable.instance('my-instance');
+   *
+   * instance.exists(function(err, exists) {});
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * instance.exists().then(function(data) {
+   *   var exists = data[0];
+   * });
+   */
+  exists(gaxOptions, callback) {
+    if (is.fn(gaxOptions)) {
+      callback = gaxOptions;
+      gaxOptions = {};
+    }
+
+    this.getMetadata(gaxOptions, err => {
+      if (err) {
+        if (err.code === 5) {
+          callback(null, false);
+          return;
+        }
+
+        callback(err);
+        return;
+      }
+
+      callback(null, true);
+    });
+  }
+
+  /**
+   * Get an instance if it exists.
+   *
+   * @param {object} [gaxOptions] Request configuration options, outlined here:
+   *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
+   * @param {function} callback The callback function.
+   * @param {?error} callback.error An error returned while making this request.
+   * @param {Instance} callback.instance The Instance object.
+   * @param {object} callback.apiResponse The resource as it exists in the API.
+   *
+   * @example
+   * const Bigtable = require('@google-cloud/bigtable');
+   * const bigtable = new Bigtable();
+   * const instance = bigtable.instance('my-instance');
+   *
+   * instance.get(function(err, instance, apiResponse) {
+   *   // The `instance` data has been populated.
+   * });
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * instance.get().then(function(data) {
+   *   var instance = data[0];
+   *   var apiResponse = data[1];
+   * });
+   */
+  get(gaxOptions, callback) {
+    const self = this;
+
+    if (is.fn(gaxOptions)) {
+      callback = gaxOptions;
+      gaxOptions = {};
+    }
+
+    this.getMetadata(gaxOptions, (err, metadata) => {
+      callback(err, err ? null : self, metadata);
+    });
+  }
+
+  /**
+   * Get App Profile objects for this instance.
+   *
+   * @param {object} [gaxOptions] Request configuration options, outlined here:
+   *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
+   * @param {function} callback The callback function.
+   * @param {?error} callback.error An error returned while making this request.
+   * @param {AppProfile[]} callback.appProfiles List of all AppProfiles.
+   * @param {object} callback.apiResponse The full API response.
+   *
+   * @example
+   * const Bigtable = require('@google-cloud/bigtable');
+   * const bigtable = new Bigtable();
+   * const instance = bigtable.instance('my-instance');
+   *
+   * instance.getAppProfiles(function(err, appProfiles) {
+   *   if (!err) {
+   *     // `appProfiles` is an array of AppProfile objects.
+   *   }
+   * });
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * instance.getAppProfiles().then(function(data) {
+   *   const appProfiles = data[0];
+   * });
+   */
+  getAppProfiles(gaxOptions, callback) {
+    const self = this;
+
+    if (is.function(gaxOptions)) {
+      callback = gaxOptions;
+      gaxOptions = {};
+    }
+
+    const reqOpts = {
+      parent: this.id,
+    };
+
+    this.bigtable.request(
+      {
+        client: 'BigtableInstanceAdminClient',
+        method: 'listAppProfiles',
+        reqOpts,
+        gaxOpts: gaxOptions,
+      },
+      (err, resp) => {
+        if (err) {
+          callback(err);
+          return;
+        }
+
+        const appProfiles = resp.map(appProfileObj => {
+          const appProfile = self.appProfile(appProfileObj.name);
+          appProfile.metadata = appProfileObj;
+          return appProfile;
+        });
+
+        callback(null, appProfiles, resp);
+      }
+    );
+  }
+
+  /**
+   * Get Cluster objects for all of your clusters.
+   *
+   * @param {object} [gaxOptions] Request configuration options, outlined here:
+   *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
+   * @param {function} callback The callback function.
+   * @param {?error} callback.error An error returned while making this request.
+   * @param {Cluster[]} callback.clusters List of all
+   *     Clusters.
+   * @param {object} callback.apiResponse The full API response.
+   *
+   * @example
+   * const Bigtable = require('@google-cloud/bigtable');
+   * const bigtable = new Bigtable();
+   * const instance = bigtable.instance('my-instance');
+   *
+   * instance.getClusters(function(err, clusters) {
+   *   if (!err) {
+   *     // `clusters` is an array of Cluster objects.
+   *   }
+   * });
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * instance.getClusters().then(function(data) {
+   *   const clusters = data[0];
+   * });
+   */
+  getClusters(gaxOptions, callback) {
+    const self = this;
+
+    if (is.function(gaxOptions)) {
+      callback = gaxOptions;
+      gaxOptions = {};
+    }
+
+    const reqOpts = {
+      parent: this.id,
+    };
+
+    this.bigtable.request(
+      {
+        client: 'BigtableInstanceAdminClient',
+        method: 'listClusters',
+        reqOpts,
+        gaxOpts: gaxOptions,
+      },
+      (err, resp) => {
+        if (err) {
+          callback(err);
+          return;
+        }
+
+        const clusters = resp.clusters.map(clusterObj => {
+          const cluster = self.cluster(clusterObj.name);
+          cluster.metadata = clusterObj;
+          return cluster;
+        });
+
+        callback(null, clusters, resp);
+      }
+    );
+  }
+
+  /**
+   * Get the instance metadata.
+   *
+   * @param {object} [gaxOptions] Request configuration options, outlined here:
+   *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
+   * @param {function} callback The callback function.
+   * @param {?error} callback.err An error returned while making this
+   *     request.
+   * @param {object} callback.metadata The metadata.
+   *
+   * @example
+   * const Bigtable = require('@google-cloud/bigtable');
+   * const bigtable = new Bigtable();
+   * const instance = bigtable.instance('my-instance');
+   *
+   * instance.getMetadata(function(err, metadata) {});
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * instance.getMetadata().then(function(data) {
+   *   var metadata = data[0];
+   *   var apiResponse = data[1];
+   * });
+   */
+  getMetadata(gaxOptions, callback) {
+    const self = this;
+
+    if (is.fn(gaxOptions)) {
+      callback = gaxOptions;
+      gaxOptions = {};
+    }
+
+    this.bigtable.request(
+      {
+        client: 'BigtableInstanceAdminClient',
+        method: 'getInstance',
+        reqOpts: {
+          name: this.id,
+        },
+        gaxOpts: gaxOptions,
+      },
+      (...args) => {
+        if (args[1]) {
+          self.metadata = args[1];
+        }
+
+        callback(...args);
+      }
+    );
+  }
+
+  /**
+   * Get Table objects for all the tables in your Compute instance.
+   *
+   * @param {object} [options] Query object.
+   * @param {boolean} [options.autoPaginate=true] Have pagination handled
+   *     automatically.
+   * @param {object} [options.gaxOptions] Request configuration options, outlined
+   *     here: https://googleapis.github.io/gax-nodejs/global.html#CallOptions.
+   * @param {number} [options.maxApiCalls] Maximum number of API calls to make.
+   * @param {number} [options.maxResults] Maximum number of items to return.
+   * @param {string} [options.pageToken] A previously-returned page token
+   *     representing part of a larger set of results to view.
+   * @param {string} [options.view] View over the table's fields. Possible options
+   *     are 'name', 'schema' or 'full'. Default: 'name'.
+   * @param {function} callback The callback function.
+   * @param {?error} callback.err An error returned while making this request.
+   * @param {Table[]} callback.tables List of all Tables.
+   * @param {object} callback.apiResponse The full API response.
+   *
+   * @example
+   * const Bigtable = require('@google-cloud/bigtable');
+   * const bigtable = new Bigtable();
+   * const instance = bigtable.instance('my-instance');
+   *
+   * instance.getTables(function(err, tables) {
+   *   if (!err) {
+   *     // `tables` is an array of Table objects.
+   *   }
+   * });
+   *
+   * //-
+   * // To control how many API requests are made and page through the results
+   * // manually, set `autoPaginate` to false.
+   * //-
+   * const callback = function(err, tables, nextQuery, apiResponse) {
+   *   if (nextQuery) {
+   *     // More results exist.
+   *     instance.getTables(nextQuery, calback);
+   *   }
+   * };
+   *
+   * instance.getTables({
+   *   autoPaginate: false
+   * }, callback);
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * instance.getTables().then(function(data) {
+   *   const tables = data[0];
+   * });
+   */
+  getTables(options, callback) {
+    const self = this;
+
+    if (is.function(options)) {
+      callback = options;
+      options = {};
+    }
+
+    const reqOpts = extend({}, options, {
+      parent: this.id,
+      view: Table.VIEWS[options.view || 'unspecified'],
+    });
+
+    delete reqOpts.gaxOptions;
+
+    this.bigtable.request(
+      {
+        client: 'BigtableTableAdminClient',
+        method: 'listTables',
+        reqOpts,
+        gaxOpts: options.gaxOptions,
+      },
+      (...args) => {
+        if (args[1]) {
+          args[1] = args[1].map(tableObj => {
+            const name = tableObj.name.split('/').pop();
+            const table = self.table(name);
+            table.metadata = tableObj;
+            return table;
+          });
+        }
+
+        callback(...args);
+      }
+    );
+  }
+
+  /**
+   * Set the instance metadata.
+   *
+   * @param {object} metadata Metadata object.
+   * @param {string} metadata.displayName The descriptive name for this
+   *     instance as it appears in UIs. It can be changed at any time, but
+   *     should be kept globally unique to avoid confusion.
+   * @param {object} [gaxOptions] Request configuration options, outlined here:
+   *     https://googleapis.github.io/gax-nodejs/global.html#CallOptions.
+   * @param {function} callback The callback function.
+   * @param {?error} callback.err An error returned while making this
+   *     request.
+   * @param {object} callback.apiResponse The full API response.
+   *
+   * @example
+   * const Bigtable = require('@google-cloud/bigtable');
+   * const bigtable = new Bigtable();
+   * const instance = bigtable.instance('my-instance');
+   *
+   * var metadata = {
+   *   displayName: 'updated-name'
+   * };
+   *
+   * instance.setMetadata(metadata, function(err, apiResponse) {});
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * instance.setMetadata(metadata).then(function(data) {
+   *   var apiResponse = data[0];
+   * });
+   */
+  setMetadata(metadata, gaxOptions, callback) {
+    const self = this;
+
+    if (is.fn(gaxOptions)) {
+      callback = gaxOptions;
+      gaxOptions = {};
+    }
+
+    this.bigtable.request(
+      {
+        client: 'BigtableInstanceAdminClient',
+        method: 'updateInstance',
+        reqOpts: extend({name: this.id}, metadata),
+        gaxOpts: gaxOptions,
+      },
+      (...args) => {
+        if (args[1]) {
+          self.metadata = args[1];
+        }
+
+        callback(...args);
+      }
+    );
+  }
+
+  /**
+   * Get a reference to a Bigtable table.
+   *
+   * @param {string} name The name of the table.
+   * @returns {Table}
+   *
+   * @example
+   * const Bigtable = require('@google-cloud/bigtable');
+   * const bigtable = new Bigtable();
+   * const instance = bigtable.instance('my-instance');
+   * const table = instance.table('presidents');
+   */
+  table(name) {
+    return new Table(this, name);
+  }
 }
 
 /**
@@ -63,8 +955,8 @@ function Instance(bigtable, name) {
  * Instance.getTypeType_('production');
  * // 1
  */
-Instance.getTypeType_ = function(type) {
-  var types = {
+Instance.getTypeType_ = type => {
+  const types = {
     unspecified: 0,
     production: 1,
     development: 2,
@@ -75,833 +967,6 @@ Instance.getTypeType_ = function(type) {
   }
 
   return types[type] || types.unspecified;
-};
-
-/**
- * Get a reference to a Bigtable App Profile.
- *
- * @param {string} name The name of the app profile.
- * @returns {AppProfile}
- */
-Instance.prototype.appProfile = function(name) {
-  return new AppProfile(this, name);
-};
-
-/**
- * Create an instance.
- *
- * @param {object} [options] See {@link Bigtable#createInstance}.
- * @param {object} [options.gaxOptions]  Request configuration options, outlined
- *     here: https://googleapis.github.io/gax-nodejs/global.html#CallOptions.
- * @param {function} callback The callback function.
- * @param {?error} callback.err An error returned while making this
- *     request.
- * @param {Instance} callback.instance The newly created
- *     instance.
- * @param {Operation} callback.operation An operation object that can be used
- *     to check the status of the request.
- * @param {object} callback.apiResponse The full API response.
- *
- * @example
- * const Bigtable = require('@google-cloud/bigtable');
- * const bigtable = new Bigtable();
- * const instance = bigtable.instance('my-instance');
- *
- * instance.create(function(err, instance, operation, apiResponse) {
- *   if (err) {
- *     // Error handling omitted.
- *   }
- *
- *   operation
- *     .on('error', console.error)
- *     .on('complete', function() {
- *       // The instance was created successfully.
- *     });
- * });
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * instance.create().then(function(data) {
- *   var instance = data[0];
- *   var operation = data[1];
- *   var apiResponse = data[2];
- * });
- */
-Instance.prototype.create = function(options, callback) {
-  if (is.fn(options)) {
-    callback = options;
-    options = {};
-  }
-
-  this.bigtable.createInstance(this.name, options, callback);
-};
-
-/**
- * Create an app profile.
- *
- * @param {string} name The name to be used when referring to the new
- *     app profile within its instance.
- * @param {object} options AppProfile creation options.
- * @param {'any'|Cluster} options.routing  The routing policy for all
- *     read/write requests which use this app profile. This can be either the
- *     string 'any' or a cluster of an instance. This value is required when
- *     creating the app profile and optional when setting the metadata.
- * @param {object} [options.gaxOptions]  Request configuration options, outlined
- *     here: https://googleapis.github.io/gax-nodejs/global.html#CallOptions.
- * @param {boolean} [options.allowTransactionalWrites] Whether or not
- *     CheckAndMutateRow and ReadModifyWriteRow requests are allowed by this
- *     app profile. It is unsafe to send these requests to the same
- *     table/row/column in multiple clusters. This is only used when the
- *     routing value is a cluster.
- * @param {string} [options.description] The long form description of the use
- *     case for this AppProfile.
- * @param {string} [options.ignoreWarnings] Whether to ignore safety checks
- *     when creating the app profile
- * @param {function} callback The callback function.
- * @param {?error} callback.err An error returned while making this request.
- * @param {Cluster} callback.appProfile The newly created app profile.
- *
- * @example
- * const Bigtable = require('@google-cloud/bigtable');
- * const bigtable = new Bigtable();
- * const instance = bigtable.instance('my-instance');
- * const cluster = instance.cluster('my-cluster');
- *
- * const callback = function(err, appProfile, apiResponse) {
- *   // `appProfile` is an AppProfile object.
- * };
- *
- * const options = {
- *   routing: cluster,
- *   allowTransactionalWrites: true,
- *   ignoreWarnings: true,
- * };
- *
- * instance.createAppProfile('my-app-profile', options, callback);
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * instance.createAppProfile('my-app-profile', options).then(function(data) {
- *   const appProfile = data[0];
- *   const apiResponse = data[1];
- * });
- */
-Instance.prototype.createAppProfile = function(name, options, callback) {
-  const self = this;
-
-  if (is.function(options)) {
-    callback = options;
-    options = {};
-  }
-
-  if (!options.routing) {
-    throw new Error('An app profile must contain a routing policy.');
-  }
-
-  const appProfile = AppProfile.formatAppProfile_(options);
-
-  const reqOpts = {
-    parent: this.id,
-    appProfileId: name,
-    appProfile,
-  };
-
-  if (is.boolean(options.ignoreWarnings)) {
-    reqOpts.ignoreWarnings = options.ignoreWarnings;
-  }
-
-  this.bigtable.request(
-    {
-      client: 'BigtableInstanceAdminClient',
-      method: 'createAppProfile',
-      reqOpts: reqOpts,
-      gaxOpts: options.gaxOptions,
-    },
-    function() {
-      var args = [].slice.call(arguments);
-
-      if (args[1]) {
-        args.splice(1, 0, self.appProfile(name));
-      }
-
-      callback.apply(null, args);
-    }
-  );
-};
-
-/**
- * Create a cluster.
- *
- * @param {string} name The name to be used when referring to the new
- *     cluster within its instance.
- * @param {object} [options] Cluster creation options.
- * @param {object} [options.gaxOptions]  Request configuration options, outlined
- *     here: https://googleapis.github.io/gax-nodejs/global.html#CallOptions.
- * @param {string} [options.location] The location where this cluster's nodes
- *     and storage reside. For best performance clients should be located as
- *     as close as possible to this cluster. Currently only zones are
- *     supported.
- * @param {number} [options.nodes] The number of nodes allocated to this
- *     cluster. More nodes enable higher throughput and more consistent
- *     performance.
- * @param {string} [options.storage] The type of storage used by this cluster
- *     to serve its parent instance's tables. Options are 'hdd' or 'ssd'.
- * @param {function} callback The callback function.
- * @param {?error} callback.err An error returned while making this request.
- * @param {Cluster} callback.cluster The newly created
- *     cluster.
- * @param {Operation} callback.operation An operation object that can be used
- *     to check the status of the request.
- *
- * @example
- * const Bigtable = require('@google-cloud/bigtable');
- * const bigtable = new Bigtable();
- * const instance = bigtable.instance('my-instance');
- *
- * const callback = function(err, cluster, operation, apiResponse) {
- *   if (err) {
- *     // Error handling omitted.
- *   }
- *
- *   operation
- *     .on('error', console.log)
- *     .on('complete', function() {
- *       // The cluster was created successfully.
- *     });
- * };
- *
- * const options = {
- *   location: 'us-central1-b',
- *   nodes: 3,
- *   storage: 'ssd'
- * };
- *
- * instance.createCluster('my-cluster', options, callback);
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * instance.createCluster('my-cluster', options).then(function(data) {
- *   const cluster = data[0];
- *   const operation = data[1];
- *   const apiResponse = data[2];
- * });
- */
-Instance.prototype.createCluster = function(name, options, callback) {
-  var self = this;
-
-  if (is.function(options)) {
-    callback = options;
-    options = {};
-  }
-
-  var reqOpts = {
-    parent: this.id,
-    clusterId: name,
-  };
-
-  if (!is.empty(options)) {
-    reqOpts.cluster = {};
-  }
-
-  if (options.location) {
-    reqOpts.cluster.location = Cluster.getLocation_(
-      this.bigtable.projectId,
-      options.location
-    );
-  }
-
-  if (options.nodes) {
-    reqOpts.cluster.serveNodes = options.nodes;
-  }
-
-  if (options.storage) {
-    var storageType = Cluster.getStorageType_(options.storage);
-    reqOpts.cluster.defaultStorageType = storageType;
-  }
-
-  this.bigtable.request(
-    {
-      client: 'BigtableInstanceAdminClient',
-      method: 'createCluster',
-      reqOpts: reqOpts,
-      gaxOpts: options.gaxOptions,
-    },
-    function() {
-      var args = [].slice.call(arguments);
-
-      if (args[1]) {
-        args.splice(1, 0, self.cluster(name));
-      }
-
-      callback.apply(null, args);
-    }
-  );
-};
-
-/**
- * Create a table on your Bigtable instance.
- *
- * @see [Designing Your Schema]{@link https://cloud.google.com/bigtable/docs/schema-design}
- * @see [Splitting Keys]{@link https://cloud.google.com/bigtable/docs/managing-tables#splits}
- *
- * @throws {error} If a name is not provided.
- *
- * @param {string} name The name of the table.
- * @param {object} [options] Table creation options.
- * @param {object|string[]} [options.families] Column families to be created
- *     within the table.
- * @param {object} [options.gaxOptions] Request configuration options, outlined
- *     here: https://googleapis.github.io/gax-nodejs/CallSettings.html.
- * @param {string[]} [options.splits] Initial
- *    [split keys](https://cloud.google.com/bigtable/docs/managing-tables#splits).
- * @param {function} callback The callback function.
- * @param {?error} callback.err An error returned while making this request.
- * @param {Table} callback.table The newly created table.
- * @param {object} callback.apiResponse The full API response.
- *
- * @example
- * const Bigtable = require('@google-cloud/bigtable');
- * const bigtable = new Bigtable();
- * const instance = bigtable.instance('my-instance');
- *
- * const callback = function(err, table, apiResponse) {
- *   // `table` is a Table object.
- * };
- *
- * instance.createTable('prezzy', callback);
- *
- * //-
- * // Optionally specify column families to be created within the table.
- * //-
- * const options = {
- *   families: ['follows']
- * };
- *
- * instance.createTable('prezzy', options, callback);
- *
- * //-
- * // You can also specify garbage collection rules for your column families.
- * // See {@link Table#createFamily} for more information about
- * // column families and garbage collection rules.
- * //-
- * const options = {
- *   families: [
- *     {
- *       name: 'follows',
- *       rule:  {
- *         age: {
- *           seconds: 0,
- *           nanos: 5000
- *         },
- *         versions: 3,
- *         union: true
- *       }
- *     }
- *   ]
- * };
- *
- * instance.createTable('prezzy', options, callback);
- *
- * //-
- * // Pre-split the table based on the row key to spread the load across
- * // multiple Cloud Bigtable nodes.
- * //-
- * const options = {
- *   splits: ['10', '20']
- * };
- *
- * instance.createTable('prezzy', options, callback);
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * instance.createTable('prezzy', options).then(function(data) {
- *   const table = data[0];
- *   const apiResponse = data[1];
- * });
- */
-Instance.prototype.createTable = function(name, options, callback) {
-  var self = this;
-
-  if (!name) {
-    throw new Error('A name is required to create a table.');
-  }
-
-  options = options || {};
-
-  if (is.function(options)) {
-    callback = options;
-    options = {};
-  }
-
-  var reqOpts = {
-    parent: this.id,
-    tableId: name,
-    table: {
-      // The granularity at which timestamps are stored in the table.
-      // Currently only milliseconds is supported, so it's not configurable.
-      granularity: 0,
-    },
-  };
-
-  if (options.splits) {
-    reqOpts.initialSplits = options.splits.map(function(key) {
-      return {
-        key: key,
-      };
-    });
-  }
-
-  if (options.families) {
-    var columnFamilies = options.families.reduce(function(families, family) {
-      if (is.string(family)) {
-        family = {
-          name: family,
-        };
-      }
-
-      var columnFamily = (families[family.name] = {});
-
-      if (family.rule) {
-        columnFamily.gcRule = Family.formatRule_(family.rule);
-      }
-
-      return families;
-    }, {});
-
-    reqOpts.table.columnFamilies = columnFamilies;
-  }
-
-  this.bigtable.request(
-    {
-      client: 'BigtableTableAdminClient',
-      method: 'createTable',
-      reqOpts: reqOpts,
-      gaxOpts: options.gaxOptions,
-    },
-    function() {
-      var args = [].slice.call(arguments);
-
-      if (args[1]) {
-        var table = self.table(args[1].name);
-        table.metadata = args[1];
-        args.splice(1, 0, table);
-      }
-
-      callback.apply(null, args);
-    }
-  );
-};
-
-/**
- * Get a reference to a Bigtable Cluster.
- *
- * @param {string} name The name of the cluster.
- * @returns {Cluster}
- */
-Instance.prototype.cluster = function(name) {
-  return new Cluster(this, name);
-};
-
-/**
- * Delete the instance.
- *
- * @param {object} [gaxOptions] Request configuration options, outlined here:
- *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
- * @param {function} [callback] The callback function.
- * @param {?error} callback.err An error returned while making this
- *     request.
- * @param {object} callback.apiResponse The full API response.
- *
- * @example
- * const Bigtable = require('@google-cloud/bigtable');
- * const bigtable = new Bigtable();
- * const instance = bigtable.instance('my-instance');
- *
- * instance.delete(function(err, apiResponse) {});
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * instance.delete().then(function(data) {
- *   var apiResponse = data[0];
- * });
- */
-Instance.prototype.delete = function(gaxOptions, callback) {
-  if (is.fn(gaxOptions)) {
-    callback = gaxOptions;
-    gaxOptions = {};
-  }
-
-  this.bigtable.request(
-    {
-      client: 'BigtableInstanceAdminClient',
-      method: 'deleteInstance',
-      reqOpts: {
-        name: this.id,
-      },
-      gaxOpts: gaxOptions,
-    },
-    callback
-  );
-};
-
-/**
- * Check if an instance exists.
- *
- * @param {object} [gaxOptions] Request configuration options, outlined
- *     here: https://googleapis.github.io/gax-nodejs/CallSettings.html.
- * @param {function} callback The callback function.
- * @param {?error} callback.err An error returned while making this
- *     request.
- * @param {boolean} callback.exists Whether the instance exists or not.
- *
- * @example
- * const Bigtable = require('@google-cloud/bigtable');
- * const bigtable = new Bigtable();
- * const instance = bigtable.instance('my-instance');
- *
- * instance.exists(function(err, exists) {});
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * instance.exists().then(function(data) {
- *   var exists = data[0];
- * });
- */
-Instance.prototype.exists = function(gaxOptions, callback) {
-  if (is.fn(gaxOptions)) {
-    callback = gaxOptions;
-    gaxOptions = {};
-  }
-
-  this.getMetadata(gaxOptions, function(err) {
-    if (err) {
-      if (err.code === 5) {
-        callback(null, false);
-        return;
-      }
-
-      callback(err);
-      return;
-    }
-
-    callback(null, true);
-  });
-};
-
-/**
- * Get an instance if it exists.
- *
- * @param {object} [gaxOptions] Request configuration options, outlined here:
- *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
- * @param {function} callback The callback function.
- * @param {?error} callback.error An error returned while making this request.
- * @param {Instance} callback.instance The Instance object.
- * @param {object} callback.apiResponse The resource as it exists in the API.
- *
- * @example
- * const Bigtable = require('@google-cloud/bigtable');
- * const bigtable = new Bigtable();
- * const instance = bigtable.instance('my-instance');
- *
- * instance.get(function(err, instance, apiResponse) {
- *   // The `instance` data has been populated.
- * });
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * instance.get().then(function(data) {
- *   var instance = data[0];
- *   var apiResponse = data[1];
- * });
- */
-Instance.prototype.get = function(gaxOptions, callback) {
-  var self = this;
-
-  if (is.fn(gaxOptions)) {
-    callback = gaxOptions;
-    gaxOptions = {};
-  }
-
-  this.getMetadata(gaxOptions, function(err, metadata) {
-    callback(err, err ? null : self, metadata);
-  });
-};
-
-/**
- * Get App Profile objects for this instance.
- *
- * @param {object} [gaxOptions] Request configuration options, outlined here:
- *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
- * @param {function} callback The callback function.
- * @param {?error} callback.error An error returned while making this request.
- * @param {AppProfile[]} callback.appProfiles List of all AppProfiles.
- * @param {object} callback.apiResponse The full API response.
- *
- * @example
- * const Bigtable = require('@google-cloud/bigtable');
- * const bigtable = new Bigtable();
- * const instance = bigtable.instance('my-instance');
- *
- * instance.getAppProfiles(function(err, appProfiles) {
- *   if (!err) {
- *     // `appProfiles` is an array of AppProfile objects.
- *   }
- * });
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * instance.getAppProfiles().then(function(data) {
- *   const appProfiles = data[0];
- * });
- */
-Instance.prototype.getAppProfiles = function(gaxOptions, callback) {
-  var self = this;
-
-  if (is.function(gaxOptions)) {
-    callback = gaxOptions;
-    gaxOptions = {};
-  }
-
-  var reqOpts = {
-    parent: this.id,
-  };
-
-  this.bigtable.request(
-    {
-      client: 'BigtableInstanceAdminClient',
-      method: 'listAppProfiles',
-      reqOpts: reqOpts,
-      gaxOpts: gaxOptions,
-    },
-    function(err, resp) {
-      if (err) {
-        callback(err);
-        return;
-      }
-
-      var appProfiles = resp.map(function(appProfileObj) {
-        var appProfile = self.appProfile(appProfileObj.name);
-        appProfile.metadata = appProfileObj;
-        return appProfile;
-      });
-
-      callback(null, appProfiles, resp);
-    }
-  );
-};
-
-/**
- * Get Cluster objects for all of your clusters.
- *
- * @param {object} [gaxOptions] Request configuration options, outlined here:
- *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
- * @param {function} callback The callback function.
- * @param {?error} callback.error An error returned while making this request.
- * @param {Cluster[]} callback.clusters List of all
- *     Clusters.
- * @param {object} callback.apiResponse The full API response.
- *
- * @example
- * const Bigtable = require('@google-cloud/bigtable');
- * const bigtable = new Bigtable();
- * const instance = bigtable.instance('my-instance');
- *
- * instance.getClusters(function(err, clusters) {
- *   if (!err) {
- *     // `clusters` is an array of Cluster objects.
- *   }
- * });
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * instance.getClusters().then(function(data) {
- *   const clusters = data[0];
- * });
- */
-Instance.prototype.getClusters = function(gaxOptions, callback) {
-  var self = this;
-
-  if (is.function(gaxOptions)) {
-    callback = gaxOptions;
-    gaxOptions = {};
-  }
-
-  var reqOpts = {
-    parent: this.id,
-  };
-
-  this.bigtable.request(
-    {
-      client: 'BigtableInstanceAdminClient',
-      method: 'listClusters',
-      reqOpts: reqOpts,
-      gaxOpts: gaxOptions,
-    },
-    function(err, resp) {
-      if (err) {
-        callback(err);
-        return;
-      }
-
-      var clusters = resp.clusters.map(function(clusterObj) {
-        var cluster = self.cluster(clusterObj.name);
-        cluster.metadata = clusterObj;
-        return cluster;
-      });
-
-      callback(null, clusters, resp);
-    }
-  );
-};
-
-/**
- * Get the instance metadata.
- *
- * @param {object} [gaxOptions] Request configuration options, outlined here:
- *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
- * @param {function} callback The callback function.
- * @param {?error} callback.err An error returned while making this
- *     request.
- * @param {object} callback.metadata The metadata.
- *
- * @example
- * const Bigtable = require('@google-cloud/bigtable');
- * const bigtable = new Bigtable();
- * const instance = bigtable.instance('my-instance');
- *
- * instance.getMetadata(function(err, metadata) {});
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * instance.getMetadata().then(function(data) {
- *   var metadata = data[0];
- *   var apiResponse = data[1];
- * });
- */
-Instance.prototype.getMetadata = function(gaxOptions, callback) {
-  var self = this;
-
-  if (is.fn(gaxOptions)) {
-    callback = gaxOptions;
-    gaxOptions = {};
-  }
-
-  this.bigtable.request(
-    {
-      client: 'BigtableInstanceAdminClient',
-      method: 'getInstance',
-      reqOpts: {
-        name: this.id,
-      },
-      gaxOpts: gaxOptions,
-    },
-    function() {
-      if (arguments[1]) {
-        self.metadata = arguments[1];
-      }
-
-      callback.apply(null, arguments);
-    }
-  );
-};
-
-/**
- * Get Table objects for all the tables in your Compute instance.
- *
- * @param {object} [options] Query object.
- * @param {boolean} [options.autoPaginate=true] Have pagination handled
- *     automatically.
- * @param {object} [options.gaxOptions] Request configuration options, outlined
- *     here: https://googleapis.github.io/gax-nodejs/global.html#CallOptions.
- * @param {number} [options.maxApiCalls] Maximum number of API calls to make.
- * @param {number} [options.maxResults] Maximum number of items to return.
- * @param {string} [options.pageToken] A previously-returned page token
- *     representing part of a larger set of results to view.
- * @param {string} [options.view] View over the table's fields. Possible options
- *     are 'name', 'schema' or 'full'. Default: 'name'.
- * @param {function} callback The callback function.
- * @param {?error} callback.err An error returned while making this request.
- * @param {Table[]} callback.tables List of all Tables.
- * @param {object} callback.apiResponse The full API response.
- *
- * @example
- * const Bigtable = require('@google-cloud/bigtable');
- * const bigtable = new Bigtable();
- * const instance = bigtable.instance('my-instance');
- *
- * instance.getTables(function(err, tables) {
- *   if (!err) {
- *     // `tables` is an array of Table objects.
- *   }
- * });
- *
- * //-
- * // To control how many API requests are made and page through the results
- * // manually, set `autoPaginate` to false.
- * //-
- * const callback = function(err, tables, nextQuery, apiResponse) {
- *   if (nextQuery) {
- *     // More results exist.
- *     instance.getTables(nextQuery, calback);
- *   }
- * };
- *
- * instance.getTables({
- *   autoPaginate: false
- * }, callback);
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * instance.getTables().then(function(data) {
- *   const tables = data[0];
- * });
- */
-Instance.prototype.getTables = function(options, callback) {
-  var self = this;
-
-  if (is.function(options)) {
-    callback = options;
-    options = {};
-  }
-
-  var reqOpts = extend({}, options, {
-    parent: this.id,
-    view: Table.VIEWS[options.view || 'unspecified'],
-  });
-
-  delete reqOpts.gaxOptions;
-
-  this.bigtable.request(
-    {
-      client: 'BigtableTableAdminClient',
-      method: 'listTables',
-      reqOpts: reqOpts,
-      gaxOpts: options.gaxOptions,
-    },
-    function() {
-      if (arguments[1]) {
-        arguments[1] = arguments[1].map(function(tableObj) {
-          var name = tableObj.name.split('/').pop();
-          var table = self.table(name);
-          table.metadata = tableObj;
-          return table;
-        });
-      }
-
-      callback.apply(null, arguments);
-    }
-  );
 };
 
 /**
@@ -936,79 +1001,6 @@ Instance.prototype.getTables = function(options, callback) {
  *   });
  */
 Instance.prototype.getTablesStream = common.paginator.streamify('getTables');
-
-/**
- * Set the instance metadata.
- *
- * @param {object} metadata Metadata object.
- * @param {string} metadata.displayName The descriptive name for this
- *     instance as it appears in UIs. It can be changed at any time, but
- *     should be kept globally unique to avoid confusion.
- * @param {object} [gaxOptions] Request configuration options, outlined here:
- *     https://googleapis.github.io/gax-nodejs/global.html#CallOptions.
- * @param {function} callback The callback function.
- * @param {?error} callback.err An error returned while making this
- *     request.
- * @param {object} callback.apiResponse The full API response.
- *
- * @example
- * const Bigtable = require('@google-cloud/bigtable');
- * const bigtable = new Bigtable();
- * const instance = bigtable.instance('my-instance');
- *
- * var metadata = {
- *   displayName: 'updated-name'
- * };
- *
- * instance.setMetadata(metadata, function(err, apiResponse) {});
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * instance.setMetadata(metadata).then(function(data) {
- *   var apiResponse = data[0];
- * });
- */
-Instance.prototype.setMetadata = function(metadata, gaxOptions, callback) {
-  var self = this;
-
-  if (is.fn(gaxOptions)) {
-    callback = gaxOptions;
-    gaxOptions = {};
-  }
-
-  this.bigtable.request(
-    {
-      client: 'BigtableInstanceAdminClient',
-      method: 'updateInstance',
-      reqOpts: extend({name: this.id}, metadata),
-      gaxOpts: gaxOptions,
-    },
-    function() {
-      if (arguments[1]) {
-        self.metadata = arguments[1];
-      }
-
-      callback.apply(null, arguments);
-    }
-  );
-};
-
-/**
- * Get a reference to a Bigtable table.
- *
- * @param {string} name The name of the table.
- * @returns {Table}
- *
- * @example
- * const Bigtable = require('@google-cloud/bigtable');
- * const bigtable = new Bigtable();
- * const instance = bigtable.instance('my-instance');
- * const table = instance.table('presidents');
- */
-Instance.prototype.table = function(name) {
-  return new Table(this, name);
-};
 
 /*! Developer Documentation
  *

--- a/src/table.js
+++ b/src/table.js
@@ -14,22 +14,20 @@
  * limitations under the License.
  */
 
-'use strict';
+const arrify = require('arrify');
+const common = require('@google-cloud/common');
+const commonGrpc = require('@google-cloud/common-grpc');
+const concat = require('concat-stream');
+const flatten = require('lodash.flatten');
+const is = require('is');
+const propAssign = require('prop-assign');
+const pumpify = require('pumpify');
+const through = require('through2');
 
-var arrify = require('arrify');
-var common = require('@google-cloud/common');
-var commonGrpc = require('@google-cloud/common-grpc');
-var concat = require('concat-stream');
-var flatten = require('lodash.flatten');
-var is = require('is');
-var propAssign = require('prop-assign');
-var pumpify = require('pumpify');
-var through = require('through2');
-
-var Family = require('./family.js');
-var Filter = require('./filter.js');
-var Mutation = require('./mutation.js');
-var Row = require('./row.js');
+const Family = require('./family.js');
+const Filter = require('./filter.js');
+const Mutation = require('./mutation.js');
+const Row = require('./row.js');
 const ChunkTransformer = require('./chunktransformer.js');
 
 // See protos/google/rpc/code.proto
@@ -49,14 +47,1266 @@ const RETRYABLE_STATUS_CODES = new Set([4, 10, 14]);
  * const instance = bigtable.instance('my-instance');
  * const table = instance.table('prezzy');
  */
-function Table(instance, name) {
-  this.bigtable = instance.bigtable;
-  this.instance = instance;
+class Table {
+  constructor(instance, name) {
+    this.bigtable = instance.bigtable;
+    this.instance = instance;
 
-  var id = Table.formatName_(instance.id, name);
+    const id = Table.formatName_(instance.id, name);
 
-  this.id = id;
-  this.name = id.split('/').pop();
+    this.id = id;
+    this.name = id.split('/').pop();
+  }
+
+  /**
+   * Create a table.
+   *
+   * @param {object} [options] See {@link Instance#createTable}.
+   * @param {object} [options.gaxOptions]  Request configuration options, outlined
+   *     here: https://googleapis.github.io/gax-nodejs/global.html#CallOptions.
+   * @param {function} callback The callback function.
+   * @param {?error} callback.err An error returned while making this request.
+   * @param {Table} callback.table The newly created table.
+   * @param {object} callback.apiResponse The full API response.
+   * @example
+   * table.create(function(err, table, apiResponse) {
+   *   if (!err) {
+   *     // The table was created successfully.
+   *   }
+   * });
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * table.create().then(function(data) {
+   *   var table = data[0];
+   *   var apiResponse = data[1];
+   * });
+   */
+  create(options, callback) {
+    if (is.fn(options)) {
+      callback = options;
+      options = {};
+    }
+
+    this.instance.createTable(this.name, options, callback);
+  }
+
+  /**
+   * Create a column family.
+   *
+   * Optionally you can send garbage collection rules and when creating a family.
+   * Garbage collection executes opportunistically in the background, so it's
+   * possible for reads to return a cell even if it matches the active expression
+   * for its family.
+   *
+   * @see [Garbage Collection Proto Docs]{@link https://github.com/googleapis/googleapis/blob/master/google/bigtable/admin/table/v1/bigtable_table_data.proto#L59}
+   *
+   * @throws {error} If a name is not provided.
+   *
+   * @param {string} name The name of column family.
+   * @param {object} [options] Configuration object.
+   * @param {object} [options.gaxOptions] Request configuration options, outlined
+   *     here: https://googleapis.github.io/gax-nodejs/global.html#CallOptions.
+   * @param {object} [options.rule] Garbage collection rule
+   * @param {object} [options.rule.age] Delete cells in a column older than the
+   *     given age. Values must be at least 1 millisecond.
+   * @param {number} [options.rule.versions] Maximum number of versions to delete
+   *     cells in a column, except for the most recent.
+   * @param {boolean} [options.rule.intersect] Cells to delete should match all
+   *     rules.
+   * @param {boolean} [options.rule.union] Cells to delete should match any of the
+   *     rules.
+   * @param {function} callback The callback function.
+   * @param {?error} callback.err An error returned while making this request.
+   * @param {Family} callback.family The newly created Family.
+   * @param {object} callback.apiResponse The full API response.
+   *
+   * @example
+   * const Bigtable = require('@google-cloud/bigtable');
+   * const bigtable = new Bigtable();
+   * const instance = bigtable.instance('my-instance');
+   * const table = instance.table('prezzy');
+   *
+   * const callback = function(err, family, apiResponse) {
+   *   // `family` is a Family object
+   * };
+   *
+   * const options={};
+   *
+   * options.rule = {
+   *   age: {
+   *     seconds: 0,
+   *     nanos: 5000
+   *   },
+   *   versions: 3,
+   *   union: true
+   * };
+   *
+   * table.createFamily('follows', options, callback);
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * table.createFamily('follows').then(function(data) {
+   *   const family = data[0];
+   *   const apiResponse = data[1];
+   * });
+   *
+   * // Note that rules can have nested rules. For example The following rule
+   * // will delete cells that are either older than 10 versions OR if the cell
+   * // is is a month old and has at least 2 newer version.
+   * // Essentially: (version > 10 OR (age > 30 AND version > 2))
+   * const rule = {
+   *   union: true,
+   *   versions: 10,
+   *   rule: {
+   *     versions: 2,
+   *     age: { seconds: 60 * 60 * 24 * 30 }, // one month
+   *   },
+   * };
+   */
+  createFamily(name, options, callback) {
+    const self = this;
+
+    if (is.function(options)) {
+      callback = options;
+      options = {};
+    }
+
+    if (!name) {
+      throw new Error('A name is required to create a family.');
+    }
+
+    const mod = {
+      id: name,
+      create: {},
+    };
+
+    if (options.rule) {
+      mod.create.gcRule = Family.formatRule_(options.rule);
+    }
+
+    const reqOpts = {
+      name: this.id,
+      modifications: [mod],
+    };
+
+    this.bigtable.request(
+      {
+        client: 'BigtableTableAdminClient',
+        method: 'modifyColumnFamilies',
+        reqOpts,
+        gaxOpts: options.gaxOptions,
+      },
+      (err, resp) => {
+        if (err) {
+          callback(err, null, resp);
+          return;
+        }
+
+        const family = self.family(resp.name);
+        family.metadata = resp;
+
+        callback(null, family, resp);
+      }
+    );
+  }
+
+  /**
+   * Get {@link Row} objects for the rows currently in your table as a
+   * readable object stream.
+   *
+   * @param {object} [options] Configuration object.
+   * @param {boolean} [options.decode=true] If set to `false` it will not decode
+   *     Buffer values returned from Bigtable.
+   * @param {string} [options.end] End value for key range.
+   * @param {Filter} [options.filter] Row filters allow you to
+   *     both make advanced queries and format how the data is returned.
+   * @param {object} [options.gaxOptions] Request configuration options, outlined
+   *     here: https://googleapis.github.io/gax-nodejs/CallSettings.html.
+   * @param {string[]} [options.keys] A list of row keys.
+   * @param {number} [options.limit] Maximum number of rows to be returned.
+   * @param {string} [options.prefix] Prefix that the row key must match.
+   * @param {string[]} [options.prefixes] List of prefixes that a row key must
+   *     match.
+   * @param {object[]} [options.ranges] A list of key ranges.
+   * @param {string} [options.start] Start value for key range.
+   * @returns {stream}
+   *
+   * @example
+   * const Bigtable = require('@google-cloud/bigtable');
+   * const bigtable = new Bigtable();
+   * const instance = bigtable.instance('my-instance');
+   * const table = instance.table('prezzy');
+   *
+   * table.createReadStream()
+   *   .on('error', console.error)
+   *   .on('data', function(row) {
+   *     // `row` is a Row object.
+   *   })
+   *   .on('end', function() {
+   *     // All rows retrieved.
+   *   });
+   *
+   * //-
+   * // If you anticipate many results, you can end a stream early to prevent
+   * // unnecessary processing.
+   * //-
+   * table.createReadStream()
+   *   .on('data', function(row) {
+   *     this.end();
+   *   });
+   *
+   * //-
+   * // Specify arbitrary keys for a non-contiguous set of rows.
+   * // The total size of the keys must remain under 1MB, after encoding.
+   * //-
+   * table.createReadStream({
+   *   keys: [
+   *     'alincoln',
+   *     'gwashington'
+   *   ]
+   * });
+   *
+   * //-
+   * // Scan for row keys that contain a specific prefix.
+   * //-
+   * table.createReadStream({
+   *   prefix: 'gwash'
+   * });
+   *
+   * //-
+   * // Specify a contiguous range of rows to read by supplying `start` and `end`
+   * // keys.
+   * //
+   * // If the `start` key is omitted, it is interpreted as an empty string.
+   * // If the `end` key is omitted, it is interpreted as infinity.
+   * //-
+   * table.createReadStream({
+   *   start: 'alincoln',
+   *   end: 'gwashington'
+   * });
+   *
+   * //-
+   * // Specify multiple ranges.
+   * //-
+   * table.createReadStream({
+   *   ranges: [{
+   *     start: 'alincoln',
+   *     end: 'gwashington'
+   *   }, {
+   *     start: 'tjefferson',
+   *     end: 'jadams'
+   *   }]
+   * });
+   *
+   * //-
+   * // Apply a {@link Filter} to the contents of the specified rows.
+   * //-
+   * table.createReadStream({
+   *   filter: [
+   *     {
+   *       column: 'gwashington'
+   *     }, {
+   *       value: 1
+   *     }
+   *   ]
+   * });
+   */
+  createReadStream(options) {
+    const self = this;
+
+    options = options || {};
+    let maxRetries = is.number(this.maxRetries) ? this.maxRetries : 3;
+
+    let rowKeys;
+    let ranges = options.ranges || [];
+    let filter;
+    let rowsLimit;
+    let rowsRead = 0;
+    let numRequestsMade = 0;
+
+    if (options.start || options.end) {
+      ranges.push({
+        start: options.start,
+        end: options.end,
+      });
+    }
+
+    if (options.keys) {
+      rowKeys = options.keys;
+    }
+
+    if (options.prefix) {
+      ranges.push(Table.createPrefixRange_(options.prefix));
+    }
+
+    if (options.prefixes) {
+      options.prefixes.forEach(prefix => {
+        ranges.push(Table.createPrefixRange_(prefix));
+      });
+    }
+
+    if (options.filter) {
+      filter = Filter.parse(options.filter);
+    }
+
+    if (options.limit) {
+      rowsLimit = options.limit;
+    }
+
+    const userStream = through.obj();
+    let chunkTransformer;
+
+    const makeNewRequest = () => {
+      let lastRowKey = chunkTransformer ? chunkTransformer.lastRowKey : '';
+      chunkTransformer = new ChunkTransformer({decode: options.decode});
+
+      const reqOpts = {
+        tableName: this.id,
+        appProfileId: this.bigtable.appProfileId,
+      };
+
+      const retryOpts = {
+        currentRetryAttempt: numRequestsMade,
+      };
+
+      if (lastRowKey) {
+        const lessThan = (lhs, rhs) => {
+          const lhsBytes = Mutation.convertToBytes(lhs);
+          const rhsBytes = Mutation.convertToBytes(rhs);
+          return lhsBytes.compare(rhsBytes) === -1;
+        };
+        const greaterThan = (lhs, rhs) => lessThan(rhs, lhs);
+        const greaterThanOrEqualTo = (lhs, rhs) => !lessThan(rhs, lhs);
+
+        if (ranges.length === 0) {
+          ranges.push({
+            start: {
+              value: lastRowKey,
+              inclusive: false,
+            },
+          });
+        } else {
+          // Readjust and/or remove ranges based on previous valid row reads.
+
+          // Iterate backward since items may need to be removed.
+          for (let index = ranges.length - 1; index >= 0; index--) {
+            const range = ranges[index];
+            const startValue = is.object(range.start)
+              ? range.start.value
+              : range.start;
+            const endValue = is.object(range.end) ? range.end.value : range.end;
+            const isWithinStart =
+              !startValue || greaterThanOrEqualTo(startValue, lastRowKey);
+            const isWithinEnd = !endValue || lessThan(lastRowKey, endValue);
+            if (isWithinStart) {
+              if (isWithinEnd) {
+                // The lastRowKey is within this range, adjust the start value.
+                range.start = {
+                  value: lastRowKey,
+                  inclusive: false,
+                };
+              } else {
+                // The lastRowKey is past this range, remove this range.
+                ranges.splice(index, 1);
+              }
+            }
+          }
+        }
+
+        // Remove rowKeys already read.
+        if (rowKeys) {
+          rowKeys = rowKeys.filter(rowKey => greaterThan(rowKey, lastRowKey));
+          if (rowKeys.length === 0) {
+            rowKeys = null;
+          }
+        }
+      }
+      if (rowKeys || ranges.length) {
+        reqOpts.rows = {};
+
+        if (rowKeys) {
+          reqOpts.rows.rowKeys = rowKeys.map(Mutation.convertToBytes);
+        }
+
+        if (ranges.length) {
+          reqOpts.rows.rowRanges = ranges.map(({start, end}) => Filter.createRange(start, end, 'Key'));
+        }
+      }
+
+      if (filter) {
+        reqOpts.filter = filter;
+      }
+
+      if (rowsLimit) {
+        reqOpts.rowsLimit = rowsLimit - rowsRead;
+      }
+
+      const requestStream = this.bigtable.request({
+        client: 'BigtableClient',
+        method: 'readRows',
+        reqOpts,
+        gaxOpts: options.gaxOptions,
+        retryOpts,
+      });
+
+      requestStream.on('request', () => numRequestsMade++);
+
+      const rowStream = pumpify.obj([
+        requestStream,
+        chunkTransformer,
+        through.obj(({key, data}, enc, next) => {
+          if (chunkTransformer._destroyed || userStream._writableState.ended) {
+            return next();
+          }
+          numRequestsMade = 0;
+          rowsRead++;
+          const row = self.row(key);
+          row.data = data;
+          next(null, row);
+        }),
+      ]);
+
+      rowStream.on('error', error => {
+        rowStream.unpipe(userStream);
+        if (
+          numRequestsMade <= maxRetries &&
+          RETRYABLE_STATUS_CODES.has(error.code)
+        ) {
+          makeNewRequest();
+        } else {
+          userStream.emit('error', error);
+        }
+      });
+      rowStream.pipe(userStream);
+    };
+
+    makeNewRequest();
+    return userStream;
+  }
+
+  /**
+   * Delete the table.
+   *
+   * @param {object} [gaxOptions] Request configuration options, outlined
+   *     here: https://googleapis.github.io/gax-nodejs/CallSettings.html.
+   * @param {function} [callback] The callback function.
+   * @param {?error} callback.err An error returned while making this
+   *     request.
+   * @param {object} callback.apiResponse The full API response.
+   *
+   * @example
+   * table.delete(function(err, apiResponse) {});
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * table.delete().then(function(data) {
+   *   var apiResponse = data[0];
+   * });
+   */
+  delete(gaxOptions, callback) {
+    if (is.fn(gaxOptions)) {
+      callback = gaxOptions;
+      gaxOptions = {};
+    }
+
+    this.bigtable.request(
+      {
+        client: 'BigtableTableAdminClient',
+        method: 'deleteTable',
+        reqOpts: {
+          name: this.id,
+        },
+        gaxOpts: gaxOptions,
+      },
+      callback
+    );
+  }
+
+  /**
+   * Delete all rows in the table, optionally corresponding to a particular
+   * prefix.
+   *
+   * @throws {error} If a prefix is not provided.
+   *
+   * @param {string} prefix Row key prefix.
+   * @param {object} [gaxOptions] Request configuration options, outlined
+   *     here: https://googleapis.github.io/gax-nodejs/CallSettings.html.
+   * @param {function} callback The callback function.
+   * @param {?error} callback.err An error returned while making this request.
+   * @param {object} callback.apiResponse The full API response.
+   *
+   * @example
+   * const Bigtable = require('@google-cloud/bigtable');
+   * const bigtable = new Bigtable();
+   * const instance = bigtable.instance('my-instance');
+   * const table = instance.table('prezzy');
+   *
+   * //-
+   * // You can supply a prefix to delete all corresponding rows.
+   * //-
+   * const callback = function(err, apiResponse) {
+   *   if (!err) {
+   *     // Rows successfully deleted.
+   *   }
+   * };
+   *
+   * table.deleteRows('alincoln', callback);
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * table.deleteRows('alincoln').then(function(data) {
+   *   const apiResponse = data[0];
+   * });
+   */
+  deleteRows(prefix, gaxOptions, callback) {
+    if (is.function(gaxOptions)) {
+      callback = gaxOptions;
+      gaxOptions = {};
+    }
+
+    if (!prefix || is.fn(prefix)) {
+      throw new Error('A prefix is required for deleteRows.');
+    }
+
+    const reqOpts = {
+      name: this.id,
+      rowKeyPrefix: Mutation.convertToBytes(prefix),
+    };
+
+    this.bigtable.request(
+      {
+        client: 'BigtableTableAdminClient',
+        method: 'dropRowRange',
+        reqOpts,
+        gaxOpts: gaxOptions,
+      },
+      callback
+    );
+  }
+
+  /**
+   * Check if a table exists.
+   *
+   * @param {object} [gaxOptions] Request configuration options, outlined
+   *     here: https://googleapis.github.io/gax-nodejs/CallSettings.html.
+   * @param {function} callback The callback function.
+   * @param {?error} callback.err An error returned while making this
+   *     request.
+   * @param {boolean} callback.exists Whether the table exists or not.
+   *
+   * @example
+   * table.exists(function(err, exists) {});
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * table.exists().then(function(data) {
+   *   var exists = data[0];
+   * });
+   */
+  exists(gaxOptions, callback) {
+    if (is.fn(gaxOptions)) {
+      callback = gaxOptions;
+      gaxOptions = {};
+    }
+
+    this.getMetadata(gaxOptions, err => {
+      if (err) {
+        if (err.code === 5) {
+          callback(null, false);
+          return;
+        }
+
+        callback(err);
+        return;
+      }
+
+      callback(null, true);
+    });
+  }
+
+  /**
+   * Get a reference to a Table Family.
+   *
+   * @throws {error} If a name is not provided.
+   *
+   * @param {string} name The family name.
+   * @returns {Family}
+   *
+   * @example
+   * const family = table.family('my-family');
+   */
+  family(name) {
+    if (!name) {
+      throw new Error('A family name must be provided.');
+    }
+
+    return new Family(this, name);
+  }
+
+  /**
+   * Get a table if it exists.
+   *
+   * You may optionally use this to "get or create" an object by providing an
+   * object with `autoCreate` set to `true`. Any extra configuration that is
+   * normally required for the `create` method must be contained within this
+   * object as well.
+   *
+   * @param {object} [options] Configuration object.
+   * @param {boolean} [options.autoCreate=false] Automatically create the
+   *     instance if it does not already exist.
+   * @param {object} [options.gaxOptions] Request configuration options, outlined
+   *     here: https://googleapis.github.io/gax-nodejs/CallSettings.html.
+   * @param {?error} callback.error An error returned while making this request.
+   * @param {Table} callback.table The Table object.
+   * @param {object} callback.apiResponse The resource as it exists in the API.
+   *
+   * @example
+   * table.get(function(err, table, apiResponse) {
+   *   // The `table` data has been populated.
+   * });
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * table.get().then(function(data) {
+   *   var table = data[0];
+   *   var apiResponse = data[0];
+   * });
+   */
+  get(options, callback) {
+    const self = this;
+
+    if (is.fn(options)) {
+      callback = options;
+      options = {};
+    }
+
+    const autoCreate = !!options.autoCreate;
+    const gaxOptions = options.gaxOptions;
+
+    this.getMetadata({gaxOptions}, (err, metadata) => {
+      if (err) {
+        if (err.code === 5 && autoCreate) {
+          self.create({gaxOptions}, callback);
+          return;
+        }
+
+        callback(err);
+        return;
+      }
+
+      callback(null, self, metadata);
+    });
+  }
+
+  /**
+   * Get Family objects for all the column familes in your table.
+   *
+   * @param {object} [gaxOptions] Request configuration options, outlined here:
+   *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
+   * @param {function} callback The callback function.
+   * @param {?error} callback.err An error returned while making this request.
+   * @param {Family[]} callback.families The list of families.
+   * @param {object} callback.apiResponse The full API response.
+   *
+   * @example
+   * const Bigtable = require('@google-cloud/bigtable');
+   * const bigtable = new Bigtable();
+   * const instance = bigtable.instance('my-instance');
+   * const table = instance.table('prezzy');
+   *
+   * table.getFamilies(function(err, families, apiResponse) {
+   *   // `families` is an array of Family objects.
+   * });
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * table.getFamilies().then(function(data) {
+   *   var families = data[0];
+   *   var apiResponse = data[1];
+   * });
+   */
+  getFamilies(gaxOptions, callback) {
+    const self = this;
+
+    if (is.fn(gaxOptions)) {
+      callback = gaxOptions;
+      gaxOptions = {};
+    }
+
+    this.getMetadata({gaxOptions}, (err, {columnFamilies}) => {
+      if (err) {
+        callback(err);
+        return;
+      }
+
+      const families = Object.keys(columnFamilies).map(familyId => {
+        const family = self.family(familyId);
+        family.metadata = columnFamilies[familyId];
+        return family;
+      });
+
+      callback(null, families, columnFamilies);
+    });
+  }
+
+  /**
+   * Get the table's metadata.
+   *
+   * @param {object} [options] Table request options.
+   * @param {object} [options.gaxOptions] Request configuration options, outlined
+   *     here: https://googleapis.github.io/gax-nodejs/CallSettings.html.
+   * @param {string} [options.view] The view to be applied to the table fields.
+   * @param {function} [callback] The callback function.
+   * @param {?error} callback.err An error returned while making this
+   *     request.
+   * @param {object} callback.metadata The table's metadata.
+   *
+   * @example
+   * const Bigtable = require('@google-cloud/bigtable');
+   * const bigtable = new Bigtable();
+   * const instance = bigtable.instance('my-instance');
+   * const table = instance.table('prezzy');
+   *
+   * table.getMetadata(function(err, metadata) {});
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * table.getMetadata().then(function(data) {
+   *   var metadata = data[0];
+   *   var apiResponse = data[1];
+   * });
+   */
+  getMetadata(options, callback) {
+    const self = this;
+
+    if (is.function(options)) {
+      callback = options;
+      options = {};
+    }
+
+    const reqOpts = {
+      name: this.id,
+      view: Table.VIEWS[options.view || 'unspecified'],
+    };
+
+    this.bigtable.request(
+      {
+        client: 'BigtableTableAdminClient',
+        method: 'getTable',
+        reqOpts,
+        gaxOpts: options.gaxOptions,
+      },
+      (...args) => {
+        if (args[1]) {
+          self.metadata = args[1];
+        }
+
+        callback(...args);
+      }
+    );
+  }
+
+  /**
+   * Get {@link Row} objects for the rows currently in your table.
+   *
+   * This method is not recommended for large datasets as it will buffer all rows
+   * before returning the results. Instead we recommend using the streaming API
+   * via {@link Table#createReadStream}.
+   *
+   * @param {object} [options] Configuration object. See
+   *     {@link Table#createReadStream} for a complete list of options.
+   * @param {object} [options.gaxOptions] Request configuration options, outlined
+   *     here: https://googleapis.github.io/gax-nodejs/CallSettings.html.
+   * @param {function} callback The callback function.
+   * @param {?error} callback.err An error returned while making this request.
+   * @param {Row[]} callback.rows List of Row objects.
+   *
+   * @example
+   * const Bigtable = require('@google-cloud/bigtable');
+   * const bigtable = new Bigtable();
+   * const instance = bigtable.instance('my-instance');
+   * const table = instance.table('prezzy');
+   *
+   * table.getRows(function(err, rows) {
+   *   if (!err) {
+   *     // `rows` is an array of Row objects.
+   *   }
+   * });
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * table.getRows().then(function(data) {
+   *   var rows = data[0];
+   * });
+   */
+  getRows(options, callback) {
+    if (is.function(options)) {
+      callback = options;
+      options = {};
+    }
+
+    this.createReadStream(options)
+      .on('error', callback)
+      .pipe(
+        concat(rows => {
+          callback(null, rows);
+        })
+      );
+  }
+
+  /**
+   * Insert or update rows in your table. It should be noted that gRPC only allows
+   * you to send payloads that are less than or equal to 4MB. If you're inserting
+   * more than that you may need to send smaller individual requests.
+   *
+   * @param {object|object[]} entries List of entries to be inserted.
+   *     See {@link Table#mutate}.
+   * @param {object} [gaxOptions] Request configuration options, outlined here:
+   *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
+   * @param {function} callback The callback function.
+   * @param {?error} callback.err An error returned while making this request.
+   * @param {object[]} callback.err.errors If present, these represent partial
+   *     failures. It's possible for part of your request to be completed
+   *     successfully, while the other part was not.
+   *
+   * @example
+   * const Bigtable = require('@google-cloud/bigtable');
+   * const bigtable = new Bigtable();
+   * const instance = bigtable.instance('my-instance');
+   * const table = instance.table('prezzy');
+   *
+   * const callback = function(err) {
+   *   if (err) {
+   *     // An API error or partial failure occurred.
+   *
+   *     if (err.name === 'PartialFailureError') {
+   *       // err.errors[].code = 'Response code'
+   *       // err.errors[].message = 'Error message'
+   *       // err.errors[].entry = The original entry
+   *     }
+   *   }
+   * };
+   *
+   * const entries = [
+   *  {
+   *     key: 'alincoln',
+   *     data: {
+   *       follows: {
+   *         gwashington: 1
+   *       }
+   *     }
+   *   }
+   * ];
+   *
+   * table.insert(entries, callback);
+   *
+   * //-
+   * // By default whenever you insert new data, the server will capture a
+   * // timestamp of when your data was inserted. It's possible to provide a
+   * // date object to be used instead.
+   * //-
+   * const entries = [
+   *   {
+   *     key: 'gwashington',
+   *     data: {
+   *       follows: {
+   *         jadams: {
+   *           value: 1,
+   *           timestamp: new Date('March 22, 2016')
+   *         }
+   *       }
+   *     }
+   *   }
+   * ];
+   *
+   * table.insert(entries, callback);
+   *
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * table.insert(entries).then(function() {
+   *   // All requested inserts have been processed.
+   * });
+   * //-
+   */
+  insert(entries, gaxOptions, callback) {
+    if (is.fn(gaxOptions)) {
+      callback = gaxOptions;
+      gaxOptions = {};
+    }
+
+    entries = arrify(entries).map(propAssign('method', Mutation.methods.INSERT));
+
+    return this.mutate(entries, gaxOptions, callback);
+  }
+
+  /**
+   * Apply a set of changes to be atomically applied to the specified row(s).
+   * Mutations are applied in order, meaning that earlier mutations can be masked
+   * by later ones.
+   *
+   * @param {object|object[]} entries List of entities to be inserted or
+   *     deleted.
+   * @param {object} [gaxOptions] Request configuration options, outlined here:
+   *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
+   * @param {function} callback The callback function.
+   * @param {?error} callback.err An error returned while making this request.
+   * @param {object[]} callback.err.errors If present, these represent partial
+   *     failures. It's possible for part of your request to be completed
+   *     successfully, while the other part was not.
+   *
+   * @example
+   * const Bigtable = require('@google-cloud/bigtable');
+   * const bigtable = new Bigtable();
+   * const instance = bigtable.instance('my-instance');
+   * const table = instance.table('prezzy');
+   *
+   * //-
+   * // Insert entities. See {@link Table#insert}.
+   * //-
+   * const callback = function(err) {
+   *   if (err) {
+   *     // An API error or partial failure occurred.
+   *
+   *     if (err.name === 'PartialFailureError') {
+   *       // err.errors[].code = 'Response code'
+   *       // err.errors[].message = 'Error message'
+   *       // err.errors[].entry = The original entry
+   *     }
+   *   }
+   * };
+   *
+   * const entries = [
+   *   {
+   *     method: 'insert',
+   *     key: 'gwashington',
+   *     data: {
+   *       follows: {
+   *         jadams: 1
+   *       }
+   *     }
+   *   }
+   * ];
+   *
+   * table.mutate(entries, callback);
+   *
+   * //-
+   * // Delete entities. See {@link Row#deleteCells}.
+   * //-
+   * const entries = [
+   *   {
+   *     method: 'delete',
+   *     key: 'gwashington'
+   *   }
+   * ];
+   *
+   * table.mutate(entries, callback);
+   *
+   * //-
+   * // Delete specific columns within a row.
+   * //-
+   * const entries = [
+   *   {
+   *     method: 'delete',
+   *     key: 'gwashington',
+   *     data: [
+   *       'follows:jadams'
+   *     ]
+   *   }
+   * ];
+   *
+   * table.mutate(entries, callback);
+   *
+   * //-
+   * // Mix and match mutations. This must contain at least one entry and at
+   * // most 100,000.
+   * //-
+   * const entries = [
+   *   {
+   *     method: 'insert',
+   *     key: 'alincoln',
+   *     data: {
+   *       follows: {
+   *         gwashington: 1
+   *       }
+   *     }
+   *   }, {
+   *     method: 'delete',
+   *     key: 'jadams',
+   *     data: [
+   *       'follows:gwashington'
+   *     ]
+   *   }
+   * ];
+   *
+   * table.mutate(entries, callback);
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * table.mutate(entries).then(function() {
+   *   // All requested mutations have been processed.
+   * });
+   */
+  mutate(entries, gaxOptions, callback) {
+    const self = this;
+
+    if (is.fn(gaxOptions)) {
+      callback = gaxOptions;
+      gaxOptions = {};
+    }
+
+    entries = flatten(arrify(entries));
+
+    let numRequestsMade = 0;
+
+    const maxRetries = is.number(this.maxRetries) ? this.maxRetries : 3;
+    const pendingEntryIndices = new Set(entries.map((entry, index) => index));
+    const entryToIndex = new Map(entries.map((entry, index) => [entry, index]));
+    const mutationErrorsByEntryIndex = new Map();
+
+    function onBatchResponse(err) {
+      if (err) {
+        // The error happened before a request was even made, don't retry.
+        callback(err);
+        return;
+      }
+      if (pendingEntryIndices.size !== 0 && numRequestsMade <= maxRetries) {
+        makeNextBatchRequest();
+        return;
+      }
+
+      if (mutationErrorsByEntryIndex.size !== 0) {
+        const mutationErrors = Array.from(mutationErrorsByEntryIndex.values());
+        err = new common.util.PartialFailureError({
+          errors: mutationErrors,
+        });
+      }
+
+      callback(err);
+    }
+
+    function makeNextBatchRequest() {
+      const entryBatch = entries.filter((entry, index) => {
+        return pendingEntryIndices.has(index);
+      });
+
+      const reqOpts = {
+        tableName: self.id,
+        appProfileId: self.bigtable.appProfileId,
+        entries: entryBatch.map(Mutation.parse),
+      };
+
+      const retryOpts = {
+        currentRetryAttempt: numRequestsMade,
+      };
+
+      self.bigtable
+        .request({
+          client: 'BigtableClient',
+          method: 'mutateRows',
+          reqOpts,
+          gaxOpts: gaxOptions,
+          retryOpts,
+        })
+        .on('request', () => numRequestsMade++)
+        .on('error', err => {
+          if (numRequestsMade === 0) {
+            callback(err); // Likely a "projectId not detected" error.
+            return;
+          }
+
+          onBatchResponse(err);
+        })
+        .on('data', obj => {
+          obj.entries.forEach(entry => {
+            const originalEntry = entryBatch[entry.index];
+            const originalEntriesIndex = entryToIndex.get(originalEntry);
+
+            // Mutation was successful.
+            if (entry.status.code === 0) {
+              pendingEntryIndices.delete(originalEntriesIndex);
+              mutationErrorsByEntryIndex.delete(originalEntriesIndex);
+              return;
+            }
+
+            if (!RETRYABLE_STATUS_CODES.has(entry.status.code)) {
+              pendingEntryIndices.delete(originalEntriesIndex);
+            }
+
+            const status = commonGrpc.Service.decorateStatus_(entry.status);
+            status.entry = originalEntry;
+
+            mutationErrorsByEntryIndex.set(originalEntriesIndex, status);
+          });
+        })
+        .on('end', onBatchResponse);
+    }
+
+    makeNextBatchRequest();
+  }
+
+  /**
+   * Get a reference to a table row.
+   *
+   * @throws {error} If a key is not provided.
+   *
+   * @param {string} key The row key.
+   * @returns {Row}
+   *
+   * @example
+   * var row = table.row('lincoln');
+   */
+  row(key) {
+    if (!key) {
+      throw new Error('A row key must be provided.');
+    }
+
+    return new Row(this, key);
+  }
+
+  /**
+   * Returns a sample of row keys in the table. The returned row keys will delimit
+   * contigous sections of the table of approximately equal size, which can be
+   * used to break up the data for distributed tasks like mapreduces.
+   *
+   * @param {object} [gaxOptions] Request configuration options, outlined here:
+   *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
+   * @param {function} [callback] The callback function.
+   * @param {?error} callback.err An error returned while making this request.
+   * @param {object[]} callback.keys The list of keys.
+   *
+   * @example
+   * table.sampleRowKeys(function(err, keys) {
+   *   // keys = [
+   *   //   {
+   *   //     key: '',
+   *   //     offset: '805306368'
+   *   //   },
+   *   //   ...
+   *   // ]
+   * });
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * table.sampleRowKeys().then(function(data) {
+   *   var keys = data[0];
+   * });
+   */
+  sampleRowKeys(gaxOptions, callback) {
+    if (is.fn(gaxOptions)) {
+      callback = gaxOptions;
+      gaxOptions = {};
+    }
+
+    this.sampleRowKeysStream(gaxOptions)
+      .on('error', callback)
+      .pipe(
+        concat(keys => {
+          callback(null, keys);
+        })
+      );
+  }
+
+  /**
+   * Returns a sample of row keys in the table as a readable object stream.
+   *
+   * See {@link Table#sampleRowKeys} for more details.
+   *
+   * @param {object} [gaxOptions] Request configuration options, outlined here:
+   *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
+   * @returns {stream}
+   *
+   * @example
+   * table.sampleRowKeysStream()
+   *   .on('error', console.error)
+   *   .on('data', function(key) {
+   *     // Do something with the `key` object.
+   *   });
+   *
+   * //-
+   * // If you anticipate many results, you can end a stream early to prevent
+   * // unnecessary processing.
+   * //-
+   * table.sampleRowKeysStream()
+   *   .on('data', function(key) {
+   *     this.end();
+   *   });
+   */
+  sampleRowKeysStream(gaxOptions) {
+    const reqOpts = {
+      tableName: this.id,
+      appProfileId: this.bigtable.appProfileId,
+    };
+
+    return pumpify.obj([
+      this.bigtable.request({
+        client: 'BigtableClient',
+        method: 'sampleRowKeys',
+        reqOpts,
+        gaxOpts: gaxOptions,
+      }),
+      through.obj(({rowKey, offsetBytes}, enc, next) => {
+        next(null, {
+          key: rowKey,
+          offset: offsetBytes,
+        });
+      }),
+    ]);
+  }
+
+  /**
+   * Truncate the table.
+   *
+   * @param {object} [gaxOptions] Request configuration options, outlined
+   *     here: https://googleapis.github.io/gax-nodejs/CallSettings.html.
+   * @param {function} callback The callback function.
+   * @param {?error} callback.err An error returned while making this request.
+   * @param {object} callback.apiResponse The full API response.
+   *
+   * @example
+   * table.truncate(function(err, apiResponse) {});
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * table.truncate().then(function(data) {
+   *   var apiResponse = data[0];
+   * });
+   */
+  truncate(gaxOptions, callback) {
+    if (is.fn(gaxOptions)) {
+      callback = gaxOptions;
+      gaxOptions = {};
+    }
+
+    const reqOpts = {
+      name: this.id,
+      deleteAllDataFromTable: true,
+    };
+
+    this.bigtable.request(
+      {
+        client: 'BigtableTableAdminClient',
+        method: 'dropRowRange',
+        reqOpts,
+        gaxOpts: gaxOptions,
+      },
+      callback
+    );
+  }
 }
 
 /**
@@ -87,12 +1337,12 @@ Table.VIEWS = {
  * );
  * // 'projects/my-project/zones/my-zone/instances/my-instance/tables/my-table'
  */
-Table.formatName_ = function(instanceName, name) {
-  if (name.indexOf('/') > -1) {
+Table.formatName_ = (instanceName, name) => {
+  if (name.includes('/')) {
     return name;
   }
 
-  return instanceName + '/tables/' + name;
+  return `${instanceName}/tables/${name}`;
 };
 
 /**
@@ -113,1277 +1363,25 @@ Table.formatName_ = function(instanceName, name) {
  * //   }
  * // }
  */
-Table.createPrefixRange_ = function(start) {
-  var prefix = start.replace(new RegExp('[\xff]+$'), '');
-  var endKey = '';
+Table.createPrefixRange_ = start => {
+  const prefix = start.replace(new RegExp('[\xff]+$'), '');
+  let endKey = '';
 
   if (prefix) {
-    var position = prefix.length - 1;
-    var charCode = prefix.charCodeAt(position);
-    var nextChar = String.fromCharCode(charCode + 1);
+    const position = prefix.length - 1;
+    const charCode = prefix.charCodeAt(position);
+    const nextChar = String.fromCharCode(charCode + 1);
 
     endKey = prefix.substring(0, position) + nextChar;
   }
 
   return {
-    start: start,
+    start,
     end: {
       value: endKey,
       inclusive: !endKey,
     },
   };
-};
-
-/**
- * Create a table.
- *
- * @param {object} [options] See {@link Instance#createTable}.
- * @param {object} [options.gaxOptions]  Request configuration options, outlined
- *     here: https://googleapis.github.io/gax-nodejs/global.html#CallOptions.
- * @param {function} callback The callback function.
- * @param {?error} callback.err An error returned while making this request.
- * @param {Table} callback.table The newly created table.
- * @param {object} callback.apiResponse The full API response.
- * @example
- * table.create(function(err, table, apiResponse) {
- *   if (!err) {
- *     // The table was created successfully.
- *   }
- * });
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * table.create().then(function(data) {
- *   var table = data[0];
- *   var apiResponse = data[1];
- * });
- */
-Table.prototype.create = function(options, callback) {
-  if (is.fn(options)) {
-    callback = options;
-    options = {};
-  }
-
-  this.instance.createTable(this.name, options, callback);
-};
-
-/**
- * Create a column family.
- *
- * Optionally you can send garbage collection rules and when creating a family.
- * Garbage collection executes opportunistically in the background, so it's
- * possible for reads to return a cell even if it matches the active expression
- * for its family.
- *
- * @see [Garbage Collection Proto Docs]{@link https://github.com/googleapis/googleapis/blob/master/google/bigtable/admin/table/v1/bigtable_table_data.proto#L59}
- *
- * @throws {error} If a name is not provided.
- *
- * @param {string} name The name of column family.
- * @param {object} [options] Configuration object.
- * @param {object} [options.gaxOptions] Request configuration options, outlined
- *     here: https://googleapis.github.io/gax-nodejs/global.html#CallOptions.
- * @param {object} [options.rule] Garbage collection rule
- * @param {object} [options.rule.age] Delete cells in a column older than the
- *     given age. Values must be at least 1 millisecond.
- * @param {number} [options.rule.versions] Maximum number of versions to delete
- *     cells in a column, except for the most recent.
- * @param {boolean} [options.rule.intersect] Cells to delete should match all
- *     rules.
- * @param {boolean} [options.rule.union] Cells to delete should match any of the
- *     rules.
- * @param {function} callback The callback function.
- * @param {?error} callback.err An error returned while making this request.
- * @param {Family} callback.family The newly created Family.
- * @param {object} callback.apiResponse The full API response.
- *
- * @example
- * const Bigtable = require('@google-cloud/bigtable');
- * const bigtable = new Bigtable();
- * const instance = bigtable.instance('my-instance');
- * const table = instance.table('prezzy');
- *
- * const callback = function(err, family, apiResponse) {
- *   // `family` is a Family object
- * };
- *
- * const options={};
- *
- * options.rule = {
- *   age: {
- *     seconds: 0,
- *     nanos: 5000
- *   },
- *   versions: 3,
- *   union: true
- * };
- *
- * table.createFamily('follows', options, callback);
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * table.createFamily('follows').then(function(data) {
- *   const family = data[0];
- *   const apiResponse = data[1];
- * });
- *
- * // Note that rules can have nested rules. For example The following rule
- * // will delete cells that are either older than 10 versions OR if the cell
- * // is is a month old and has at least 2 newer version.
- * // Essentially: (version > 10 OR (age > 30 AND version > 2))
- * const rule = {
- *   union: true,
- *   versions: 10,
- *   rule: {
- *     versions: 2,
- *     age: { seconds: 60 * 60 * 24 * 30 }, // one month
- *   },
- * };
- */
-Table.prototype.createFamily = function(name, options, callback) {
-  var self = this;
-
-  if (is.function(options)) {
-    callback = options;
-    options = {};
-  }
-
-  if (!name) {
-    throw new Error('A name is required to create a family.');
-  }
-
-  var mod = {
-    id: name,
-    create: {},
-  };
-
-  if (options.rule) {
-    mod.create.gcRule = Family.formatRule_(options.rule);
-  }
-
-  var reqOpts = {
-    name: this.id,
-    modifications: [mod],
-  };
-
-  this.bigtable.request(
-    {
-      client: 'BigtableTableAdminClient',
-      method: 'modifyColumnFamilies',
-      reqOpts: reqOpts,
-      gaxOpts: options.gaxOptions,
-    },
-    function(err, resp) {
-      if (err) {
-        callback(err, null, resp);
-        return;
-      }
-
-      var family = self.family(resp.name);
-      family.metadata = resp;
-
-      callback(null, family, resp);
-    }
-  );
-};
-
-/**
- * Get {@link Row} objects for the rows currently in your table as a
- * readable object stream.
- *
- * @param {object} [options] Configuration object.
- * @param {boolean} [options.decode=true] If set to `false` it will not decode
- *     Buffer values returned from Bigtable.
- * @param {string} [options.end] End value for key range.
- * @param {Filter} [options.filter] Row filters allow you to
- *     both make advanced queries and format how the data is returned.
- * @param {object} [options.gaxOptions] Request configuration options, outlined
- *     here: https://googleapis.github.io/gax-nodejs/CallSettings.html.
- * @param {string[]} [options.keys] A list of row keys.
- * @param {number} [options.limit] Maximum number of rows to be returned.
- * @param {string} [options.prefix] Prefix that the row key must match.
- * @param {string[]} [options.prefixes] List of prefixes that a row key must
- *     match.
- * @param {object[]} [options.ranges] A list of key ranges.
- * @param {string} [options.start] Start value for key range.
- * @returns {stream}
- *
- * @example
- * const Bigtable = require('@google-cloud/bigtable');
- * const bigtable = new Bigtable();
- * const instance = bigtable.instance('my-instance');
- * const table = instance.table('prezzy');
- *
- * table.createReadStream()
- *   .on('error', console.error)
- *   .on('data', function(row) {
- *     // `row` is a Row object.
- *   })
- *   .on('end', function() {
- *     // All rows retrieved.
- *   });
- *
- * //-
- * // If you anticipate many results, you can end a stream early to prevent
- * // unnecessary processing.
- * //-
- * table.createReadStream()
- *   .on('data', function(row) {
- *     this.end();
- *   });
- *
- * //-
- * // Specify arbitrary keys for a non-contiguous set of rows.
- * // The total size of the keys must remain under 1MB, after encoding.
- * //-
- * table.createReadStream({
- *   keys: [
- *     'alincoln',
- *     'gwashington'
- *   ]
- * });
- *
- * //-
- * // Scan for row keys that contain a specific prefix.
- * //-
- * table.createReadStream({
- *   prefix: 'gwash'
- * });
- *
- * //-
- * // Specify a contiguous range of rows to read by supplying `start` and `end`
- * // keys.
- * //
- * // If the `start` key is omitted, it is interpreted as an empty string.
- * // If the `end` key is omitted, it is interpreted as infinity.
- * //-
- * table.createReadStream({
- *   start: 'alincoln',
- *   end: 'gwashington'
- * });
- *
- * //-
- * // Specify multiple ranges.
- * //-
- * table.createReadStream({
- *   ranges: [{
- *     start: 'alincoln',
- *     end: 'gwashington'
- *   }, {
- *     start: 'tjefferson',
- *     end: 'jadams'
- *   }]
- * });
- *
- * //-
- * // Apply a {@link Filter} to the contents of the specified rows.
- * //-
- * table.createReadStream({
- *   filter: [
- *     {
- *       column: 'gwashington'
- *     }, {
- *       value: 1
- *     }
- *   ]
- * });
- */
-Table.prototype.createReadStream = function(options) {
-  var self = this;
-
-  options = options || {};
-  let maxRetries = is.number(this.maxRetries) ? this.maxRetries : 3;
-
-  let rowKeys;
-  let ranges = options.ranges || [];
-  let filter;
-  let rowsLimit;
-  let rowsRead = 0;
-  let numRequestsMade = 0;
-
-  if (options.start || options.end) {
-    ranges.push({
-      start: options.start,
-      end: options.end,
-    });
-  }
-
-  if (options.keys) {
-    rowKeys = options.keys;
-  }
-
-  if (options.prefix) {
-    ranges.push(Table.createPrefixRange_(options.prefix));
-  }
-
-  if (options.prefixes) {
-    options.prefixes.forEach(function(prefix) {
-      ranges.push(Table.createPrefixRange_(prefix));
-    });
-  }
-
-  if (options.filter) {
-    filter = Filter.parse(options.filter);
-  }
-
-  if (options.limit) {
-    rowsLimit = options.limit;
-  }
-
-  const userStream = through.obj();
-  let chunkTransformer;
-
-  const makeNewRequest = () => {
-    let lastRowKey = chunkTransformer ? chunkTransformer.lastRowKey : '';
-    chunkTransformer = new ChunkTransformer({decode: options.decode});
-
-    var reqOpts = {
-      tableName: this.id,
-      appProfileId: this.bigtable.appProfileId,
-    };
-
-    var retryOpts = {
-      currentRetryAttempt: numRequestsMade,
-    };
-
-    if (lastRowKey) {
-      const lessThan = (lhs, rhs) => {
-        const lhsBytes = Mutation.convertToBytes(lhs);
-        const rhsBytes = Mutation.convertToBytes(rhs);
-        return lhsBytes.compare(rhsBytes) === -1;
-      };
-      const greaterThan = (lhs, rhs) => lessThan(rhs, lhs);
-      const greaterThanOrEqualTo = (lhs, rhs) => !lessThan(rhs, lhs);
-
-      if (ranges.length === 0) {
-        ranges.push({
-          start: {
-            value: lastRowKey,
-            inclusive: false,
-          },
-        });
-      } else {
-        // Readjust and/or remove ranges based on previous valid row reads.
-
-        // Iterate backward since items may need to be removed.
-        for (let index = ranges.length - 1; index >= 0; index--) {
-          const range = ranges[index];
-          const startValue = is.object(range.start)
-            ? range.start.value
-            : range.start;
-          const endValue = is.object(range.end) ? range.end.value : range.end;
-          const isWithinStart =
-            !startValue || greaterThanOrEqualTo(startValue, lastRowKey);
-          const isWithinEnd = !endValue || lessThan(lastRowKey, endValue);
-          if (isWithinStart) {
-            if (isWithinEnd) {
-              // The lastRowKey is within this range, adjust the start value.
-              range.start = {
-                value: lastRowKey,
-                inclusive: false,
-              };
-            } else {
-              // The lastRowKey is past this range, remove this range.
-              ranges.splice(index, 1);
-            }
-          }
-        }
-      }
-
-      // Remove rowKeys already read.
-      if (rowKeys) {
-        rowKeys = rowKeys.filter(rowKey => greaterThan(rowKey, lastRowKey));
-        if (rowKeys.length === 0) {
-          rowKeys = null;
-        }
-      }
-    }
-    if (rowKeys || ranges.length) {
-      reqOpts.rows = {};
-
-      if (rowKeys) {
-        reqOpts.rows.rowKeys = rowKeys.map(Mutation.convertToBytes);
-      }
-
-      if (ranges.length) {
-        reqOpts.rows.rowRanges = ranges.map(function(range) {
-          return Filter.createRange(range.start, range.end, 'Key');
-        });
-      }
-    }
-
-    if (filter) {
-      reqOpts.filter = filter;
-    }
-
-    if (rowsLimit) {
-      reqOpts.rowsLimit = rowsLimit - rowsRead;
-    }
-
-    const requestStream = this.bigtable.request({
-      client: 'BigtableClient',
-      method: 'readRows',
-      reqOpts: reqOpts,
-      gaxOpts: options.gaxOptions,
-      retryOpts: retryOpts,
-    });
-
-    requestStream.on('request', () => numRequestsMade++);
-
-    const rowStream = pumpify.obj([
-      requestStream,
-      chunkTransformer,
-      through.obj(function(rowData, enc, next) {
-        if (chunkTransformer._destroyed || userStream._writableState.ended) {
-          return next();
-        }
-        numRequestsMade = 0;
-        rowsRead++;
-        const row = self.row(rowData.key);
-        row.data = rowData.data;
-        next(null, row);
-      }),
-    ]);
-
-    rowStream.on('error', error => {
-      rowStream.unpipe(userStream);
-      if (
-        numRequestsMade <= maxRetries &&
-        RETRYABLE_STATUS_CODES.has(error.code)
-      ) {
-        makeNewRequest();
-      } else {
-        userStream.emit('error', error);
-      }
-    });
-    rowStream.pipe(userStream);
-  };
-
-  makeNewRequest();
-  return userStream;
-};
-
-/**
- * Delete the table.
- *
- * @param {object} [gaxOptions] Request configuration options, outlined
- *     here: https://googleapis.github.io/gax-nodejs/CallSettings.html.
- * @param {function} [callback] The callback function.
- * @param {?error} callback.err An error returned while making this
- *     request.
- * @param {object} callback.apiResponse The full API response.
- *
- * @example
- * table.delete(function(err, apiResponse) {});
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * table.delete().then(function(data) {
- *   var apiResponse = data[0];
- * });
- */
-Table.prototype.delete = function(gaxOptions, callback) {
-  if (is.fn(gaxOptions)) {
-    callback = gaxOptions;
-    gaxOptions = {};
-  }
-
-  this.bigtable.request(
-    {
-      client: 'BigtableTableAdminClient',
-      method: 'deleteTable',
-      reqOpts: {
-        name: this.id,
-      },
-      gaxOpts: gaxOptions,
-    },
-    callback
-  );
-};
-
-/**
- * Delete all rows in the table, optionally corresponding to a particular
- * prefix.
- *
- * @throws {error} If a prefix is not provided.
- *
- * @param {string} prefix Row key prefix.
- * @param {object} [gaxOptions] Request configuration options, outlined
- *     here: https://googleapis.github.io/gax-nodejs/CallSettings.html.
- * @param {function} callback The callback function.
- * @param {?error} callback.err An error returned while making this request.
- * @param {object} callback.apiResponse The full API response.
- *
- * @example
- * const Bigtable = require('@google-cloud/bigtable');
- * const bigtable = new Bigtable();
- * const instance = bigtable.instance('my-instance');
- * const table = instance.table('prezzy');
- *
- * //-
- * // You can supply a prefix to delete all corresponding rows.
- * //-
- * const callback = function(err, apiResponse) {
- *   if (!err) {
- *     // Rows successfully deleted.
- *   }
- * };
- *
- * table.deleteRows('alincoln', callback);
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * table.deleteRows('alincoln').then(function(data) {
- *   const apiResponse = data[0];
- * });
- */
-Table.prototype.deleteRows = function(prefix, gaxOptions, callback) {
-  if (is.function(gaxOptions)) {
-    callback = gaxOptions;
-    gaxOptions = {};
-  }
-
-  if (!prefix || is.fn(prefix)) {
-    throw new Error('A prefix is required for deleteRows.');
-  }
-
-  var reqOpts = {
-    name: this.id,
-    rowKeyPrefix: Mutation.convertToBytes(prefix),
-  };
-
-  this.bigtable.request(
-    {
-      client: 'BigtableTableAdminClient',
-      method: 'dropRowRange',
-      reqOpts: reqOpts,
-      gaxOpts: gaxOptions,
-    },
-    callback
-  );
-};
-
-/**
- * Check if a table exists.
- *
- * @param {object} [gaxOptions] Request configuration options, outlined
- *     here: https://googleapis.github.io/gax-nodejs/CallSettings.html.
- * @param {function} callback The callback function.
- * @param {?error} callback.err An error returned while making this
- *     request.
- * @param {boolean} callback.exists Whether the table exists or not.
- *
- * @example
- * table.exists(function(err, exists) {});
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * table.exists().then(function(data) {
- *   var exists = data[0];
- * });
- */
-Table.prototype.exists = function(gaxOptions, callback) {
-  if (is.fn(gaxOptions)) {
-    callback = gaxOptions;
-    gaxOptions = {};
-  }
-
-  this.getMetadata(gaxOptions, function(err) {
-    if (err) {
-      if (err.code === 5) {
-        callback(null, false);
-        return;
-      }
-
-      callback(err);
-      return;
-    }
-
-    callback(null, true);
-  });
-};
-
-/**
- * Get a reference to a Table Family.
- *
- * @throws {error} If a name is not provided.
- *
- * @param {string} name The family name.
- * @returns {Family}
- *
- * @example
- * const family = table.family('my-family');
- */
-Table.prototype.family = function(name) {
-  if (!name) {
-    throw new Error('A family name must be provided.');
-  }
-
-  return new Family(this, name);
-};
-
-/**
- * Get a table if it exists.
- *
- * You may optionally use this to "get or create" an object by providing an
- * object with `autoCreate` set to `true`. Any extra configuration that is
- * normally required for the `create` method must be contained within this
- * object as well.
- *
- * @param {object} [options] Configuration object.
- * @param {boolean} [options.autoCreate=false] Automatically create the
- *     instance if it does not already exist.
- * @param {object} [options.gaxOptions] Request configuration options, outlined
- *     here: https://googleapis.github.io/gax-nodejs/CallSettings.html.
- * @param {?error} callback.error An error returned while making this request.
- * @param {Table} callback.table The Table object.
- * @param {object} callback.apiResponse The resource as it exists in the API.
- *
- * @example
- * table.get(function(err, table, apiResponse) {
- *   // The `table` data has been populated.
- * });
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * table.get().then(function(data) {
- *   var table = data[0];
- *   var apiResponse = data[0];
- * });
- */
-Table.prototype.get = function(options, callback) {
-  var self = this;
-
-  if (is.fn(options)) {
-    callback = options;
-    options = {};
-  }
-
-  var autoCreate = !!options.autoCreate;
-  var gaxOptions = options.gaxOptions;
-
-  this.getMetadata({gaxOptions}, function(err, metadata) {
-    if (err) {
-      if (err.code === 5 && autoCreate) {
-        self.create({gaxOptions}, callback);
-        return;
-      }
-
-      callback(err);
-      return;
-    }
-
-    callback(null, self, metadata);
-  });
-};
-
-/**
- * Get Family objects for all the column familes in your table.
- *
- * @param {object} [gaxOptions] Request configuration options, outlined here:
- *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
- * @param {function} callback The callback function.
- * @param {?error} callback.err An error returned while making this request.
- * @param {Family[]} callback.families The list of families.
- * @param {object} callback.apiResponse The full API response.
- *
- * @example
- * const Bigtable = require('@google-cloud/bigtable');
- * const bigtable = new Bigtable();
- * const instance = bigtable.instance('my-instance');
- * const table = instance.table('prezzy');
- *
- * table.getFamilies(function(err, families, apiResponse) {
- *   // `families` is an array of Family objects.
- * });
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * table.getFamilies().then(function(data) {
- *   var families = data[0];
- *   var apiResponse = data[1];
- * });
- */
-Table.prototype.getFamilies = function(gaxOptions, callback) {
-  var self = this;
-
-  if (is.fn(gaxOptions)) {
-    callback = gaxOptions;
-    gaxOptions = {};
-  }
-
-  this.getMetadata({gaxOptions}, function(err, metadata) {
-    if (err) {
-      callback(err);
-      return;
-    }
-
-    var families = Object.keys(metadata.columnFamilies).map(function(familyId) {
-      var family = self.family(familyId);
-      family.metadata = metadata.columnFamilies[familyId];
-      return family;
-    });
-
-    callback(null, families, metadata.columnFamilies);
-  });
-};
-
-/**
- * Get the table's metadata.
- *
- * @param {object} [options] Table request options.
- * @param {object} [options.gaxOptions] Request configuration options, outlined
- *     here: https://googleapis.github.io/gax-nodejs/CallSettings.html.
- * @param {string} [options.view] The view to be applied to the table fields.
- * @param {function} [callback] The callback function.
- * @param {?error} callback.err An error returned while making this
- *     request.
- * @param {object} callback.metadata The table's metadata.
- *
- * @example
- * const Bigtable = require('@google-cloud/bigtable');
- * const bigtable = new Bigtable();
- * const instance = bigtable.instance('my-instance');
- * const table = instance.table('prezzy');
- *
- * table.getMetadata(function(err, metadata) {});
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * table.getMetadata().then(function(data) {
- *   var metadata = data[0];
- *   var apiResponse = data[1];
- * });
- */
-Table.prototype.getMetadata = function(options, callback) {
-  var self = this;
-
-  if (is.function(options)) {
-    callback = options;
-    options = {};
-  }
-
-  var reqOpts = {
-    name: this.id,
-    view: Table.VIEWS[options.view || 'unspecified'],
-  };
-
-  this.bigtable.request(
-    {
-      client: 'BigtableTableAdminClient',
-      method: 'getTable',
-      reqOpts: reqOpts,
-      gaxOpts: options.gaxOptions,
-    },
-    function() {
-      if (arguments[1]) {
-        self.metadata = arguments[1];
-      }
-
-      callback.apply(null, arguments);
-    }
-  );
-};
-
-/**
- * Get {@link Row} objects for the rows currently in your table.
- *
- * This method is not recommended for large datasets as it will buffer all rows
- * before returning the results. Instead we recommend using the streaming API
- * via {@link Table#createReadStream}.
- *
- * @param {object} [options] Configuration object. See
- *     {@link Table#createReadStream} for a complete list of options.
- * @param {object} [options.gaxOptions] Request configuration options, outlined
- *     here: https://googleapis.github.io/gax-nodejs/CallSettings.html.
- * @param {function} callback The callback function.
- * @param {?error} callback.err An error returned while making this request.
- * @param {Row[]} callback.rows List of Row objects.
- *
- * @example
- * const Bigtable = require('@google-cloud/bigtable');
- * const bigtable = new Bigtable();
- * const instance = bigtable.instance('my-instance');
- * const table = instance.table('prezzy');
- *
- * table.getRows(function(err, rows) {
- *   if (!err) {
- *     // `rows` is an array of Row objects.
- *   }
- * });
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * table.getRows().then(function(data) {
- *   var rows = data[0];
- * });
- */
-Table.prototype.getRows = function(options, callback) {
-  if (is.function(options)) {
-    callback = options;
-    options = {};
-  }
-
-  this.createReadStream(options)
-    .on('error', callback)
-    .pipe(
-      concat(function(rows) {
-        callback(null, rows);
-      })
-    );
-};
-
-/**
- * Insert or update rows in your table. It should be noted that gRPC only allows
- * you to send payloads that are less than or equal to 4MB. If you're inserting
- * more than that you may need to send smaller individual requests.
- *
- * @param {object|object[]} entries List of entries to be inserted.
- *     See {@link Table#mutate}.
- * @param {object} [gaxOptions] Request configuration options, outlined here:
- *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
- * @param {function} callback The callback function.
- * @param {?error} callback.err An error returned while making this request.
- * @param {object[]} callback.err.errors If present, these represent partial
- *     failures. It's possible for part of your request to be completed
- *     successfully, while the other part was not.
- *
- * @example
- * const Bigtable = require('@google-cloud/bigtable');
- * const bigtable = new Bigtable();
- * const instance = bigtable.instance('my-instance');
- * const table = instance.table('prezzy');
- *
- * const callback = function(err) {
- *   if (err) {
- *     // An API error or partial failure occurred.
- *
- *     if (err.name === 'PartialFailureError') {
- *       // err.errors[].code = 'Response code'
- *       // err.errors[].message = 'Error message'
- *       // err.errors[].entry = The original entry
- *     }
- *   }
- * };
- *
- * const entries = [
- *  {
- *     key: 'alincoln',
- *     data: {
- *       follows: {
- *         gwashington: 1
- *       }
- *     }
- *   }
- * ];
- *
- * table.insert(entries, callback);
- *
- * //-
- * // By default whenever you insert new data, the server will capture a
- * // timestamp of when your data was inserted. It's possible to provide a
- * // date object to be used instead.
- * //-
- * const entries = [
- *   {
- *     key: 'gwashington',
- *     data: {
- *       follows: {
- *         jadams: {
- *           value: 1,
- *           timestamp: new Date('March 22, 2016')
- *         }
- *       }
- *     }
- *   }
- * ];
- *
- * table.insert(entries, callback);
- *
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * table.insert(entries).then(function() {
- *   // All requested inserts have been processed.
- * });
- * //-
- */
-Table.prototype.insert = function(entries, gaxOptions, callback) {
-  if (is.fn(gaxOptions)) {
-    callback = gaxOptions;
-    gaxOptions = {};
-  }
-
-  entries = arrify(entries).map(propAssign('method', Mutation.methods.INSERT));
-
-  return this.mutate(entries, gaxOptions, callback);
-};
-
-/**
- * Apply a set of changes to be atomically applied to the specified row(s).
- * Mutations are applied in order, meaning that earlier mutations can be masked
- * by later ones.
- *
- * @param {object|object[]} entries List of entities to be inserted or
- *     deleted.
- * @param {object} [gaxOptions] Request configuration options, outlined here:
- *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
- * @param {function} callback The callback function.
- * @param {?error} callback.err An error returned while making this request.
- * @param {object[]} callback.err.errors If present, these represent partial
- *     failures. It's possible for part of your request to be completed
- *     successfully, while the other part was not.
- *
- * @example
- * const Bigtable = require('@google-cloud/bigtable');
- * const bigtable = new Bigtable();
- * const instance = bigtable.instance('my-instance');
- * const table = instance.table('prezzy');
- *
- * //-
- * // Insert entities. See {@link Table#insert}.
- * //-
- * const callback = function(err) {
- *   if (err) {
- *     // An API error or partial failure occurred.
- *
- *     if (err.name === 'PartialFailureError') {
- *       // err.errors[].code = 'Response code'
- *       // err.errors[].message = 'Error message'
- *       // err.errors[].entry = The original entry
- *     }
- *   }
- * };
- *
- * const entries = [
- *   {
- *     method: 'insert',
- *     key: 'gwashington',
- *     data: {
- *       follows: {
- *         jadams: 1
- *       }
- *     }
- *   }
- * ];
- *
- * table.mutate(entries, callback);
- *
- * //-
- * // Delete entities. See {@link Row#deleteCells}.
- * //-
- * const entries = [
- *   {
- *     method: 'delete',
- *     key: 'gwashington'
- *   }
- * ];
- *
- * table.mutate(entries, callback);
- *
- * //-
- * // Delete specific columns within a row.
- * //-
- * const entries = [
- *   {
- *     method: 'delete',
- *     key: 'gwashington',
- *     data: [
- *       'follows:jadams'
- *     ]
- *   }
- * ];
- *
- * table.mutate(entries, callback);
- *
- * //-
- * // Mix and match mutations. This must contain at least one entry and at
- * // most 100,000.
- * //-
- * const entries = [
- *   {
- *     method: 'insert',
- *     key: 'alincoln',
- *     data: {
- *       follows: {
- *         gwashington: 1
- *       }
- *     }
- *   }, {
- *     method: 'delete',
- *     key: 'jadams',
- *     data: [
- *       'follows:gwashington'
- *     ]
- *   }
- * ];
- *
- * table.mutate(entries, callback);
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * table.mutate(entries).then(function() {
- *   // All requested mutations have been processed.
- * });
- */
-Table.prototype.mutate = function(entries, gaxOptions, callback) {
-  var self = this;
-
-  if (is.fn(gaxOptions)) {
-    callback = gaxOptions;
-    gaxOptions = {};
-  }
-
-  entries = flatten(arrify(entries));
-
-  var numRequestsMade = 0;
-
-  var maxRetries = is.number(this.maxRetries) ? this.maxRetries : 3;
-  var pendingEntryIndices = new Set(entries.map((entry, index) => index));
-  var entryToIndex = new Map(entries.map((entry, index) => [entry, index]));
-  var mutationErrorsByEntryIndex = new Map();
-
-  function onBatchResponse(err) {
-    if (err) {
-      // The error happened before a request was even made, don't retry.
-      callback(err);
-      return;
-    }
-    if (pendingEntryIndices.size !== 0 && numRequestsMade <= maxRetries) {
-      makeNextBatchRequest();
-      return;
-    }
-
-    if (mutationErrorsByEntryIndex.size !== 0) {
-      var mutationErrors = Array.from(mutationErrorsByEntryIndex.values());
-      err = new common.util.PartialFailureError({
-        errors: mutationErrors,
-      });
-    }
-
-    callback(err);
-  }
-
-  function makeNextBatchRequest() {
-    var entryBatch = entries.filter((entry, index) => {
-      return pendingEntryIndices.has(index);
-    });
-
-    var reqOpts = {
-      tableName: self.id,
-      appProfileId: self.bigtable.appProfileId,
-      entries: entryBatch.map(Mutation.parse),
-    };
-
-    var retryOpts = {
-      currentRetryAttempt: numRequestsMade,
-    };
-
-    self.bigtable
-      .request({
-        client: 'BigtableClient',
-        method: 'mutateRows',
-        reqOpts: reqOpts,
-        gaxOpts: gaxOptions,
-        retryOpts: retryOpts,
-      })
-      .on('request', () => numRequestsMade++)
-      .on('error', err => {
-        if (numRequestsMade === 0) {
-          callback(err); // Likely a "projectId not detected" error.
-          return;
-        }
-
-        onBatchResponse(err);
-      })
-      .on('data', function(obj) {
-        obj.entries.forEach(function(entry) {
-          var originalEntry = entryBatch[entry.index];
-          var originalEntriesIndex = entryToIndex.get(originalEntry);
-
-          // Mutation was successful.
-          if (entry.status.code === 0) {
-            pendingEntryIndices.delete(originalEntriesIndex);
-            mutationErrorsByEntryIndex.delete(originalEntriesIndex);
-            return;
-          }
-
-          if (!RETRYABLE_STATUS_CODES.has(entry.status.code)) {
-            pendingEntryIndices.delete(originalEntriesIndex);
-          }
-
-          var status = commonGrpc.Service.decorateStatus_(entry.status);
-          status.entry = originalEntry;
-
-          mutationErrorsByEntryIndex.set(originalEntriesIndex, status);
-        });
-      })
-      .on('end', onBatchResponse);
-  }
-
-  makeNextBatchRequest();
-};
-
-/**
- * Get a reference to a table row.
- *
- * @throws {error} If a key is not provided.
- *
- * @param {string} key The row key.
- * @returns {Row}
- *
- * @example
- * var row = table.row('lincoln');
- */
-Table.prototype.row = function(key) {
-  if (!key) {
-    throw new Error('A row key must be provided.');
-  }
-
-  return new Row(this, key);
-};
-
-/**
- * Returns a sample of row keys in the table. The returned row keys will delimit
- * contigous sections of the table of approximately equal size, which can be
- * used to break up the data for distributed tasks like mapreduces.
- *
- * @param {object} [gaxOptions] Request configuration options, outlined here:
- *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
- * @param {function} [callback] The callback function.
- * @param {?error} callback.err An error returned while making this request.
- * @param {object[]} callback.keys The list of keys.
- *
- * @example
- * table.sampleRowKeys(function(err, keys) {
- *   // keys = [
- *   //   {
- *   //     key: '',
- *   //     offset: '805306368'
- *   //   },
- *   //   ...
- *   // ]
- * });
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * table.sampleRowKeys().then(function(data) {
- *   var keys = data[0];
- * });
- */
-Table.prototype.sampleRowKeys = function(gaxOptions, callback) {
-  if (is.fn(gaxOptions)) {
-    callback = gaxOptions;
-    gaxOptions = {};
-  }
-
-  this.sampleRowKeysStream(gaxOptions)
-    .on('error', callback)
-    .pipe(
-      concat(function(keys) {
-        callback(null, keys);
-      })
-    );
-};
-
-/**
- * Returns a sample of row keys in the table as a readable object stream.
- *
- * See {@link Table#sampleRowKeys} for more details.
- *
- * @param {object} [gaxOptions] Request configuration options, outlined here:
- *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
- * @returns {stream}
- *
- * @example
- * table.sampleRowKeysStream()
- *   .on('error', console.error)
- *   .on('data', function(key) {
- *     // Do something with the `key` object.
- *   });
- *
- * //-
- * // If you anticipate many results, you can end a stream early to prevent
- * // unnecessary processing.
- * //-
- * table.sampleRowKeysStream()
- *   .on('data', function(key) {
- *     this.end();
- *   });
- */
-Table.prototype.sampleRowKeysStream = function(gaxOptions) {
-  var reqOpts = {
-    tableName: this.id,
-    appProfileId: this.bigtable.appProfileId,
-  };
-
-  return pumpify.obj([
-    this.bigtable.request({
-      client: 'BigtableClient',
-      method: 'sampleRowKeys',
-      reqOpts: reqOpts,
-      gaxOpts: gaxOptions,
-    }),
-    through.obj(function(key, enc, next) {
-      next(null, {
-        key: key.rowKey,
-        offset: key.offsetBytes,
-      });
-    }),
-  ]);
-};
-
-/**
- * Truncate the table.
- *
- * @param {object} [gaxOptions] Request configuration options, outlined
- *     here: https://googleapis.github.io/gax-nodejs/CallSettings.html.
- * @param {function} callback The callback function.
- * @param {?error} callback.err An error returned while making this request.
- * @param {object} callback.apiResponse The full API response.
- *
- * @example
- * table.truncate(function(err, apiResponse) {});
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * table.truncate().then(function(data) {
- *   var apiResponse = data[0];
- * });
- */
-Table.prototype.truncate = function(gaxOptions, callback) {
-  if (is.fn(gaxOptions)) {
-    callback = gaxOptions;
-    gaxOptions = {};
-  }
-
-  var reqOpts = {
-    name: this.id,
-    deleteAllDataFromTable: true,
-  };
-
-  this.bigtable.request(
-    {
-      client: 'BigtableTableAdminClient',
-      method: 'dropRowRange',
-      reqOpts: reqOpts,
-      gaxOpts: gaxOptions,
-    },
-    callback
-  );
 };
 
 /*! Developer Documentation

--- a/test/chunktransformer.js
+++ b/test/chunktransformer.js
@@ -85,10 +85,6 @@ describe('Bigtable/ChunkTransformer', function() {
         'invalid initial state'
       );
     });
-    it('calling as function should return chunkTransformer instance', function() {
-      const instance = ChunkTransformer();
-      assert(instance instanceof ChunkTransformer);
-    });
   });
   describe('processNewRow', function() {
     var processNewRowSpy;

--- a/test/index.js
+++ b/test/index.js
@@ -21,7 +21,6 @@ var common = require('@google-cloud/common');
 var commonGrpc = require('@google-cloud/common-grpc');
 var extend = require('extend');
 var grpc = require('google-gax').grpc().grpc;
-var nodeutil = require('util');
 var proxyquire = require('proxyquire');
 var sinon = require('sinon').sandbox.create();
 var through = require('through2');
@@ -69,12 +68,12 @@ function fakeRetryRequest() {
 }
 
 function createFake(Class) {
-  function Fake() {
-    this.calledWith_ = arguments;
-    Class.apply(this, arguments);
-  }
-  nodeutil.inherits(Fake, Class);
-  return Fake;
+  return class Fake extends Class {
+    constructor() {
+      super(...arguments);
+      this.calledWith_ = arguments;
+    }
+  };
 }
 
 var FakeCluster = createFake(Cluster);

--- a/test/instance.js
+++ b/test/instance.js
@@ -21,7 +21,6 @@ var common = require('@google-cloud/common');
 var extend = require('extend');
 var format = require('string-format-obj');
 var proxyquire = require('proxyquire');
-var util = require('util');
 
 var AppProfile = require('../src/app-profile.js');
 var Cluster = require('../src/cluster.js');
@@ -50,13 +49,12 @@ var fakePaginator = {
 };
 
 function createFake(Class) {
-  function Fake() {
-    this.calledWith_ = arguments;
-    Class.apply(this, arguments);
-  }
-
-  util.inherits(Fake, Class);
-  return Fake;
+  return class Fake extends Class {
+    constructor() {
+      super(...arguments);
+      this.calledWith_ = arguments;
+    }
+  };
 }
 
 var FakeAppProfile = createFake(AppProfile);

--- a/test/table.js
+++ b/test/table.js
@@ -19,7 +19,6 @@
 var assert = require('assert');
 var Buffer = require('buffer').Buffer;
 var extend = require('extend');
-var nodeutil = require('util');
 var proxyquire = require('proxyquire');
 var pumpify = require('pumpify');
 var sinon = require('sinon').sandbox.create();
@@ -46,12 +45,12 @@ var fakeUtil = extend({}, common.util, {
 });
 
 function createFake(Class) {
-  function Fake() {
-    this.calledWith_ = arguments;
-    Class.apply(this, arguments);
-  }
-  nodeutil.inherits(Fake, Class);
-  return Fake;
+  return class Fake extends Class {
+    constructor() {
+      super(...arguments);
+      this.calledWith_ = arguments;
+    }
+  };
 }
 
 var FakeGrpcService = createFake(commonGrpc.Service);


### PR DESCRIPTION
## Node v4 goes EOL 4/30/18

Fixes #85 

- [ ] Tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)

Note that instantiating a `Bigtable` still works via Proxies (See https://stackoverflow.com/a/35339748 ), yet all the other classes require the `new` keyword

This was generated by installing [lebab](https://github.com/lebab/lebab) and running:

```
./node_modules/.bin/lebab --replace test/ --transform class
```

and then fixing the newly broken tests.

I imagine we'll want to followup on the rest of the other transforms lebab offers.