### PR TITLE
Handle buffers as literal atoms when used as a Filter.

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "concat-stream": "^1.5.0",
     "create-error-class": "^3.0.2",
     "dot-prop": "^4.2.0",
+    "escape-string-regexp": "^1.0.5",
     "extend": "^3.0.0",
     "google-auto-auth": "^0.10.0",
     "google-gax": "^0.16.0",

--- a/src/filter.js
+++ b/src/filter.js
@@ -811,7 +811,7 @@ Filter.prototype.toProto = function() {
  * // Or you can provide a Buffer or an array of Buffers if you wish to match
  * // against specfic binary value(s).
  * //-
- * var userInputedFaces = [Buffer.from('.|.'), Buffer.from(':-)')]
+ * var userInputedFaces = [Buffer.from('.|.'), Buffer.from(':-)')];
  * var filter = [
  *   {
  *     value: userInputedFaces

--- a/src/filter.js
+++ b/src/filter.js
@@ -19,6 +19,7 @@
 var arrify = require('arrify');
 var createErrorClass = require('create-error-class');
 var extend = require('extend');
+var escapeStringRegexp = require('escape-string-regexp');
 var is = require('is');
 
 var Mutation = require('./mutation.js');
@@ -100,7 +101,7 @@ Filter.convertToRegExpString = function(regex) {
   }
 
   if (is.array(regex)) {
-    return '(' + regex.join('|') + ')';
+    return '(' + regex.map(Filter.convertToRegExpString).join('|') + ')';
   }
 
   if (is.string(regex)) {
@@ -109,6 +110,10 @@ Filter.convertToRegExpString = function(regex) {
 
   if (is.number(regex)) {
     return regex.toString();
+  }
+
+  if (Buffer.isBuffer(regex)) {
+    return escapeStringRegexp(regex.toString());
   }
 
   throw new TypeError("Can't convert to RegExp String from unknown type.");
@@ -793,12 +798,23 @@ Filter.prototype.toProto = function() {
  * ];
  *
  * //-
- * // Or you can provide an array of strings if you wish to match against
+ * // You can also provide an array of strings if you wish to match against
  * // multiple values.
  * //-
  * var filter = [
  *   {
  *     value: ['1', '9']
+ *   }
+ * ];
+ *
+ * //-
+ * // Or you can provide a Buffer or an array of Buffers if you wish to match
+ * // against specfic binary value(s).
+ * //-
+ * var userInputedFaces = [Buffer.from('.|.'), Buffer.from(':-)')]
+ * var filter = [
+ *   {
+ *     value: userInputedFaces
  *   }
  * ];
  *

--- a/test/filter.js
+++ b/test/filter.js
@@ -65,6 +65,13 @@ describe('Bigtable/Filter', function() {
       assert.strictEqual(str, '(a|b|c)');
     });
 
+    it('should convert an Array of buffers to a single string', function() {
+      var faces = [Buffer.from('.|.'), Buffer.from('=|=')];
+      var str = Filter.convertToRegExpString(faces);
+
+      assert.strictEqual(str, '(\\.\\|\\.|=\\|=)');
+    });
+
     it('should not do anything to a string', function() {
       var str1 = 'hello';
       var str2 = Filter.convertToRegExpString(str1);
@@ -76,6 +83,14 @@ describe('Bigtable/Filter', function() {
       var str = Filter.convertToRegExpString(1);
 
       assert.strictEqual(str, '1');
+    });
+
+    it('should convert a buffer to a string', function() {
+      var str1 = 'hello';
+      var buffer = Buffer.from(str1);
+      var str2 = Filter.convertToRegExpString(buffer);
+
+      assert.strictEqual(str1, str2);
     });
 
     it('should throw an error for unknown types', function() {


### PR DESCRIPTION
Fixes #128 

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
