### PR TITLE
Fix broken system test

### DIFF
--- a/src/mutation.js
+++ b/src/mutation.js
@@ -63,10 +63,10 @@ var methods = (Mutation.methods = {
  */
 Mutation.convertFromBytes = function(bytes, options) {
   var buf = bytes instanceof Buffer ? bytes : Buffer.from(bytes, 'base64');
-  if (options && options.isPossibleNumber) {
+  if (options && options.isPossibleNumber && buf.length === 8) {
     var num = Long.fromBytes(buf).toNumber();
 
-    if (!isNaN(num) && isFinite(num)) {
+    if (Number.MIN_SAFE_INTEGER < num && num < Number.MAX_SAFE_INTEGER) {
       return num;
     }
   }


### PR DESCRIPTION
`if (!isNaN(num) && isFinite(num)) {` is no longer a valid check if the converted number is valid. Instead:

```js
if (Number.MIN_SAFE_INTEGER < num && num < Number.MAX_SAFE_INTEGER) {
```

is used. Also there's no point in trying to convert the buffer to a number if the buffer length isn't `8`

Fixes #<issue_number_goes_here> (it's a good idea to open an issue first for discussion)

- [ ] Tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)
