### PR TITLE
Enable a way to specify nested gc rules.

### DIFF
--- a/src/family.js
+++ b/src/family.js
@@ -126,8 +126,21 @@ Family.formatRule_ = function(ruleObj) {
     });
   }
 
-  if (!ruleObj.intersection && !ruleObj.union) {
+  if (ruleObj.rule) {
+    rules.push(Family.formatRule_(ruleObj.rule));
+  }
+
+  if (rules.length === 1) {
+    if (ruleObj.union) {
+      throw new Error(
+        'A union must have more than one garbage collection rule.'
+      );
+    }
     return rules[0];
+  }
+
+  if (rules.length === 0) {
+    throw new Error('No garbage collection rules were specified.');
   }
 
   var rule = {};

--- a/src/table.js
+++ b/src/table.js
@@ -223,6 +223,19 @@ Table.prototype.create = function(options, callback) {
  *   const family = data[0];
  *   const apiResponse = data[1];
  * });
+ *
+ * // Note that rules can have nested rules. For example The following rule
+ * // will delete cells that are either older than 10 versions OR if the cell
+ * // is is a month old and has at least 2 newer version.
+ * // Essentially: (version > 10 OR (age > 30 AND version > 2))
+ * const rule = {
+ *   union: true,
+ *   versions: 10,
+ *   rule: {
+ *     versions: 2,
+ *     age: { seconds: 60 * 60 * 24 * 30 }, // one month
+ *   },
+ * };
  */
 Table.prototype.createFamily = function(name, options, callback) {
   var self = this;

--- a/system-test/bigtable.js
+++ b/system-test/bigtable.js
@@ -334,6 +334,63 @@ describe('Bigtable', function() {
       );
     });
 
+    it('should create a family with nested gc rules', function(done) {
+      var family = TABLE.family('prezzies');
+      var options = {
+        rule: {
+          union: true,
+          versions: 10,
+          rule: {
+            versions: 2,
+            age: {seconds: 60 * 60 * 24 * 30},
+          },
+        },
+      };
+
+      async.series(
+        [
+          family.create.bind(family, options),
+          next => {
+            family.getMetadata((err, metadata) => {
+              if (err) return next(err);
+              assert.deepStrictEqual(metadata.gcRule, {
+                union: {
+                  rules: [
+                    {
+                      maxNumVersions: 10,
+                      rule: 'maxNumVersions',
+                    },
+                    {
+                      intersection: {
+                        rules: [
+                          {
+                            maxAge: {
+                              seconds: '2592000',
+                              nanos: 0,
+                            },
+                            rule: 'maxAge',
+                          },
+                          {
+                            maxNumVersions: 2,
+                            rule: 'maxNumVersions',
+                          },
+                        ],
+                      },
+                      rule: 'intersection',
+                    },
+                  ],
+                },
+                rule: 'union',
+              });
+              next();
+            });
+          },
+          family.delete.bind(family),
+        ],
+        done
+      );
+    });
+
     it('should get the column family metadata', function(done) {
       FAMILY.getMetadata(function(err, metadata) {
         assert.ifError(err);


### PR DESCRIPTION
- [ ] Tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
