### PR TITLE
Removed deletedCells from the row.data object

### DIFF
--- a/src/row.js
+++ b/src/row.js
@@ -460,13 +460,28 @@ Row.prototype.deleteCells = function(columns, gaxOptions, callback) {
     gaxOptions = {};
   }
 
+  columns = arrify(columns);
+
   var mutation = {
     key: this.id,
-    data: arrify(columns),
+    data: columns,
     method: Mutation.methods.DELETE,
   };
 
-  this.table.mutate(mutation, gaxOptions, callback);
+  this.table.mutate(mutation, gaxOptions, err => {
+    if (!err) {
+      columns.map(Mutation.parseColumnName).forEach(column => {
+        if (this.data[column.family]) {
+          if (column.qualifier) {
+            delete this.data[column.family][column.qualifier];
+          } else {
+            delete this.data[column.family];
+          }
+        }
+      });
+    }
+    callback(err);
+  });
 };
 
 /**

--- a/test/row.js
+++ b/test/row.js
@@ -692,6 +692,38 @@ describe('Bigtable/Row', function() {
 
       row.deleteCells(columns, gaxOptions, done);
     });
+
+    it('should remove the column qualifier from the data object', function() {
+      row.data = {
+        family: {
+          qualifier: 'removed',
+          notQualifier: 'kept',
+        },
+      };
+      row.table.mutate = function(mutation, gaxOptions, callback) {
+        callback(null);
+      };
+      row.deleteCells(['family:qualifier'], function() {
+        assert.deepStrictEqual(row.data, {
+          family: {notQualifier: 'kept'},
+        });
+      });
+    });
+
+    it('should remove the column family from the data object', function() {
+      row.data = {
+        family: {
+          qualifier1: 'removed',
+          qualifier2: 'also removed',
+        },
+      };
+      row.table.mutate = function(mutation, gaxOptions, callback) {
+        callback(null);
+      };
+      row.deleteCells(['family'], function() {
+        assert.deepStrictEqual(row.data, {});
+      });
+    });
   });
 
   describe('exists', function() {


### PR DESCRIPTION
Fixes #151 Fixes #149

This PR will keep the row data in sync with how it's represented in bigtable as best as possible. Consider the current behavior:

```js
const row = table.row('myRow');
setInterval(() => console.log(is.empty(row.data)), 10)
await row.get()

// The above will log true a couple of times then start logging false.
```

The row object has it's state changed whenever it hydrates it's data. By the same token, when removing cells the `deleteCells` method should remove data that no longer exists in the data object.

- [ ] Tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)
