### PR TITLE
Pass rules when autocreating a family.

### DIFF
--- a/src/family.js
+++ b/src/family.js
@@ -297,7 +297,7 @@ Family.prototype.get = function(options, callback) {
   this.getMetadata(gaxOptions, function(err, metadata) {
     if (err) {
       if (err instanceof FamilyError && autoCreate) {
-        self.create({gaxOptions}, callback);
+        self.create({gaxOptions, rule: options.rule}, callback);
         return;
       }
 

--- a/test/family.js
+++ b/test/family.js
@@ -327,6 +327,28 @@ describe('Bigtable/Family', function() {
       family.get(options, done);
     });
 
+    it('should pass the rules when auto creating', function(done) {
+      var error = new FamilyError(TABLE.id);
+
+      var options = {
+        autoCreate: true,
+        rule: {
+          versions: 1,
+        },
+      };
+
+      family.getMetadata = function(gaxOptions, callback) {
+        callback(error);
+      };
+
+      family.create = function(options_, callback) {
+        assert.deepStrictEqual(options.rule, {versions: 1});
+        callback();
+      };
+
+      family.get(options, done);
+    });
+
     it('should not auto create without a FamilyError error', function(done) {
       var error = new Error('Error.');
       error.code = 'NOT-5';


### PR DESCRIPTION
Fixes #96

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
