### PR TITLE
Remove skip flag from truncate test now that GAPIC was regenerated.

### DIFF
--- a/system-test/bigtable.js
+++ b/system-test/bigtable.js
@@ -1118,8 +1118,7 @@ describe('Bigtable', function() {
 
       afterEach(table.delete.bind(table));
 
-      // @TODO fix https://github.com/googleapis/nodejs-bigtable/issues/79
-      it.skip('should truncate a table', function(done) {
+      it('should truncate a table', function(done) {
         async.series([
           table.truncate.bind(table),
           function() {


### PR DESCRIPTION
Fixes #79 
- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
