### PR TITLE
Default to using client side timestamps

### DIFF
--- a/src/mutation.js
+++ b/src/mutation.js
@@ -146,7 +146,7 @@ Mutation.createTimeRange = function(start, end) {
  * //     setCell: {
  * //       familyName: 'follows',
  * //       columnQualifier: 'alincoln', // as buffer
- * //       timestampMicros: -1,
+ * //       timestampMicros: new Date(), // uses the client's current time
  * //       value: 1 // as buffer
  * //     }
  * //   }
@@ -167,7 +167,7 @@ Mutation.encodeSetCell = function(data) {
         };
       }
 
-      var timestamp = cell.timestamp;
+      var timestamp = cell.timestamp || new Date();
 
       if (is.date(timestamp)) {
         timestamp = timestamp.getTime() * 1000;
@@ -176,7 +176,7 @@ Mutation.encodeSetCell = function(data) {
       var setCell = {
         familyName: familyName,
         columnQualifier: Mutation.convertToBytes(cellName),
-        timestampMicros: timestamp || -1,
+        timestampMicros: timestamp,
         value: Mutation.convertToBytes(cell.value),
       };
 

--- a/test/mutation.js
+++ b/test/mutation.js
@@ -138,23 +138,17 @@ describe('Bigtable/Mutation', function() {
   });
 
   describe('encodeSetCell', function() {
-    var convert;
-    var convertCalls = [];
-
-    before(function() {
-      convert = Mutation.convertToBytes;
-      Mutation.convertToBytes = function(value) {
-        convertCalls.push(value);
-        return value;
-      };
-    });
-
-    after(function() {
-      Mutation.convertToBytes = convert;
-    });
+    var convertCalls;
+    var fakeTime = new Date('2018-1-1');
+    var realTimestamp = new Date();
 
     beforeEach(function() {
+      sinon.stub(global, 'Date').returns(fakeTime);
       convertCalls = [];
+      sinon.stub(Mutation, 'convertToBytes').callsFake(function(value) {
+        convertCalls.push(value);
+        return value;
+      });
     });
 
     it('should encode a setCell mutation', function() {
@@ -174,7 +168,7 @@ describe('Bigtable/Mutation', function() {
           setCell: {
             familyName: 'follows',
             columnQualifier: 'gwashington',
-            timestampMicros: -1,
+            timestampMicros: fakeTime * 1000, // Convert ms to μs
             value: 1,
           },
         },
@@ -182,7 +176,7 @@ describe('Bigtable/Mutation', function() {
           setCell: {
             familyName: 'follows',
             columnQualifier: 'alincoln',
-            timestampMicros: -1,
+            timestampMicros: fakeTime * 1000, // Convert ms to μs
             value: 1,
           },
         },
@@ -193,12 +187,11 @@ describe('Bigtable/Mutation', function() {
     });
 
     it('should optionally accept a timestamp', function() {
-      var timestamp = Date.now();
       var fakeMutation = {
         follows: {
           gwashington: {
             value: 1,
-            timestamp: new Date(timestamp),
+            timestamp: realTimestamp,
           },
         },
       };
@@ -210,7 +203,7 @@ describe('Bigtable/Mutation', function() {
           setCell: {
             familyName: 'follows',
             columnQualifier: 'gwashington',
-            timestampMicros: timestamp * 1000, // Convert ms to ms
+            timestampMicros: realTimestamp * 1000, // Convert ms to μs
             value: 1,
           },
         },
@@ -235,7 +228,7 @@ describe('Bigtable/Mutation', function() {
           setCell: {
             familyName: 'follows',
             columnQualifier: 'gwashington',
-            timestampMicros: -1,
+            timestampMicros: fakeTime * 1000, // Convert ms to μs
             value: val,
           },
         },


### PR DESCRIPTION
Fixes #104 

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
