### PR TITLE
Check if Error is FamilyError for autoCreate.

### DIFF
--- a/src/family.js
+++ b/src/family.js
@@ -296,7 +296,7 @@ Family.prototype.get = function(options, callback) {
 
   this.getMetadata(gaxOptions, function(err, metadata) {
     if (err) {
-      if (err.code === 5 && autoCreate) {
+      if (err instanceof FamilyError && autoCreate) {
         self.create({gaxOptions}, callback);
         return;
       }

--- a/system-test/bigtable.js
+++ b/system-test/bigtable.js
@@ -264,6 +264,14 @@ describe('Bigtable', function() {
         done();
       });
     });
+
+    it('should create a table if autoCreate is true', function(done) {
+      var table = INSTANCE.table(generateName('table'));
+      async.series(
+        [table.get.bind(table, {autoCreate: true}), table.delete.bind(table)],
+        done
+      );
+    });
   });
 
   describe('column families', function() {
@@ -312,6 +320,18 @@ describe('Bigtable', function() {
         assert.strictEqual(exists, false);
         done();
       });
+    });
+
+    it('should create a family if autoCreate is true', function(done) {
+      var family = TABLE.family('prezzies');
+
+      async.series(
+        [
+          family.get.bind(family, {autoCreate: true}),
+          family.delete.bind(family),
+        ],
+        done
+      );
     });
 
     it('should get the column family metadata', function(done) {

--- a/test/family.js
+++ b/test/family.js
@@ -308,8 +308,7 @@ describe('Bigtable/Family', function() {
     });
 
     it('should auto create with error code 5', function(done) {
-      var error = new Error('Error.');
-      error.code = 5;
+      var error = new FamilyError(TABLE.id);
 
       var options = {
         autoCreate: true,
@@ -322,7 +321,7 @@ describe('Bigtable/Family', function() {
 
       family.create = function(options_, callback) {
         assert.strictEqual(options_.gaxOptions, options.gaxOptions);
-        callback(); // done()
+        callback();
       };
 
       family.get(options, done);
@@ -351,8 +350,7 @@ describe('Bigtable/Family', function() {
     });
 
     it('should not auto create unless requested', function(done) {
-      var error = new Error('Error.');
-      error.code = 5;
+      var error = new FamilyError(TABLE.id);
 
       family.getMetadata = function(gaxOptions, callback) {
         callback(error);

--- a/test/family.js
+++ b/test/family.js
@@ -307,7 +307,7 @@ describe('Bigtable/Family', function() {
       family.get(assert.ifError);
     });
 
-    it('should auto create with error code 5', function(done) {
+    it('should auto create with a FamilyError error', function(done) {
       var error = new FamilyError(TABLE.id);
 
       var options = {
@@ -327,7 +327,7 @@ describe('Bigtable/Family', function() {
       family.get(options, done);
     });
 
-    it('should not auto create without error code 5', function(done) {
+    it('should not auto create without a FamilyError error', function(done) {
       var error = new Error('Error.');
       error.code = 'NOT-5';
 


### PR DESCRIPTION
Relying on the error code is fragile (and broken). Since the client library
manually controls when this error is thrown, it's the most reliable test
to use for autoCreate.

Fixes #90

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
~- Appropriate docs were updated (if necessary)~
