### PR TITLE
Fix system test

### DIFF
--- a/system-test/bigtable.js
+++ b/system-test/bigtable.js
@@ -505,7 +505,6 @@ describe('Bigtable', function() {
           seconds: 10000,
           nanos: 10000,
         },
-        union: true,
       };
 
       FAMILY.setMetadata({rule: rule}, function(err, metadata) {


### PR DESCRIPTION
Union on a GC rule only works when there's more than one rule, this now throws in the system test. This PR fixes that by removing the union property