### PR TITLE
Drop support for nodev4.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,10 +3,6 @@ workflows:
   version: 2
   tests:
     jobs: &workflow_jobs
-      - node4:
-          filters:
-            tags:
-              only: /.*/
       - node6:
           filters:
             tags:
@@ -21,7 +17,6 @@ workflows:
               only: /.*/
       - lint:
           requires:
-            - node4
             - node6
             - node8
             - node9
@@ -30,7 +25,6 @@ workflows:
               only: /.*/
       - docs:
           requires:
-            - node4
             - node6
             - node8
             - node9
@@ -73,38 +67,6 @@ workflows:
               only: master
     jobs: *workflow_jobs
 jobs:
-  node4:
-    docker:
-      - image: 'node:4'
-        user: node
-    steps: &unit_tests_steps
-      - checkout
-      - run: &remove_package_lock
-          name: Remove package-lock.json if needed.
-          command: |
-            WORKFLOW_NAME=`python .circleci/get_workflow_name.py`
-            echo "Workflow name: $WORKFLOW_NAME"
-            if [ "$WORKFLOW_NAME" = "nightly" ]; then
-              echo "Nightly build detected, removing package-lock.json."
-              rm -f package-lock.json samples/package-lock.json
-            else
-              echo "Not a nightly build, skipping this step."
-            fi
-      - run:
-          name: Install modules and dependencies.
-          command: |-
-            npm install
-            repo_tools="node_modules/@google-cloud/nodejs-repo-tools/bin/tools"
-            if ! test -x "$repo_tools"; then
-              chmod +x "$repo_tools"
-            fi
-      - run:
-          name: Run unit tests.
-          command: npm test
-      - run:
-          name: Submit coverage data to codecov.
-          command: node_modules/.bin/codecov
-          when: always
   node6:
     docker:
       - image: 'node:6'


### PR DESCRIPTION
## Node 4 goes EOL 4/30/18

Fixes #86

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
