### PR TITLE
Switch src/ to use ES classes

### DIFF
--- a/samples/system-test/instances.test.js
+++ b/samples/system-test/instances.test.js
@@ -20,7 +20,8 @@ const test = require(`ava`);
 const tools = require(`@google-cloud/nodejs-repo-tools`);
 const uuid = require(`uuid`);
 
-const bigtable = require(`@google-cloud/bigtable`)();
+const Bigtable = require(`@google-cloud/bigtable`);
+const bigtable = new Bigtable();
 const clusterName = `nodejs-bigtable-samples-${uuid.v4()}`.substr(0, 30); // Bigtable naming rules
 const instanceName = `nodejs-bigtable-samples-${uuid.v4()}`.substr(0, 30); // Bigtable naming rules
 const instance = bigtable.instance(instanceName);

--- a/src/app-profile.js
+++ b/src/app-profile.js
@@ -382,7 +382,7 @@ AppProfile.prototype.setMetadata = function(metadata, gaxOptions, callback) {
     {
       client: 'BigtableInstanceAdminClient',
       method: 'updateAppProfile',
-      reqOpts: reqOpts,
+      reqOpts,
       gaxOpts: gaxOptions,
     },
     callback

--- a/src/app-profile.js
+++ b/src/app-profile.js
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-var common = require('@google-cloud/common');
-var is = require('is');
-var snakeCase = require('lodash.snakecase');
+const common = require('@google-cloud/common');
+const is = require('is');
+const snakeCase = require('lodash.snakecase');
 
-var Cluster = require('./cluster.js');
+const Cluster = require('./cluster.js');
 
 /**
  * Create an app profile object to interact with your app profile.
@@ -37,7 +37,7 @@ function AppProfile(instance, name) {
   this.bigtable = instance.bigtable;
   this.instance = instance;
 
-  var id = name;
+  let id = name;
 
   if (id.indexOf('/') === -1) {
     id = `${instance.id}/appProfiles/${name}`;
@@ -251,7 +251,7 @@ AppProfile.prototype.exists = function(gaxOptions, callback) {
  * });
  */
 AppProfile.prototype.get = function(gaxOptions, callback) {
-  var self = this;
+  const self = this;
 
   if (is.fn(gaxOptions)) {
     callback = gaxOptions;
@@ -286,7 +286,7 @@ AppProfile.prototype.get = function(gaxOptions, callback) {
  * });
  */
 AppProfile.prototype.getMetadata = function(gaxOptions, callback) {
-  var self = this;
+  const self = this;
 
   if (is.fn(gaxOptions)) {
     callback = gaxOptions;
@@ -351,7 +351,7 @@ AppProfile.prototype.setMetadata = function(metadata, gaxOptions, callback) {
     gaxOptions = {};
   }
 
-  var reqOpts = {
+  const reqOpts = {
     appProfile: AppProfile.formatAppProfile_(metadata),
     updateMask: {
       paths: [],

--- a/src/app-profile.js
+++ b/src/app-profile.js
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-'use strict';
-
 var common = require('@google-cloud/common');
 var is = require('is');
 var snakeCase = require('lodash.snakecase');

--- a/src/app-profile.js
+++ b/src/app-profile.js
@@ -40,7 +40,7 @@ class AppProfile {
 
     let id = name;
 
-    if (id.indexOf('/') === -1) {
+    if (!id.includes('/')) {
       id = `${instance.id}/appProfiles/${name}`;
     }
 

--- a/src/app-profile.js
+++ b/src/app-profile.js
@@ -33,359 +33,361 @@ const Cluster = require('./cluster.js');
  * const instance = bigtable.instance('my-instance');
  * const appProfile = instance.appProfile('my-app-profile');
  */
-function AppProfile(instance, name) {
-  this.bigtable = instance.bigtable;
-  this.instance = instance;
+class AppProfile {
+  constructor(instance, name) {
+    this.bigtable = instance.bigtable;
+    this.instance = instance;
 
-  let id = name;
+    let id = name;
 
-  if (id.indexOf('/') === -1) {
-    id = `${instance.id}/appProfiles/${name}`;
-  }
-
-  this.id = id;
-  this.name = id.split('/').pop();
-}
-
-/**
- * Formats a app profile options object into proto format.
- *
- * @private
- *
- * @param {object} options The options object.
- * @returns {object}
- *
- * @example
- * // Any cluster routing:
- * Family.formatAppProfile_({
- *   routing: 'any',
- *   description: 'My App Profile',
- * });
- * // {
- * //   multiClusterRoutingUseAny: {},
- * //   description: 'My App Profile',
- * // }
- *
- * // Single cluster routing:
- * const cluster = myInstance.cluster('my-cluster');
- * Family.formatAppProfile_({
- *   routing: cluster,
- *   allowTransactionalWrites: true,
- *   description: 'My App Profile',
- * });
- * // {
- * //   singleClusterRouting: {
- * //     clusterId: 'my-cluster',
- * //     allowTransactionalWrites: true,
- * //   },
- * //   description: 'My App Profile',
- * // }
- */
-AppProfile.formatAppProfile_ = function(options) {
-  const appProfile = {};
-
-  if (options.routing) {
-    if (options.routing === 'any') {
-      appProfile.multiClusterRoutingUseAny = {};
-    } else if (options.routing instanceof Cluster) {
-      appProfile.singleClusterRouting = {
-        clusterId: options.routing.name,
-      };
-      if (is.boolean(options.allowTransactionalWrites)) {
-        appProfile.singleClusterRouting.allowTransactionalWrites =
-          options.allowTransactionalWrites;
-      }
-    } else {
-      throw new Error(
-        'An app profile routing policy can only contain "any" or a `Cluster`.'
-      );
+    if (id.indexOf('/') === -1) {
+      id = `${instance.id}/appProfiles/${name}`;
     }
+
+    this.id = id;
+    this.name = id.split('/').pop();
   }
 
-  if (is.string(options.description)) {
-    appProfile.description = options.description;
+  /**
+   * Formats a app profile options object into proto format.
+   *
+   * @private
+   *
+   * @param {object} options The options object.
+   * @returns {object}
+   *
+   * @example
+   * // Any cluster routing:
+   * Family.formatAppProfile_({
+   *   routing: 'any',
+   *   description: 'My App Profile',
+   * });
+   * // {
+   * //   multiClusterRoutingUseAny: {},
+   * //   description: 'My App Profile',
+   * // }
+   *
+   * // Single cluster routing:
+   * const cluster = myInstance.cluster('my-cluster');
+   * Family.formatAppProfile_({
+   *   routing: cluster,
+   *   allowTransactionalWrites: true,
+   *   description: 'My App Profile',
+   * });
+   * // {
+   * //   singleClusterRouting: {
+   * //     clusterId: 'my-cluster',
+   * //     allowTransactionalWrites: true,
+   * //   },
+   * //   description: 'My App Profile',
+   * // }
+   */
+  static formatAppProfile_(options) {
+    const appProfile = {};
+
+    if (options.routing) {
+      if (options.routing === 'any') {
+        appProfile.multiClusterRoutingUseAny = {};
+      } else if (options.routing instanceof Cluster) {
+        appProfile.singleClusterRouting = {
+          clusterId: options.routing.name,
+        };
+        if (is.boolean(options.allowTransactionalWrites)) {
+          appProfile.singleClusterRouting.allowTransactionalWrites =
+            options.allowTransactionalWrites;
+        }
+      } else {
+        throw new Error(
+          'An app profile routing policy can only contain "any" or a `Cluster`.'
+        );
+      }
+    }
+
+    if (is.string(options.description)) {
+      appProfile.description = options.description;
+    }
+
+    return appProfile;
   }
 
-  return appProfile;
-};
-
-/**
- * Create an app profile.
- *
- * @param {object} [options] See {@link Instance#createAppProfile}.
- *
- * @example
- * const Bigtable = require('@google-cloud/bigtable');
- * const bigtable = new Bigtable();
- * const instance = bigtable.instance('my-instance');
- * const appProfile = instance.appProfile('my-appProfile');
- *
- * appProfile.create(function(err, appProfile, apiResponse) {
- *   if (!err) {
- *     // The app profile was created successfully.
- *   }
- * });
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * appProfile.create().then(function(data) {
- *   const appProfile = data[0];
- *   const apiResponse = data[1];
- * });
- */
-AppProfile.prototype.create = function(options, callback) {
-  if (is.fn(options)) {
-    callback = options;
-    options = {};
-  }
-  this.instance.createAppProfile(this.name, options, callback);
-};
-
-/**
- * Delete the app profile.
- *
- * @param {object} [options] Cluster creation options.
- * @param {object} [options.gaxOptions] Request configuration options, outlined
- *     here: https://googleapis.github.io/gax-nodejs/global.html#CallOptions.
- * @param {boolean} [options.ignoreWarnings] Whether to ignore safety checks
- *     when deleting the app profile.
- * @param {function} [callback] The callback function.
- * @param {?error} callback.err An error returned while making this
- *     request.
- * @param {object} callback.apiResponse The full API response.
- *
- * @example
- * appProfile.delete(function(err, apiResponse) {});
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * appProfile.delete().then(function(data) {
- *   var apiResponse = data[0];
- * });
- */
-AppProfile.prototype.delete = function(options, callback) {
-  if (is.fn(options)) {
-    callback = options;
-    options = {};
+  /**
+   * Create an app profile.
+   *
+   * @param {object} [options] See {@link Instance#createAppProfile}.
+   *
+   * @example
+   * const Bigtable = require('@google-cloud/bigtable');
+   * const bigtable = new Bigtable();
+   * const instance = bigtable.instance('my-instance');
+   * const appProfile = instance.appProfile('my-appProfile');
+   *
+   * appProfile.create(function(err, appProfile, apiResponse) {
+   *   if (!err) {
+   *     // The app profile was created successfully.
+   *   }
+   * });
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * appProfile.create().then(function(data) {
+   *   const appProfile = data[0];
+   *   const apiResponse = data[1];
+   * });
+   */
+  create(options, callback) {
+    if (is.fn(options)) {
+      callback = options;
+      options = {};
+    }
+    this.instance.createAppProfile(this.name, options, callback);
   }
 
-  const reqOpts = {
-    name: this.id,
-  };
+  /**
+   * Delete the app profile.
+   *
+   * @param {object} [options] Cluster creation options.
+   * @param {object} [options.gaxOptions] Request configuration options, outlined
+   *     here: https://googleapis.github.io/gax-nodejs/global.html#CallOptions.
+   * @param {boolean} [options.ignoreWarnings] Whether to ignore safety checks
+   *     when deleting the app profile.
+   * @param {function} [callback] The callback function.
+   * @param {?error} callback.err An error returned while making this
+   *     request.
+   * @param {object} callback.apiResponse The full API response.
+   *
+   * @example
+   * appProfile.delete(function(err, apiResponse) {});
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * appProfile.delete().then(function(data) {
+   *   var apiResponse = data[0];
+   * });
+   */
+  delete(options, callback) {
+    if (is.fn(options)) {
+      callback = options;
+      options = {};
+    }
 
-  if (is.boolean(options.ignoreWarnings)) {
-    reqOpts.ignoreWarnings = options.ignoreWarnings;
+    const reqOpts = {
+      name: this.id,
+    };
+
+    if (is.boolean(options.ignoreWarnings)) {
+      reqOpts.ignoreWarnings = options.ignoreWarnings;
+    }
+
+    this.bigtable.request(
+      {
+        client: 'BigtableInstanceAdminClient',
+        method: 'deleteAppProfile',
+        reqOpts,
+        gaxOpts: options.gaxOptions,
+      },
+      callback
+    );
   }
 
-  this.bigtable.request(
-    {
-      client: 'BigtableInstanceAdminClient',
-      method: 'deleteAppProfile',
-      reqOpts,
-      gaxOpts: options.gaxOptions,
-    },
-    callback
-  );
-};
+  /**
+   * Check if an app profile exists.
+   *
+   * @param {object} [gaxOptions] Request configuration options, outlined here:
+   *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
+   * @param {function} callback The callback function.
+   * @param {?error} callback.err An error returned while making this
+   *     request.
+   * @param {boolean} callback.exists Whether the app profile exists or not.
+   *
+   * @example
+   * appProfile.exists(function(err, exists) {});
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * appProfile.exists().then(function(data) {
+   *   var exists = data[0];
+   * });
+   */
+  exists(gaxOptions, callback) {
+    if (is.fn(gaxOptions)) {
+      callback = gaxOptions;
+      gaxOptions = {};
+    }
 
-/**
- * Check if an app profile exists.
- *
- * @param {object} [gaxOptions] Request configuration options, outlined here:
- *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
- * @param {function} callback The callback function.
- * @param {?error} callback.err An error returned while making this
- *     request.
- * @param {boolean} callback.exists Whether the app profile exists or not.
- *
- * @example
- * appProfile.exists(function(err, exists) {});
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * appProfile.exists().then(function(data) {
- *   var exists = data[0];
- * });
- */
-AppProfile.prototype.exists = function(gaxOptions, callback) {
-  if (is.fn(gaxOptions)) {
-    callback = gaxOptions;
-    gaxOptions = {};
-  }
+    this.getMetadata(gaxOptions, function(err) {
+      if (err) {
+        if (err.code === 5) {
+          callback(null, false);
+          return;
+        }
 
-  this.getMetadata(gaxOptions, function(err) {
-    if (err) {
-      if (err.code === 5) {
-        callback(null, false);
+        callback(err);
         return;
       }
 
-      callback(err);
-      return;
+      callback(null, true);
+    });
+  }
+
+  /**
+   * Get a appProfile if it exists.
+   *
+   * @param {object} [gaxOptions] Request configuration options, outlined here:
+   *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
+   *
+   * @example
+   * appProfile.get(function(err, appProfile, apiResponse) {
+   *   // The `appProfile` data has been populated.
+   * });
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * appProfile.get().then(function(data) {
+   *   var appProfile = data[0];
+   *   var apiResponse = data[1];
+   * });
+   */
+  get(gaxOptions, callback) {
+    const self = this;
+
+    if (is.fn(gaxOptions)) {
+      callback = gaxOptions;
+      gaxOptions = {};
     }
 
-    callback(null, true);
-  });
-};
-
-/**
- * Get a appProfile if it exists.
- *
- * @param {object} [gaxOptions] Request configuration options, outlined here:
- *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
- *
- * @example
- * appProfile.get(function(err, appProfile, apiResponse) {
- *   // The `appProfile` data has been populated.
- * });
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * appProfile.get().then(function(data) {
- *   var appProfile = data[0];
- *   var apiResponse = data[1];
- * });
- */
-AppProfile.prototype.get = function(gaxOptions, callback) {
-  const self = this;
-
-  if (is.fn(gaxOptions)) {
-    callback = gaxOptions;
-    gaxOptions = {};
+    this.getMetadata(gaxOptions, function(err, metadata) {
+      callback(err, err ? null : self, metadata);
+    });
   }
 
-  this.getMetadata(gaxOptions, function(err, metadata) {
-    callback(err, err ? null : self, metadata);
-  });
-};
+  /**
+   * Get the app profile metadata.
+   *
+   * @param {object} [gaxOptions] Request configuration options, outlined
+   *     here: https://googleapis.github.io/gax-nodejs/CallSettings.html.
+   * @param {function} callback The callback function.
+   * @param {?error} callback.err An error returned while making this
+   *     request.
+   * @param {object} callback.metadata The metadata.
+   * @param {object} callback.apiResponse The full API response.
+   *
+   * @example
+   * appProfile.getMetadata(function(err, metadata, apiResponse) {});
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * appProfile.getMetadata().then(function(data) {
+   *   var metadata = data[0];
+   *   var apiResponse = data[1];
+   * });
+   */
+  getMetadata(gaxOptions, callback) {
+    const self = this;
 
-/**
- * Get the app profile metadata.
- *
- * @param {object} [gaxOptions] Request configuration options, outlined
- *     here: https://googleapis.github.io/gax-nodejs/CallSettings.html.
- * @param {function} callback The callback function.
- * @param {?error} callback.err An error returned while making this
- *     request.
- * @param {object} callback.metadata The metadata.
- * @param {object} callback.apiResponse The full API response.
- *
- * @example
- * appProfile.getMetadata(function(err, metadata, apiResponse) {});
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * appProfile.getMetadata().then(function(data) {
- *   var metadata = data[0];
- *   var apiResponse = data[1];
- * });
- */
-AppProfile.prototype.getMetadata = function(gaxOptions, callback) {
-  const self = this;
+    if (is.fn(gaxOptions)) {
+      callback = gaxOptions;
+      gaxOptions = {};
+    }
 
-  if (is.fn(gaxOptions)) {
-    callback = gaxOptions;
-    gaxOptions = {};
-  }
-
-  this.bigtable.request(
-    {
-      client: 'BigtableInstanceAdminClient',
-      method: 'getAppProfile',
-      reqOpts: {
-        name: this.id,
+    this.bigtable.request(
+      {
+        client: 'BigtableInstanceAdminClient',
+        method: 'getAppProfile',
+        reqOpts: {
+          name: this.id,
+        },
+        gaxOpts: gaxOptions,
       },
-      gaxOpts: gaxOptions,
-    },
-    function(...args) {
-      if (args[1]) {
-        self.metadata = args[1];
+      function(...args) {
+        if (args[1]) {
+          self.metadata = args[1];
+        }
+
+        callback(...args);
       }
-
-      callback(...args);
-    }
-  );
-};
-
-/**
- * Set the app profile metadata.
- *
- * @param {object} metadata See {@link Instance#createAppProfile} for the
- *     available metadata options.
- * @param {object} [gaxOptions] Request configuration options, outlined here:
- *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
- * @param {function} callback The callback function.
- * @param {?error} callback.err An error returned while making this request.
- * @param {object} callback.apiResponse The full API response.
- *
- * @example
- * const Bigtable = require('@google-cloud/bigtable');
- * const bigtable = new Bigtable();
- * const instance = bigtable.instance('my-instance');
- * const cluster = instance.cluster('my-cluster');
- * const appProfile = instance.appProfile('my-appProfile');
- *
- * const metadata = {
- *   description: 'My Updated App Profile',
- *   routing: cluster,
- *   allowTransactionalWrites: true,
- * };
- *
- * appProfile.setMetadata(metadata, callback);
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * appProfile.setMetadata(metadata).then(function(data) {
- *   const apiResponse = data[0];
- * });
- */
-AppProfile.prototype.setMetadata = function(metadata, gaxOptions, callback) {
-  if (is.fn(gaxOptions)) {
-    callback = gaxOptions;
-    gaxOptions = {};
+    );
   }
 
-  const reqOpts = {
-    appProfile: AppProfile.formatAppProfile_(metadata),
-    updateMask: {
-      paths: [],
-    },
-  };
-  reqOpts.appProfile.name = this.id;
-
-  const fieldsForMask = [
-    'description',
-    'singleClusterRouting',
-    'multiClusterRoutingUseAny',
-    'allowTransactionalWrites',
-  ];
-
-  fieldsForMask.forEach(field => {
-    if (reqOpts.appProfile[field]) {
-      reqOpts.updateMask.paths.push(snakeCase(field));
+  /**
+   * Set the app profile metadata.
+   *
+   * @param {object} metadata See {@link Instance#createAppProfile} for the
+   *     available metadata options.
+   * @param {object} [gaxOptions] Request configuration options, outlined here:
+   *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
+   * @param {function} callback The callback function.
+   * @param {?error} callback.err An error returned while making this request.
+   * @param {object} callback.apiResponse The full API response.
+   *
+   * @example
+   * const Bigtable = require('@google-cloud/bigtable');
+   * const bigtable = new Bigtable();
+   * const instance = bigtable.instance('my-instance');
+   * const cluster = instance.cluster('my-cluster');
+   * const appProfile = instance.appProfile('my-appProfile');
+   *
+   * const metadata = {
+   *   description: 'My Updated App Profile',
+   *   routing: cluster,
+   *   allowTransactionalWrites: true,
+   * };
+   *
+   * appProfile.setMetadata(metadata, callback);
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * appProfile.setMetadata(metadata).then(function(data) {
+   *   const apiResponse = data[0];
+   * });
+   */
+  setMetadata(metadata, gaxOptions, callback) {
+    if (is.fn(gaxOptions)) {
+      callback = gaxOptions;
+      gaxOptions = {};
     }
-  });
 
-  if (is.boolean(metadata.ignoreWarnings)) {
-    reqOpts.ignoreWarnings = metadata.ignoreWarnings;
+    const reqOpts = {
+      appProfile: AppProfile.formatAppProfile_(metadata),
+      updateMask: {
+        paths: [],
+      },
+    };
+    reqOpts.appProfile.name = this.id;
+
+    const fieldsForMask = [
+      'description',
+      'singleClusterRouting',
+      'multiClusterRoutingUseAny',
+      'allowTransactionalWrites',
+    ];
+
+    fieldsForMask.forEach(field => {
+      if (reqOpts.appProfile[field]) {
+        reqOpts.updateMask.paths.push(snakeCase(field));
+      }
+    });
+
+    if (is.boolean(metadata.ignoreWarnings)) {
+      reqOpts.ignoreWarnings = metadata.ignoreWarnings;
+    }
+
+    this.bigtable.request(
+      {
+        client: 'BigtableInstanceAdminClient',
+        method: 'updateAppProfile',
+        reqOpts,
+        gaxOpts: gaxOptions,
+      },
+      callback
+    );
   }
-
-  this.bigtable.request(
-    {
-      client: 'BigtableInstanceAdminClient',
-      method: 'updateAppProfile',
-      reqOpts,
-      gaxOpts: gaxOptions,
-    },
-    callback
-  );
-};
+}
 
 /*! Developer Documentation
  *

--- a/src/chunktransformer.js
+++ b/src/chunktransformer.js
@@ -34,265 +34,308 @@ const RowStateEnum = Object.freeze({
   ROW_IN_PROGRESS: 2,
   CELL_IN_PROGRESS: 3,
 });
+
 /**
  * ChunkTransformer formats all incoming chunks in to row
  * keeps all intermediate state until end of stream.
  * Should use new instance for each request.
  */
-function ChunkTransformer(options) {
-  options = options || {};
-  options.objectMode = true; // forcing object mode
-  Transform.call(this, options);
-  this.options = options;
-  this._destroyed = false;
-  this.lastRowKey = undefined;
-  this.reset();
-}
-util.inherits(ChunkTransformer, Transform);
-/**
- * transform the readrowsresponse chunks into friendly format. Chunks contain 3 properties:
- *
- * `rowContents` The row contents, this essentially is all data pertaining
- *     to a single family.
- *
- * `commitRow` This is a boolean telling us the all previous chunks for this
- *     row are ok to consume.
- *
- * `resetRow` This is a boolean telling us that all the previous chunks are to
- *     be discarded.
- *
- * @public
- *
- * @param {object} data readrows response containing array of chunks.
- * @param {object} [enc] encoding options.
- * @param {callback} next callback will be called once data is processed, with error if any error in processing
- */
-ChunkTransformer.prototype._transform = function(data, enc, next) {
-  for (const chunk of data.chunks) {
-    switch (this.state) {
-      case RowStateEnum.NEW_ROW:
-        this.processNewRow(chunk);
-        break;
-      case RowStateEnum.ROW_IN_PROGRESS:
-        this.processRowInProgress(chunk);
-        break;
-      case RowStateEnum.CELL_IN_PROGRESS:
-        this.processCellInProgress(chunk);
-        break;
+class ChunkTransformer extends Transform {
+  constructor(options) {
+    options = options || {};
+    options.objectMode = true; // forcing object mode
+    super(options);
+    this.options = options;
+    this._destroyed = false;
+    this.lastRowKey = undefined;
+    this.reset();
+  }
+
+  /**
+   * transform the readrowsresponse chunks into friendly format. Chunks contain 3 properties:
+   *
+   * `rowContents` The row contents, this essentially is all data pertaining
+   *     to a single family.
+   *
+   * `commitRow` This is a boolean telling us the all previous chunks for this
+   *     row are ok to consume.
+   *
+   * `resetRow` This is a boolean telling us that all the previous chunks are to
+   *     be discarded.
+   *
+   * @public
+   *
+   * @param {object} data readrows response containing array of chunks.
+   * @param {object} [enc] encoding options.
+   * @param {callback} next callback will be called once data is processed, with error if any error in processing
+   */
+  _transform(data, enc, next) {
+    for (const chunk of data.chunks) {
+      switch (this.state) {
+        case RowStateEnum.NEW_ROW:
+          this.processNewRow(chunk);
+          break;
+        case RowStateEnum.ROW_IN_PROGRESS:
+          this.processRowInProgress(chunk);
+          break;
+        case RowStateEnum.CELL_IN_PROGRESS:
+          this.processCellInProgress(chunk);
+          break;
+      }
+      if (this._destroyed) {
+        return;
+      }
     }
-    if (this._destroyed) {
-      return;
+    if (data.lastScannedRowKey && data.lastScannedRowKey.length > 0) {
+      this.lastRowKey = Mutation.convertFromBytes(data.lastScannedRowKey);
     }
+    next();
   }
-  if (data.lastScannedRowKey && data.lastScannedRowKey.length > 0) {
-    this.lastRowKey = Mutation.convertFromBytes(data.lastScannedRowKey);
-  }
-  next();
-};
 
-/**
- * called at end of the stream.
- * @public
- * @param {callback} cb callback will be called with error if there is any uncommitted row
- */
-ChunkTransformer.prototype._flush = function(cb) {
-  if (typeof this.row.key !== 'undefined') {
-    this.destroy(
-      new TransformError({
-        message: 'Response ended with pending row without commit',
-        chunk: null,
-      })
-    );
-    return;
-  }
-  cb();
-};
-
-/**
- * called when stream is destroyed.
- * @public
- * @param {error} err error if any
- */
-ChunkTransformer.prototype.destroy = function(err) {
-  if (this._destroyed) return;
-  this._destroyed = true;
-  const self = this;
-  if (err) {
-    self.emit('error', err);
-  }
-  self.emit('close');
-};
-
-/**
- * Resets state of formatter
- * @private
- */
-ChunkTransformer.prototype.reset = function() {
-  this.prevRowKey = '';
-  this.family = {};
-  this.qualifiers = [];
-  this.qualifier = {};
-  this.row = {};
-  this.state = RowStateEnum.NEW_ROW;
-};
-/**
- * sets prevRowkey and calls reset when row is committed.
- * @private
- */
-ChunkTransformer.prototype.commit = function() {
-  const row = this.row;
-  this.reset();
-  this.prevRowKey = row.key;
-};
-/**
- * Validates valuesize and commitrow in a chunk
- * @private
- * @param {chunk} chunk chunk to validate for valuesize and commitRow
- */
-ChunkTransformer.prototype.validateValueSizeAndCommitRow = function(chunk) {
-  if (chunk.valueSize > 0 && chunk.commitRow) {
-    this.destroy(
-      new TransformError({
-        message: 'A row cannot be have a value size and be a commit row',
-        chunk,
-      })
-    );
-  }
-};
-/**
- * Validates resetRow condition for chunk
- * @private
- * @param {chunk} chunk chunk to validate for resetrow
- */
-ChunkTransformer.prototype.validateResetRow = function(chunk) {
-  const containsData =
-    (chunk.rowKey && chunk.rowKey.toString() !== '') ||
-    chunk.familyName ||
-    chunk.qualifier ||
-    (chunk.value && chunk.value.toString() !== '') ||
-    chunk.timestampMicros > 0;
-  if (chunk.resetRow && containsData) {
-    this.destroy(
-      new TransformError({
-        message: 'A reset should have no data',
-        chunk,
-      })
-    );
-  }
-};
-/**
- * Validates state for new row.
- * @private
- * @param {chunk} chunk chunk to validate
- * @param {newRowKey} newRowKey newRowKey of the new row
- */
-ChunkTransformer.prototype.validateNewRow = function(chunk, newRowKey) {
-  const row = this.row;
-  const prevRowKey = this.prevRowKey;
-  let errorMessage;
-
-  if (typeof row.key !== 'undefined') {
-    errorMessage = 'A new row cannot have existing state';
-  } else if (
-    typeof chunk.rowKey === 'undefined' ||
-    chunk.rowKey === '' ||
-    newRowKey === ''
-  ) {
-    errorMessage = 'A row key must be set';
-  } else if (chunk.resetRow) {
-    errorMessage = 'A new row cannot be reset';
-  } else if (prevRowKey === newRowKey) {
-    errorMessage = 'A commit happened but the same key followed';
-  } else if (!chunk.familyName) {
-    errorMessage = 'A family must be set';
-  } else if (!chunk.qualifier) {
-    errorMessage = 'A column qualifier must be set';
-  }
-  if (errorMessage) {
-    this.destroy(new TransformError({message: errorMessage, chunk}));
-    return;
-  }
-  this.validateValueSizeAndCommitRow(chunk);
-};
-/**
- * Validates state for rowInProgress
- * @private
- * @param {chunk} chunk chunk to validate
- */
-ChunkTransformer.prototype.validateRowInProgress = function(chunk) {
-  const row = this.row;
-  if (chunk.rowKey && chunk.rowKey.length) {
-    const newRowKey = Mutation.convertFromBytes(chunk.rowKey);
-    if (
-      newRowKey &&
-      chunk.rowKey &&
-      newRowKey !== '' &&
-      newRowKey !== row.key
-    ) {
+  /**
+   * called at end of the stream.
+   * @public
+   * @param {callback} cb callback will be called with error if there is any uncommitted row
+   */
+  _flush(cb) {
+    if (typeof this.row.key !== 'undefined') {
       this.destroy(
         new TransformError({
-          message: 'A commit is required between row keys',
+          message: 'Response ended with pending row without commit',
+          chunk: null,
+        })
+      );
+      return;
+    }
+    cb();
+  }
+
+  /**
+   * called when stream is destroyed.
+   * @public
+   * @param {error} err error if any
+   */
+  destroy(err) {
+    if (this._destroyed) return;
+    this._destroyed = true;
+    const self = this;
+    if (err) {
+      self.emit('error', err);
+    }
+    self.emit('close');
+  }
+
+  /**
+   * Resets state of formatter
+   * @private
+   */
+  reset() {
+    this.prevRowKey = '';
+    this.family = {};
+    this.qualifiers = [];
+    this.qualifier = {};
+    this.row = {};
+    this.state = RowStateEnum.NEW_ROW;
+  }
+
+  /**
+   * sets prevRowkey and calls reset when row is committed.
+   * @private
+   */
+  commit() {
+    const row = this.row;
+    this.reset();
+    this.prevRowKey = row.key;
+  }
+
+  /**
+   * Validates valuesize and commitrow in a chunk
+   * @private
+   * @param {chunk} chunk chunk to validate for valuesize and commitRow
+   */
+  validateValueSizeAndCommitRow(chunk) {
+    if (chunk.valueSize > 0 && chunk.commitRow) {
+      this.destroy(
+        new TransformError({
+          message: 'A row cannot be have a value size and be a commit row',
+          chunk,
+        })
+      );
+    }
+  }
+
+  /**
+   * Validates resetRow condition for chunk
+   * @private
+   * @param {chunk} chunk chunk to validate for resetrow
+   */
+  validateResetRow(chunk) {
+    const containsData =
+      (chunk.rowKey && chunk.rowKey.toString() !== '') ||
+      chunk.familyName ||
+      chunk.qualifier ||
+      (chunk.value && chunk.value.toString() !== '') ||
+      chunk.timestampMicros > 0;
+    if (chunk.resetRow && containsData) {
+      this.destroy(
+        new TransformError({
+          message: 'A reset should have no data',
+          chunk,
+        })
+      );
+    }
+  }
+
+  /**
+   * Validates state for new row.
+   * @private
+   * @param {chunk} chunk chunk to validate
+   * @param {newRowKey} newRowKey newRowKey of the new row
+   */
+  validateNewRow(chunk, newRowKey) {
+    const row = this.row;
+    const prevRowKey = this.prevRowKey;
+    let errorMessage;
+
+    if (typeof row.key !== 'undefined') {
+      errorMessage = 'A new row cannot have existing state';
+    } else if (
+      typeof chunk.rowKey === 'undefined' ||
+      chunk.rowKey === '' ||
+      newRowKey === ''
+    ) {
+      errorMessage = 'A row key must be set';
+    } else if (chunk.resetRow) {
+      errorMessage = 'A new row cannot be reset';
+    } else if (prevRowKey === newRowKey) {
+      errorMessage = 'A commit happened but the same key followed';
+    } else if (!chunk.familyName) {
+      errorMessage = 'A family must be set';
+    } else if (!chunk.qualifier) {
+      errorMessage = 'A column qualifier must be set';
+    }
+    if (errorMessage) {
+      this.destroy(new TransformError({message: errorMessage, chunk}));
+      return;
+    }
+    this.validateValueSizeAndCommitRow(chunk);
+  }
+
+  /**
+   * Validates state for rowInProgress
+   * @private
+   * @param {chunk} chunk chunk to validate
+   */
+  validateRowInProgress(chunk) {
+    const row = this.row;
+    if (chunk.rowKey && chunk.rowKey.length) {
+      const newRowKey = Mutation.convertFromBytes(chunk.rowKey);
+      if (
+        newRowKey &&
+        chunk.rowKey &&
+        newRowKey !== '' &&
+        newRowKey !== row.key
+      ) {
+        this.destroy(
+          new TransformError({
+            message: 'A commit is required between row keys',
+            chunk,
+          })
+        );
+        return;
+      }
+    }
+    if (chunk.familyName && !chunk.qualifier) {
+      this.destroy(
+        new TransformError({
+          message: 'A qualifier must be specified',
           chunk,
         })
       );
       return;
     }
+    this.validateResetRow(chunk);
+    this.validateValueSizeAndCommitRow(chunk);
   }
-  if (chunk.familyName && !chunk.qualifier) {
-    this.destroy(
-      new TransformError({
-        message: 'A qualifier must be specified',
-        chunk,
-      })
-    );
-    return;
+
+  /**
+   * Validates chunk for cellInProgress state.
+   * @private
+   * @param {chunk} chunk chunk to validate
+   */
+  validateCellInProgress(chunk) {
+    this.validateResetRow(chunk);
+    this.validateValueSizeAndCommitRow(chunk);
   }
-  this.validateResetRow(chunk);
-  this.validateValueSizeAndCommitRow(chunk);
-};
-/**
- * Validates chunk for cellInProgress state.
- * @private
- * @param {chunk} chunk chunk to validate
- */
-ChunkTransformer.prototype.validateCellInProgress = function(chunk) {
-  this.validateResetRow(chunk);
-  this.validateValueSizeAndCommitRow(chunk);
-};
-/**
- * Moves to next state in processing.
- * @private
- * @param {chunk} chunk chunk in process
- */
-ChunkTransformer.prototype.moveToNextState = function(chunk) {
-  const row = this.row;
-  if (chunk.commitRow) {
-    this.push(row);
-    this.commit();
-    this.lastRowKey = row.key;
-  } else {
-    if (chunk.valueSize > 0) {
-      this.state = RowStateEnum.CELL_IN_PROGRESS;
+
+  /**
+   * Moves to next state in processing.
+   * @private
+   * @param {chunk} chunk chunk in process
+   */
+  moveToNextState(chunk) {
+    const row = this.row;
+    if (chunk.commitRow) {
+      this.push(row);
+      this.commit();
+      this.lastRowKey = row.key;
     } else {
-      this.state = RowStateEnum.ROW_IN_PROGRESS;
+      if (chunk.valueSize > 0) {
+        this.state = RowStateEnum.CELL_IN_PROGRESS;
+      } else {
+        this.state = RowStateEnum.ROW_IN_PROGRESS;
+      }
     }
   }
-};
-/**
- * Process chunk when in NEW_ROW state.
- * @private
- * @param {chunks} chunk chunk to process
- */
-ChunkTransformer.prototype.processNewRow = function(chunk) {
-  const newRowKey = Mutation.convertFromBytes(chunk.rowKey);
-  this.validateNewRow(chunk, newRowKey);
-  if (chunk.familyName && chunk.qualifier) {
+
+  /**
+   * Process chunk when in NEW_ROW state.
+   * @private
+   * @param {chunks} chunk chunk to process
+   */
+  processNewRow(chunk) {
+    const newRowKey = Mutation.convertFromBytes(chunk.rowKey);
+    this.validateNewRow(chunk, newRowKey);
+    if (chunk.familyName && chunk.qualifier) {
+      const row = this.row;
+      row.key = newRowKey;
+      row.data = {};
+      this.family = row.data[chunk.familyName.value] = {};
+      const qualifierName = Mutation.convertFromBytes(chunk.qualifier.value);
+      this.qualifiers = this.family[qualifierName] = [];
+      this.qualifier = {
+        value: Mutation.convertFromBytes(chunk.value, {
+          userOptions: this.options,
+          isPossibleNumber: true,
+        }),
+        labels: chunk.labels,
+        timestamp: chunk.timestampMicros,
+      };
+      this.qualifiers.push(this.qualifier);
+      this.moveToNextState(chunk);
+    }
+  }
+
+  /**
+   * Process chunk when in ROW_IN_PROGRESS state.
+   * @private
+   * @param {chunk} chunk chunk to process
+   */
+  processRowInProgress(chunk) {
+    this.validateRowInProgress(chunk);
+    if (chunk.resetRow) {
+      return this.reset();
+    }
     const row = this.row;
-    row.key = newRowKey;
-    row.data = {};
-    this.family = row.data[chunk.familyName.value] = {};
-    const qualifierName = Mutation.convertFromBytes(chunk.qualifier.value);
-    this.qualifiers = this.family[qualifierName] = [];
+    if (chunk.familyName) {
+      this.family = row.data[chunk.familyName.value] =
+        row.data[chunk.familyName.value] || {};
+    }
+    if (chunk.qualifier) {
+      const qualifierName = Mutation.convertFromBytes(chunk.qualifier.value);
+      this.qualifiers = this.family[qualifierName] =
+        this.family[qualifierName] || [];
+    }
     this.qualifier = {
       value: Mutation.convertFromBytes(chunk.value, {
         userOptions: this.options,
@@ -304,65 +347,35 @@ ChunkTransformer.prototype.processNewRow = function(chunk) {
     this.qualifiers.push(this.qualifier);
     this.moveToNextState(chunk);
   }
-};
-/**
- * Process chunk when in ROW_IN_PROGRESS state.
- * @private
- * @param {chunk} chunk chunk to process
- */
-ChunkTransformer.prototype.processRowInProgress = function(chunk) {
-  this.validateRowInProgress(chunk);
-  if (chunk.resetRow) {
-    return this.reset();
-  }
-  const row = this.row;
-  if (chunk.familyName) {
-    this.family = row.data[chunk.familyName.value] =
-      row.data[chunk.familyName.value] || {};
-  }
-  if (chunk.qualifier) {
-    const qualifierName = Mutation.convertFromBytes(chunk.qualifier.value);
-    this.qualifiers = this.family[qualifierName] =
-      this.family[qualifierName] || [];
-  }
-  this.qualifier = {
-    value: Mutation.convertFromBytes(chunk.value, {
-      userOptions: this.options,
-      isPossibleNumber: true,
-    }),
-    labels: chunk.labels,
-    timestamp: chunk.timestampMicros,
-  };
-  this.qualifiers.push(this.qualifier);
-  this.moveToNextState(chunk);
-};
-/**
- * Process chunk when in CELl_IN_PROGRESS state.
- * @private
- * @param {chunk} chunk chunk to process
- */
-ChunkTransformer.prototype.processCellInProgress = function(chunk) {
-  this.validateCellInProgress(chunk);
-  if (chunk.resetRow) {
-    return this.reset();
-  }
-  const chunkQualifierValue = Mutation.convertFromBytes(chunk.value, {
-    userOptions: this.options,
-  });
 
-  if (
-    chunkQualifierValue instanceof Buffer &&
-    this.qualifier.value instanceof Buffer
-  ) {
-    this.qualifier.value = Buffer.concat([
-      this.qualifier.value,
-      chunkQualifierValue,
-    ]);
-  } else {
-    this.qualifier.value += chunkQualifierValue;
+  /**
+   * Process chunk when in CELl_IN_PROGRESS state.
+   * @private
+   * @param {chunk} chunk chunk to process
+   */
+  processCellInProgress(chunk) {
+    this.validateCellInProgress(chunk);
+    if (chunk.resetRow) {
+      return this.reset();
+    }
+    const chunkQualifierValue = Mutation.convertFromBytes(chunk.value, {
+      userOptions: this.options,
+    });
+
+    if (
+      chunkQualifierValue instanceof Buffer &&
+      this.qualifier.value instanceof Buffer
+    ) {
+      this.qualifier.value = Buffer.concat([
+        this.qualifier.value,
+        chunkQualifierValue,
+      ]);
+    } else {
+      this.qualifier.value += chunkQualifierValue;
+    }
+    this.moveToNextState(chunk);
   }
-  this.moveToNextState(chunk);
-};
+}
 
 module.exports = ChunkTransformer;
 module.exports.RowStateEnum = RowStateEnum;

--- a/src/chunktransformer.js
+++ b/src/chunktransformer.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-'use strict';
 const Mutation = require('./mutation.js');
 const stream = require('stream');
 const util = require('util');

--- a/src/chunktransformer.js
+++ b/src/chunktransformer.js
@@ -116,7 +116,7 @@ ChunkTransformer.prototype._flush = function(cb) {
 ChunkTransformer.prototype.destroy = function(err) {
   if (this._destroyed) return;
   this._destroyed = true;
-  var self = this;
+  const self = this;
   if (err) {
     self.emit('error', err);
   }

--- a/src/chunktransformer.js
+++ b/src/chunktransformer.js
@@ -155,7 +155,7 @@ ChunkTransformer.prototype.validateValueSizeAndCommitRow = function(chunk) {
     this.destroy(
       new TransformError({
         message: 'A row cannot be have a value size and be a commit row',
-        chunk: chunk,
+        chunk,
       })
     );
   }
@@ -176,7 +176,7 @@ ChunkTransformer.prototype.validateResetRow = function(chunk) {
     this.destroy(
       new TransformError({
         message: 'A reset should have no data',
-        chunk: chunk,
+        chunk,
       })
     );
   }

--- a/src/chunktransformer.js
+++ b/src/chunktransformer.js
@@ -15,7 +15,6 @@
  */
 const Mutation = require('./mutation.js');
 const stream = require('stream');
-const util = require('util');
 const Transform = stream.Transform;
 const createErrorClass = require('create-error-class');
 

--- a/src/chunktransformer.js
+++ b/src/chunktransformer.js
@@ -41,8 +41,7 @@ const RowStateEnum = Object.freeze({
  * Should use new instance for each request.
  */
 class ChunkTransformer extends Transform {
-  constructor(options) {
-    options = options || {};
+  constructor(options = {}) {
     options.objectMode = true; // forcing object mode
     super(options);
     this.options = options;

--- a/src/cluster.js
+++ b/src/cluster.js
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-var common = require('@google-cloud/common');
-var format = require('string-format-obj');
-var is = require('is');
+const common = require('@google-cloud/common');
+const format = require('string-format-obj');
+const is = require('is');
 
 /**
  * Create a cluster object to interact with your cluster.
@@ -35,7 +35,7 @@ function Cluster(instance, name) {
   this.bigtable = instance.bigtable;
   this.instance = instance;
 
-  var id = name;
+  let id = name;
 
   if (id.indexOf('/') === -1) {
     id = `${instance.id}/clusters/${name}`;
@@ -87,7 +87,7 @@ Cluster.getLocation_ = function(project, location) {
  * // 1
  */
 Cluster.getStorageType_ = function(type) {
-  var storageTypes = {
+  const storageTypes = {
     unspecified: 0,
     ssd: 1,
     hdd: 2,
@@ -249,7 +249,7 @@ Cluster.prototype.exists = function(gaxOptions, callback) {
  * });
  */
 Cluster.prototype.get = function(gaxOptions, callback) {
-  var self = this;
+  const self = this;
 
   if (is.fn(gaxOptions)) {
     callback = gaxOptions;
@@ -284,7 +284,7 @@ Cluster.prototype.get = function(gaxOptions, callback) {
  * });
  */
 Cluster.prototype.getMetadata = function(gaxOptions, callback) {
-  var self = this;
+  const self = this;
 
   if (is.fn(gaxOptions)) {
     callback = gaxOptions;
@@ -363,7 +363,7 @@ Cluster.prototype.setMetadata = function(metadata, gaxOptions, callback) {
     gaxOptions = {};
   }
 
-  var reqOpts = {
+  const reqOpts = {
     name: this.id,
   };
 

--- a/src/cluster.js
+++ b/src/cluster.js
@@ -31,367 +31,369 @@ const is = require('is');
  * const instance = bigtable.instance('my-instance');
  * const cluster = instance.cluster('my-cluster');
  */
-function Cluster(instance, name) {
-  this.bigtable = instance.bigtable;
-  this.instance = instance;
+class Cluster {
+  constructor(instance, name) {
+    this.bigtable = instance.bigtable;
+    this.instance = instance;
 
-  let id = name;
+    let id = name;
 
-  if (id.indexOf('/') === -1) {
-    id = `${instance.id}/clusters/${name}`;
-  }
-
-  this.id = id;
-  this.name = id.split('/').pop();
-}
-
-/**
- * Formats zone location.
- *
- * @private
- *
- * @param {string} project The project ID.
- * @param {string} location The zone location.
- * @returns {string}
- *
- * @example
- * Cluster.getLocation_('my-project', 'us-central1-b');
- * // 'projects/my-project/locations/us-central1-b'
- */
-Cluster.getLocation_ = function(project, location) {
-  if (location.indexOf('/') > -1) {
-    return location;
-  }
-
-  // in-case project has '/', split and pick last component
-  if (project.indexOf('/') > -1) {
-    project = project.split('/').pop();
-  }
-
-  return format('projects/{project}/locations/{location}', {
-    project,
-    location,
-  });
-};
-
-/**
- * Maps the storage type to the proper integer.
- *
- * @private
- *
- * @param {string} type The storage type (hdd, ssd).
- * @returns {number}
- *
- * @example
- * Cluster.getStorageType_('ssd');
- * // 1
- */
-Cluster.getStorageType_ = function(type) {
-  const storageTypes = {
-    unspecified: 0,
-    ssd: 1,
-    hdd: 2,
-  };
-
-  if (is.string(type)) {
-    type = type.toLowerCase();
-  }
-
-  return storageTypes[type] || storageTypes.unspecified;
-};
-
-/**
- * Create a cluster.
- *
- * @param {object} [options] See {@link Instance#createCluster}.
- * @param {function} [callback] The callback function.
- * @param {?error} callback.err An error returned while making this
- *     request.
- * @param {object} callback.apiResponse The full API response.
- *
- * @example
- * const Bigtable = require('@google-cloud/bigtable');
- * const bigtable = new Bigtable();
- * const instance = bigtable.instance('my-instance');
- * const cluster = instance.cluster('my-cluster');
- *
- * cluster.create(function(err, cluster, operation, apiResponse) {
- *   if (err) {
- *     // Error handling omitted.
- *   }
- *
- *   operation
- *     .on('error', console.error)
- *     .on('complete', function() {
- *       // The cluster was created successfully.
- *     });
- * });
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * cluster.create().then(function(data) {
- *   const cluster = data[0];
- *   const operation = data[1];
- *   const apiResponse = data[2];
- * });
- */
-Cluster.prototype.create = function(options, callback) {
-  if (is.fn(options)) {
-    callback = options;
-    options = {};
-  }
-
-  this.instance.createCluster(this.name, options, callback);
-};
-
-/**
- * Delete the cluster.
- *
- * @param {object} [gaxOptions] Request configuration options, outlined here:
- *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
- * @param {function} [callback] The callback function.
- * @param {?error} callback.err An error returned while making this
- *     request.
- * @param {object} callback.apiResponse The full API response.
- *
- * @example
- * cluster.delete(function(err, apiResponse) {});
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * cluster.delete().then(function(data) {
- *   var apiResponse = data[0];
- * });
- */
-Cluster.prototype.delete = function(gaxOptions, callback) {
-  if (is.fn(gaxOptions)) {
-    callback = gaxOptions;
-    gaxOptions = {};
-  }
-
-  this.bigtable.request(
-    {
-      client: 'BigtableInstanceAdminClient',
-      method: 'deleteCluster',
-      reqOpts: {
-        name: this.id,
-      },
-      gaxOpts: gaxOptions,
-    },
-    callback
-  );
-};
-
-/**
- * Check if a cluster exists.
- *
- * @param {object} [gaxOptions] Request configuration options, outlined here:
- *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
- * @param {function} callback The callback function.
- * @param {?error} callback.err An error returned while making this
- *     request.
- * @param {boolean} callback.exists Whether the cluster exists or not.
- *
- * @example
- * cluster.exists(function(err, exists) {});
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * cluster.exists().then(function(data) {
- *   var exists = data[0];
- * });
- */
-Cluster.prototype.exists = function(gaxOptions, callback) {
-  if (is.fn(gaxOptions)) {
-    callback = gaxOptions;
-    gaxOptions = {};
-  }
-
-  this.getMetadata(gaxOptions, function(err) {
-    if (err) {
-      if (err.code === 5) {
-        callback(null, false);
-        return;
-      }
-
-      callback(err);
-      return;
+    if (id.indexOf('/') === -1) {
+      id = `${instance.id}/clusters/${name}`;
     }
 
-    callback(null, true);
-  });
-};
-
-/**
- * Get a cluster if it exists.
- *
- * @param {object} [gaxOptions] Request configuration options, outlined here:
- *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
- * @param {function} callback The callback function.
- * @param {?error} callback.err An error returned while making this
- *     request.
- * @param {object} callback.apiResponse The full API response.
- *
- * @example
- * cluster.get(function(err, cluster, apiResponse) {
- *   // The `cluster` data has been populated.
- * });
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * cluster.get().then(function(data) {
- *   var cluster = data[0];
- *   var apiResponse = data[1];
- * });
- */
-Cluster.prototype.get = function(gaxOptions, callback) {
-  const self = this;
-
-  if (is.fn(gaxOptions)) {
-    callback = gaxOptions;
-    gaxOptions = {};
+    this.id = id;
+    this.name = id.split('/').pop();
   }
 
-  this.getMetadata(gaxOptions, function(err, metadata) {
-    callback(err, err ? null : self, metadata);
-  });
-};
-
-/**
- * Get the cluster metadata.
- *
- * @param {object} [gaxOptions] Request configuration options, outlined
- *     here: https://googleapis.github.io/gax-nodejs/CallSettings.html.
- * @param {function} callback The callback function.
- * @param {?error} callback.err An error returned while making this
- *     request.
- * @param {object} callback.metadata The metadata.
- * @param {object} callback.apiResponse The full API response.
- *
- * @example
- * cluster.getMetadata(function(err, metadata, apiResponse) {});
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * cluster.getMetadata().then(function(data) {
- *   var metadata = data[0];
- *   var apiResponse = data[1];
- * });
- */
-Cluster.prototype.getMetadata = function(gaxOptions, callback) {
-  const self = this;
-
-  if (is.fn(gaxOptions)) {
-    callback = gaxOptions;
-    gaxOptions = {};
-  }
-
-  this.bigtable.request(
-    {
-      client: 'BigtableInstanceAdminClient',
-      method: 'getCluster',
-      reqOpts: {
-        name: this.id,
-      },
-      gaxOpts: gaxOptions,
-    },
-    function(...args) {
-      if (args[1]) {
-        self.metadata = args[1];
-      }
-
-      callback(...args);
+  /**
+   * Formats zone location.
+   *
+   * @private
+   *
+   * @param {string} project The project ID.
+   * @param {string} location The zone location.
+   * @returns {string}
+   *
+   * @example
+   * Cluster.getLocation_('my-project', 'us-central1-b');
+   * // 'projects/my-project/locations/us-central1-b'
+   */
+  static getLocation_(project, location) {
+    if (location.indexOf('/') > -1) {
+      return location;
     }
-  );
-};
 
-/**
- * Set the cluster metadata.
- *
- * @param {object} metadata See {@link Instance#createCluster} for the
- *     available metadata options.
- * @param {object} [gaxOptions] Request configuration options, outlined here:
- *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
- * @param {function} callback The callback function.
- * @param {?error} callback.err An error returned while making this request.
- * @param {Operation} callback.operation An operation object that can be used
- *     to check the status of the request.
- * @param {object} callback.apiResponse The full API response.
- *
- * @example
- * const Bigtable = require('@google-cloud/bigtable');
- * const bigtable = new Bigtable();
- * const instance = bigtable.instance('my-instance');
- * const cluster = instance.cluster('my-cluster');
- *
- * const callback = function(err, operation, apiResponse) {
- *   if (err) {
- *     // Error handling omitted.
- *   }
- *
- *   operation
- *     .on('error', console.error)
- *     .on('complete', function() {
- *       // The cluster was updated successfully.
- *     });
- * };
- *
- * const metadata = {
- *   location: 'us-central1-b',
- *   nodes: 3,
- *   storage: 'ssd'
- * };
- *
- * cluster.setMetadata(metadata, callback);
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * cluster.setMetadata(metadata).then(function(data) {
- *   const operation = data[0];
- *   const apiResponse = data[1];
- * });
- */
-Cluster.prototype.setMetadata = function(metadata, gaxOptions, callback) {
-  if (is.fn(gaxOptions)) {
-    callback = gaxOptions;
-    gaxOptions = {};
+    // in-case project has '/', split and pick last component
+    if (project.indexOf('/') > -1) {
+      project = project.split('/').pop();
+    }
+
+    return format('projects/{project}/locations/{location}', {
+      project,
+      location,
+    });
   }
 
-  const reqOpts = {
-    name: this.id,
-  };
+  /**
+   * Maps the storage type to the proper integer.
+   *
+   * @private
+   *
+   * @param {string} type The storage type (hdd, ssd).
+   * @returns {number}
+   *
+   * @example
+   * Cluster.getStorageType_('ssd');
+   * // 1
+   */
+  static getStorageType_(type) {
+    const storageTypes = {
+      unspecified: 0,
+      ssd: 1,
+      hdd: 2,
+    };
 
-  if (metadata.location) {
-    reqOpts.location = Cluster.getLocation_(
-      this.bigtable.projectId,
-      metadata.location
+    if (is.string(type)) {
+      type = type.toLowerCase();
+    }
+
+    return storageTypes[type] || storageTypes.unspecified;
+  }
+
+  /**
+   * Create a cluster.
+   *
+   * @param {object} [options] See {@link Instance#createCluster}.
+   * @param {function} [callback] The callback function.
+   * @param {?error} callback.err An error returned while making this
+   *     request.
+   * @param {object} callback.apiResponse The full API response.
+   *
+   * @example
+   * const Bigtable = require('@google-cloud/bigtable');
+   * const bigtable = new Bigtable();
+   * const instance = bigtable.instance('my-instance');
+   * const cluster = instance.cluster('my-cluster');
+   *
+   * cluster.create(function(err, cluster, operation, apiResponse) {
+   *   if (err) {
+   *     // Error handling omitted.
+   *   }
+   *
+   *   operation
+   *     .on('error', console.error)
+   *     .on('complete', function() {
+   *       // The cluster was created successfully.
+   *     });
+   * });
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * cluster.create().then(function(data) {
+   *   const cluster = data[0];
+   *   const operation = data[1];
+   *   const apiResponse = data[2];
+   * });
+   */
+  create(options, callback) {
+    if (is.fn(options)) {
+      callback = options;
+      options = {};
+    }
+
+    this.instance.createCluster(this.name, options, callback);
+  }
+
+  /**
+   * Delete the cluster.
+   *
+   * @param {object} [gaxOptions] Request configuration options, outlined here:
+   *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
+   * @param {function} [callback] The callback function.
+   * @param {?error} callback.err An error returned while making this
+   *     request.
+   * @param {object} callback.apiResponse The full API response.
+   *
+   * @example
+   * cluster.delete(function(err, apiResponse) {});
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * cluster.delete().then(function(data) {
+   *   var apiResponse = data[0];
+   * });
+   */
+  delete(gaxOptions, callback) {
+    if (is.fn(gaxOptions)) {
+      callback = gaxOptions;
+      gaxOptions = {};
+    }
+
+    this.bigtable.request(
+      {
+        client: 'BigtableInstanceAdminClient',
+        method: 'deleteCluster',
+        reqOpts: {
+          name: this.id,
+        },
+        gaxOpts: gaxOptions,
+      },
+      callback
     );
   }
 
-  if (metadata.nodes) {
-    reqOpts.serveNodes = metadata.nodes;
+  /**
+   * Check if a cluster exists.
+   *
+   * @param {object} [gaxOptions] Request configuration options, outlined here:
+   *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
+   * @param {function} callback The callback function.
+   * @param {?error} callback.err An error returned while making this
+   *     request.
+   * @param {boolean} callback.exists Whether the cluster exists or not.
+   *
+   * @example
+   * cluster.exists(function(err, exists) {});
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * cluster.exists().then(function(data) {
+   *   var exists = data[0];
+   * });
+   */
+  exists(gaxOptions, callback) {
+    if (is.fn(gaxOptions)) {
+      callback = gaxOptions;
+      gaxOptions = {};
+    }
+
+    this.getMetadata(gaxOptions, function(err) {
+      if (err) {
+        if (err.code === 5) {
+          callback(null, false);
+          return;
+        }
+
+        callback(err);
+        return;
+      }
+
+      callback(null, true);
+    });
   }
 
-  if (metadata.storage) {
-    reqOpts.defaultStorageType = Cluster.getStorageType_(metadata.storage);
+  /**
+   * Get a cluster if it exists.
+   *
+   * @param {object} [gaxOptions] Request configuration options, outlined here:
+   *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
+   * @param {function} callback The callback function.
+   * @param {?error} callback.err An error returned while making this
+   *     request.
+   * @param {object} callback.apiResponse The full API response.
+   *
+   * @example
+   * cluster.get(function(err, cluster, apiResponse) {
+   *   // The `cluster` data has been populated.
+   * });
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * cluster.get().then(function(data) {
+   *   var cluster = data[0];
+   *   var apiResponse = data[1];
+   * });
+   */
+  get(gaxOptions, callback) {
+    const self = this;
+
+    if (is.fn(gaxOptions)) {
+      callback = gaxOptions;
+      gaxOptions = {};
+    }
+
+    this.getMetadata(gaxOptions, function(err, metadata) {
+      callback(err, err ? null : self, metadata);
+    });
   }
 
-  this.bigtable.request(
-    {
-      client: 'BigtableInstanceAdminClient',
-      method: 'updateCluster',
-      reqOpts,
-      gaxOpts: gaxOptions,
-    },
-    callback
-  );
-};
+  /**
+   * Get the cluster metadata.
+   *
+   * @param {object} [gaxOptions] Request configuration options, outlined
+   *     here: https://googleapis.github.io/gax-nodejs/CallSettings.html.
+   * @param {function} callback The callback function.
+   * @param {?error} callback.err An error returned while making this
+   *     request.
+   * @param {object} callback.metadata The metadata.
+   * @param {object} callback.apiResponse The full API response.
+   *
+   * @example
+   * cluster.getMetadata(function(err, metadata, apiResponse) {});
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * cluster.getMetadata().then(function(data) {
+   *   var metadata = data[0];
+   *   var apiResponse = data[1];
+   * });
+   */
+  getMetadata(gaxOptions, callback) {
+    const self = this;
+
+    if (is.fn(gaxOptions)) {
+      callback = gaxOptions;
+      gaxOptions = {};
+    }
+
+    this.bigtable.request(
+      {
+        client: 'BigtableInstanceAdminClient',
+        method: 'getCluster',
+        reqOpts: {
+          name: this.id,
+        },
+        gaxOpts: gaxOptions,
+      },
+      function(...args) {
+        if (args[1]) {
+          self.metadata = args[1];
+        }
+
+        callback(...args);
+      }
+    );
+  }
+
+  /**
+   * Set the cluster metadata.
+   *
+   * @param {object} metadata See {@link Instance#createCluster} for the
+   *     available metadata options.
+   * @param {object} [gaxOptions] Request configuration options, outlined here:
+   *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
+   * @param {function} callback The callback function.
+   * @param {?error} callback.err An error returned while making this request.
+   * @param {Operation} callback.operation An operation object that can be used
+   *     to check the status of the request.
+   * @param {object} callback.apiResponse The full API response.
+   *
+   * @example
+   * const Bigtable = require('@google-cloud/bigtable');
+   * const bigtable = new Bigtable();
+   * const instance = bigtable.instance('my-instance');
+   * const cluster = instance.cluster('my-cluster');
+   *
+   * const callback = function(err, operation, apiResponse) {
+   *   if (err) {
+   *     // Error handling omitted.
+   *   }
+   *
+   *   operation
+   *     .on('error', console.error)
+   *     .on('complete', function() {
+   *       // The cluster was updated successfully.
+   *     });
+   * };
+   *
+   * const metadata = {
+   *   location: 'us-central1-b',
+   *   nodes: 3,
+   *   storage: 'ssd'
+   * };
+   *
+   * cluster.setMetadata(metadata, callback);
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * cluster.setMetadata(metadata).then(function(data) {
+   *   const operation = data[0];
+   *   const apiResponse = data[1];
+   * });
+   */
+  setMetadata(metadata, gaxOptions, callback) {
+    if (is.fn(gaxOptions)) {
+      callback = gaxOptions;
+      gaxOptions = {};
+    }
+
+    const reqOpts = {
+      name: this.id,
+    };
+
+    if (metadata.location) {
+      reqOpts.location = Cluster.getLocation_(
+        this.bigtable.projectId,
+        metadata.location
+      );
+    }
+
+    if (metadata.nodes) {
+      reqOpts.serveNodes = metadata.nodes;
+    }
+
+    if (metadata.storage) {
+      reqOpts.defaultStorageType = Cluster.getStorageType_(metadata.storage);
+    }
+
+    this.bigtable.request(
+      {
+        client: 'BigtableInstanceAdminClient',
+        method: 'updateCluster',
+        reqOpts,
+        gaxOpts: gaxOptions,
+      },
+      callback
+    );
+  }
+}
 
 /*! Developer Documentation
  *

--- a/src/cluster.js
+++ b/src/cluster.js
@@ -71,8 +71,8 @@ Cluster.getLocation_ = function(project, location) {
   }
 
   return format('projects/{project}/locations/{location}', {
-    project: project,
-    location: location,
+    project,
+    location,
   });
 };
 
@@ -388,7 +388,7 @@ Cluster.prototype.setMetadata = function(metadata, gaxOptions, callback) {
     {
       client: 'BigtableInstanceAdminClient',
       method: 'updateCluster',
-      reqOpts: reqOpts,
+      reqOpts,
       gaxOpts: gaxOptions,
     },
     callback

--- a/src/cluster.js
+++ b/src/cluster.js
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-'use strict';
-
 var common = require('@google-cloud/common');
 var format = require('string-format-obj');
 var is = require('is');

--- a/src/cluster.js
+++ b/src/cluster.js
@@ -38,7 +38,7 @@ class Cluster {
 
     let id = name;
 
-    if (id.indexOf('/') === -1) {
+    if (!id.includes('/')) {
       id = `${instance.id}/clusters/${name}`;
     }
 
@@ -60,12 +60,12 @@ class Cluster {
    * // 'projects/my-project/locations/us-central1-b'
    */
   static getLocation_(project, location) {
-    if (location.indexOf('/') > -1) {
+    if (location.includes('/')) {
       return location;
     }
 
     // in-case project has '/', split and pick last component
-    if (project.indexOf('/') > -1) {
+    if (project.includes('/')) {
       project = project.split('/').pop();
     }
 

--- a/src/family.js
+++ b/src/family.js
@@ -40,412 +40,414 @@ const FamilyError = createErrorClass('FamilyError', function(name) {
  * const table = instance.table('prezzy');
  * const family = table.family('follows');
  */
-function Family(table, name) {
-  this.bigtable = table.bigtable;
-  this.table = table;
+class Family {
+  constructor(table, name) {
+    this.bigtable = table.bigtable;
+    this.table = table;
 
-  this.id = Family.formatName_(table.id, name);
+    this.id = Family.formatName_(table.id, name);
+
+    /**
+     * @name Family#familyName
+     * @type {string}
+     */
+    this.familyName = name.split('/').pop();
+  }
 
   /**
-   * @name Family#familyName
-   * @type {string}
+   * Format the Column Family name into the expected proto format.
+   *
+   * @private
+   *
+   * @param {string} tableName The full formatted table name.
+   * @param {string} name The column family name.
+   * @returns {string}
+   *
+   * @example
+   * Family.formatName_(
+   *   'projects/p/zones/z/clusters/c/tables/t',
+   *   'my-family'
+   * );
+   * // 'projects/p/zones/z/clusters/c/tables/t/columnFamilies/my-family'
    */
-  this.familyName = name.split('/').pop();
-}
-
-/**
- * Format the Column Family name into the expected proto format.
- *
- * @private
- *
- * @param {string} tableName The full formatted table name.
- * @param {string} name The column family name.
- * @returns {string}
- *
- * @example
- * Family.formatName_(
- *   'projects/p/zones/z/clusters/c/tables/t',
- *   'my-family'
- * );
- * // 'projects/p/zones/z/clusters/c/tables/t/columnFamilies/my-family'
- */
-Family.formatName_ = function(tableName, name) {
-  if (name.indexOf('/') > -1) {
-    return name;
-  }
-
-  return tableName + '/columnFamilies/' + name;
-};
-
-/**
- * Formats Garbage Collection rule into proto format.
- *
- * @private
- *
- * @param {object} ruleObj The rule object.
- * @returns {object}
- *
- * @example
- * Family.formatRule({
- *   age: {
- *     seconds: 10000,
- *     nanos: 10000
- *   },
- *   versions: 2,
- *   union: true
- * });
- * // {
- * //   union: {
- * //     rules: [
- * //       {
- * //         maxAge: {
- * //           seconds: 10000,
- * //           nanos: 10000
- * //         }
- * //       }, {
- * //         maxNumVersions: 2
- * //       }
- * //     ]
- * //   }
- * // }
- */
-Family.formatRule_ = function(ruleObj) {
-  const rules = [];
-
-  if (ruleObj.age) {
-    rules.push({
-      maxAge: ruleObj.age,
-    });
-  }
-
-  if (ruleObj.versions) {
-    rules.push({
-      maxNumVersions: ruleObj.versions,
-    });
-  }
-
-  if (ruleObj.rule) {
-    rules.push(Family.formatRule_(ruleObj.rule));
-  }
-
-  if (rules.length === 1) {
-    if (ruleObj.union) {
-      throw new Error(
-        'A union must have more than one garbage collection rule.'
-      );
+  static formatName_(tableName, name) {
+    if (name.indexOf('/') > -1) {
+      return name;
     }
-    return rules[0];
+
+    return tableName + '/columnFamilies/' + name;
   }
 
-  if (rules.length === 0) {
-    throw new Error('No garbage collection rules were specified.');
+  /**
+   * Formats Garbage Collection rule into proto format.
+   *
+   * @private
+   *
+   * @param {object} ruleObj The rule object.
+   * @returns {object}
+   *
+   * @example
+   * Family.formatRule({
+   *   age: {
+   *     seconds: 10000,
+   *     nanos: 10000
+   *   },
+   *   versions: 2,
+   *   union: true
+   * });
+   * // {
+   * //   union: {
+   * //     rules: [
+   * //       {
+   * //         maxAge: {
+   * //           seconds: 10000,
+   * //           nanos: 10000
+   * //         }
+   * //       }, {
+   * //         maxNumVersions: 2
+   * //       }
+   * //     ]
+   * //   }
+   * // }
+   */
+  static formatRule_(ruleObj) {
+    const rules = [];
+
+    if (ruleObj.age) {
+      rules.push({
+        maxAge: ruleObj.age,
+      });
+    }
+
+    if (ruleObj.versions) {
+      rules.push({
+        maxNumVersions: ruleObj.versions,
+      });
+    }
+
+    if (ruleObj.rule) {
+      rules.push(Family.formatRule_(ruleObj.rule));
+    }
+
+    if (rules.length === 1) {
+      if (ruleObj.union) {
+        throw new Error(
+          'A union must have more than one garbage collection rule.'
+        );
+      }
+      return rules[0];
+    }
+
+    if (rules.length === 0) {
+      throw new Error('No garbage collection rules were specified.');
+    }
+
+    const rule = {};
+    const ruleType = ruleObj.union ? 'union' : 'intersection';
+
+    rule[ruleType] = {
+      rules,
+    };
+
+    return rule;
   }
 
-  const rule = {};
-  const ruleType = ruleObj.union ? 'union' : 'intersection';
+  /**
+   * Create a column family.
+   *
+   * @param {object} [options] See {@link Table#createFamily}.
+   * @param {function} callback The callback function.
+   * @param {?error} callback.err An error returned while making this
+   *     request.
+   * @param {Family} callback.family The metadata.
+   * @param {object} callback.apiResponse The full API response.
+   *
+   * @example
+   * family.create(function(err, family, apiResponse) {
+   *   // The column family was created successfully.
+   * });
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * family.create().then(function(data) {
+   *   const family = data[0];
+   *   const apiResponse = data[1];
+   * });
+   */
+  create(options, callback) {
+    if (is.fn(options)) {
+      callback = options;
+      options = {};
+    }
 
-  rule[ruleType] = {
-    rules,
-  };
-
-  return rule;
-};
-
-/**
- * Create a column family.
- *
- * @param {object} [options] See {@link Table#createFamily}.
- * @param {function} callback The callback function.
- * @param {?error} callback.err An error returned while making this
- *     request.
- * @param {Family} callback.family The metadata.
- * @param {object} callback.apiResponse The full API response.
- *
- * @example
- * family.create(function(err, family, apiResponse) {
- *   // The column family was created successfully.
- * });
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * family.create().then(function(data) {
- *   const family = data[0];
- *   const apiResponse = data[1];
- * });
- */
-Family.prototype.create = function(options, callback) {
-  if (is.fn(options)) {
-    callback = options;
-    options = {};
+    this.table.createFamily(this.familyName, options, callback);
   }
 
-  this.table.createFamily(this.familyName, options, callback);
-};
+  /**
+   * Delete the column family.
+   *
+   * @param {object} [gaxOptions] Request configuration options, outlined here:
+   *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
+   * @param {function} [callback] The callback function.
+   * @param {?error} callback.err An error returned while making this
+   *     request.
+   * @param {object} callback.apiResponse The full API response.
+   *
+   * @example
+   * family.delete(function(err, apiResponse) {});
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * family.delete().then(function(data) {
+   *   const apiResponse = data[0];
+   * });
+   */
+  delete(gaxOptions, callback) {
+    if (is.fn(gaxOptions)) {
+      callback = gaxOptions;
+      gaxOptions = {};
+    }
 
-/**
- * Delete the column family.
- *
- * @param {object} [gaxOptions] Request configuration options, outlined here:
- *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
- * @param {function} [callback] The callback function.
- * @param {?error} callback.err An error returned while making this
- *     request.
- * @param {object} callback.apiResponse The full API response.
- *
- * @example
- * family.delete(function(err, apiResponse) {});
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * family.delete().then(function(data) {
- *   const apiResponse = data[0];
- * });
- */
-Family.prototype.delete = function(gaxOptions, callback) {
-  if (is.fn(gaxOptions)) {
-    callback = gaxOptions;
-    gaxOptions = {};
-  }
-
-  this.bigtable.request(
-    {
-      client: 'BigtableTableAdminClient',
-      method: 'modifyColumnFamilies',
-      reqOpts: {
-        name: this.table.id,
-        modifications: [
-          {
-            id: this.familyName,
-            drop: true,
-          },
-        ],
+    this.bigtable.request(
+      {
+        client: 'BigtableTableAdminClient',
+        method: 'modifyColumnFamilies',
+        reqOpts: {
+          name: this.table.id,
+          modifications: [
+            {
+              id: this.familyName,
+              drop: true,
+            },
+          ],
+        },
+        gaxOpts: gaxOptions,
       },
-      gaxOpts: gaxOptions,
-    },
-    callback
-  );
-};
-
-/**
- * Check if the column family exists.
- *
- * @param {object} [gaxOptions] Request configuration options, outlined here:
- *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
- * @param {function} callback The callback function.
- * @param {?error} callback.err An error returned while making this
- *     request.
- * @param {boolean} callback.exists Whether the family exists or not.
- *
- * @example
- * family.exists(function(err, exists) {});
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * family.exists().then(function(data) {
- *   const exists = data[0];
- * });
- */
-Family.prototype.exists = function(gaxOptions, callback) {
-  if (is.fn(gaxOptions)) {
-    callback = gaxOptions;
-    gaxOptions = {};
+      callback
+    );
   }
 
-  this.getMetadata(gaxOptions, function(err) {
-    if (err) {
-      if (err instanceof FamilyError) {
-        callback(null, false);
+  /**
+   * Check if the column family exists.
+   *
+   * @param {object} [gaxOptions] Request configuration options, outlined here:
+   *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
+   * @param {function} callback The callback function.
+   * @param {?error} callback.err An error returned while making this
+   *     request.
+   * @param {boolean} callback.exists Whether the family exists or not.
+   *
+   * @example
+   * family.exists(function(err, exists) {});
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * family.exists().then(function(data) {
+   *   const exists = data[0];
+   * });
+   */
+  exists(gaxOptions, callback) {
+    if (is.fn(gaxOptions)) {
+      callback = gaxOptions;
+      gaxOptions = {};
+    }
+
+    this.getMetadata(gaxOptions, function(err) {
+      if (err) {
+        if (err instanceof FamilyError) {
+          callback(null, false);
+          return;
+        }
+
+        callback(err);
         return;
       }
 
-      callback(err);
-      return;
-    }
-
-    callback(null, true);
-  });
-};
-
-/**
- * Get a column family if it exists.
- *
- * You may optionally use this to "get or create" an object by providing an
- * object with `autoCreate` set to `true`. Any extra configuration that is
- * normally required for the `create` method must be contained within this
- * object as well.
- *
- * @param {object} [options] Configuration object.
- * @param {boolean} [options.autoCreate=false] Automatically create the
- *     instance if it does not already exist.
- * @param {object} [options.gaxOptions] Request configuration options, outlined
- *     here: https://googleapis.github.io/gax-nodejs/CallSettings.html.
- * @param {?error} callback.error An error returned while making this request.
- * @param {Family} callback.family The Family object.
- * @param {object} callback.apiResponse The resource as it exists in the API.
- *
- * @example
- * family.get(function(err, family, apiResponse) {
- *   // `family.metadata` has been populated.
- * });
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * family.get().then(function(data) {
- *   const family = data[0];
- *   const apiResponse = data[1];
- * });
- */
-Family.prototype.get = function(options, callback) {
-  const self = this;
-
-  if (is.fn(options)) {
-    callback = options;
-    options = {};
+      callback(null, true);
+    });
   }
 
-  const autoCreate = !!options.autoCreate;
-  const gaxOptions = options.gaxOptions;
+  /**
+   * Get a column family if it exists.
+   *
+   * You may optionally use this to "get or create" an object by providing an
+   * object with `autoCreate` set to `true`. Any extra configuration that is
+   * normally required for the `create` method must be contained within this
+   * object as well.
+   *
+   * @param {object} [options] Configuration object.
+   * @param {boolean} [options.autoCreate=false] Automatically create the
+   *     instance if it does not already exist.
+   * @param {object} [options.gaxOptions] Request configuration options, outlined
+   *     here: https://googleapis.github.io/gax-nodejs/CallSettings.html.
+   * @param {?error} callback.error An error returned while making this request.
+   * @param {Family} callback.family The Family object.
+   * @param {object} callback.apiResponse The resource as it exists in the API.
+   *
+   * @example
+   * family.get(function(err, family, apiResponse) {
+   *   // `family.metadata` has been populated.
+   * });
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * family.get().then(function(data) {
+   *   const family = data[0];
+   *   const apiResponse = data[1];
+   * });
+   */
+  get(options, callback) {
+    const self = this;
 
-  this.getMetadata(gaxOptions, function(err, metadata) {
-    if (err) {
-      if (err instanceof FamilyError && autoCreate) {
-        self.create({gaxOptions, rule: options.rule}, callback);
+    if (is.fn(options)) {
+      callback = options;
+      options = {};
+    }
+
+    const autoCreate = !!options.autoCreate;
+    const gaxOptions = options.gaxOptions;
+
+    this.getMetadata(gaxOptions, function(err, metadata) {
+      if (err) {
+        if (err instanceof FamilyError && autoCreate) {
+          self.create({gaxOptions, rule: options.rule}, callback);
+          return;
+        }
+
+        callback(err);
         return;
       }
 
-      callback(err);
-      return;
-    }
-
-    callback(null, self, metadata);
-  });
-};
-
-/**
- * Get the column family's metadata.
- *
- * @param {object} [gaxOptions] Request configuration options, outlined here:
- *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
- * @param {function} callback The callback function.
- * @param {?error} callback.err An error returned while making this
- *     request.
- * @param {object} callback.metadata The metadata.
- *
- * @example
- * family.getMetadata(function(err, metadata, apiResponse) {});
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * family.getMetadata().then(function(data) {
- *   var metadata = data[0];
- *   var apiResponse = data[1];
- * });
- */
-Family.prototype.getMetadata = function(gaxOptions, callback) {
-  const self = this;
-
-  if (is.fn(gaxOptions)) {
-    callback = gaxOptions;
-    gaxOptions = {};
+      callback(null, self, metadata);
+    });
   }
 
-  this.table.getFamilies(gaxOptions, function(err, families) {
-    if (err) {
-      callback(err);
-      return;
+  /**
+   * Get the column family's metadata.
+   *
+   * @param {object} [gaxOptions] Request configuration options, outlined here:
+   *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
+   * @param {function} callback The callback function.
+   * @param {?error} callback.err An error returned while making this
+   *     request.
+   * @param {object} callback.metadata The metadata.
+   *
+   * @example
+   * family.getMetadata(function(err, metadata, apiResponse) {});
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * family.getMetadata().then(function(data) {
+   *   var metadata = data[0];
+   *   var apiResponse = data[1];
+   * });
+   */
+  getMetadata(gaxOptions, callback) {
+    const self = this;
+
+    if (is.fn(gaxOptions)) {
+      callback = gaxOptions;
+      gaxOptions = {};
     }
 
-    for (let i = 0, l = families.length; i < l; i++) {
-      if (families[i].id === self.id) {
-        self.metadata = families[i].metadata;
-        callback(null, self.metadata);
+    this.table.getFamilies(gaxOptions, function(err, families) {
+      if (err) {
+        callback(err);
         return;
       }
-    }
 
-    const error = new FamilyError(self.id);
-    callback(error);
-  });
-};
-
-/**
- * Set the column family's metadata.
- *
- * See {@link Table#createFamily} for a detailed explanation of the
- * arguments.
- *
- * @see [Garbage Collection Proto Docs]{@link https://github.com/googleapis/googleapis/blob/3592a7339da5a31a3565870989beb86e9235476e/google/bigtable/admin/table/v1/bigtable_table_data.proto#L59}
- *
- * @param {object} metadata Metadata object.
- * @param {object} [metadata.rule] Garbage collection rule.
- * @param {object} [gaxOptions] Request configuration options, outlined here:
- *     https://googleapis.github.io/gax-nodejs/global.html#CallOptions.
- * @param {function} callback The callback function.
- * @param {?error} callback.err An error returned while making this
- *     request.
- * @param {object} callback.apiResponse The full API response.
- *
- * @example
- * var metadata = {
- *   rule: {
- *     versions: 2,
- *     union: true
- *   }
- * };
- *
- * family.setMetadata(metadata, function(err, apiResponse) {});
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * family.setMetadata(metadata).then(function(data) {
- *   var apiResponse = data[0];
- * });
- */
-Family.prototype.setMetadata = function(metadata, gaxOptions, callback) {
-  const self = this;
-
-  if (is.fn(gaxOptions)) {
-    callback = gaxOptions;
-    gaxOptions = {};
-  }
-
-  const mod = {
-    id: this.familyName,
-    update: {},
-  };
-
-  if (metadata.rule) {
-    mod.update.gcRule = Family.formatRule_(metadata.rule);
-  }
-
-  const reqOpts = {
-    name: this.table.id,
-    modifications: [mod],
-  };
-
-  this.bigtable.request(
-    {
-      client: 'BigtableTableAdminClient',
-      method: 'modifyColumnFamilies',
-      reqOpts,
-      gaxOpts: gaxOptions,
-    },
-    function(...args) {
-      if (args[1]) {
-        self.metadata = args[1].columnFamilies[self.familyName];
-        args.splice(1, 0, self.metadata);
+      for (let i = 0, l = families.length; i < l; i++) {
+        if (families[i].id === self.id) {
+          self.metadata = families[i].metadata;
+          callback(null, self.metadata);
+          return;
+        }
       }
 
-      callback(...args);
+      const error = new FamilyError(self.id);
+      callback(error);
+    });
+  }
+
+  /**
+   * Set the column family's metadata.
+   *
+   * See {@link Table#createFamily} for a detailed explanation of the
+   * arguments.
+   *
+   * @see [Garbage Collection Proto Docs]{@link https://github.com/googleapis/googleapis/blob/3592a7339da5a31a3565870989beb86e9235476e/google/bigtable/admin/table/v1/bigtable_table_data.proto#L59}
+   *
+   * @param {object} metadata Metadata object.
+   * @param {object} [metadata.rule] Garbage collection rule.
+   * @param {object} [gaxOptions] Request configuration options, outlined here:
+   *     https://googleapis.github.io/gax-nodejs/global.html#CallOptions.
+   * @param {function} callback The callback function.
+   * @param {?error} callback.err An error returned while making this
+   *     request.
+   * @param {object} callback.apiResponse The full API response.
+   *
+   * @example
+   * var metadata = {
+   *   rule: {
+   *     versions: 2,
+   *     union: true
+   *   }
+   * };
+   *
+   * family.setMetadata(metadata, function(err, apiResponse) {});
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * family.setMetadata(metadata).then(function(data) {
+   *   var apiResponse = data[0];
+   * });
+   */
+  setMetadata(metadata, gaxOptions, callback) {
+    const self = this;
+
+    if (is.fn(gaxOptions)) {
+      callback = gaxOptions;
+      gaxOptions = {};
     }
-  );
-};
+
+    const mod = {
+      id: this.familyName,
+      update: {},
+    };
+
+    if (metadata.rule) {
+      mod.update.gcRule = Family.formatRule_(metadata.rule);
+    }
+
+    const reqOpts = {
+      name: this.table.id,
+      modifications: [mod],
+    };
+
+    this.bigtable.request(
+      {
+        client: 'BigtableTableAdminClient',
+        method: 'modifyColumnFamilies',
+        reqOpts,
+        gaxOpts: gaxOptions,
+      },
+      function(...args) {
+        if (args[1]) {
+          self.metadata = args[1].columnFamilies[self.familyName];
+          args.splice(1, 0, self.metadata);
+        }
+
+        callback(...args);
+      }
+    );
+  }
+}
 
 /*! Developer Documentation
  *

--- a/src/family.js
+++ b/src/family.js
@@ -71,7 +71,7 @@ class Family {
    * // 'projects/p/zones/z/clusters/c/tables/t/columnFamilies/my-family'
    */
   static formatName_(tableName, name) {
-    if (name.indexOf('/') > -1) {
+    if (name.includes('/')) {
       return name;
     }
 

--- a/src/family.js
+++ b/src/family.js
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-'use strict';
-
 var common = require('@google-cloud/common');
 var createErrorClass = require('create-error-class');
 var is = require('is');

--- a/src/family.js
+++ b/src/family.js
@@ -147,7 +147,7 @@ Family.formatRule_ = function(ruleObj) {
   var ruleType = ruleObj.union ? 'union' : 'intersection';
 
   rule[ruleType] = {
-    rules: rules,
+    rules,
   };
 
   return rule;
@@ -435,7 +435,7 @@ Family.prototype.setMetadata = function(metadata, gaxOptions, callback) {
     {
       client: 'BigtableTableAdminClient',
       method: 'modifyColumnFamilies',
-      reqOpts: reqOpts,
+      reqOpts,
       gaxOpts: gaxOptions,
     },
     function(...args) {

--- a/src/family.js
+++ b/src/family.js
@@ -22,7 +22,7 @@ const is = require('is');
  * @private
  */
 const FamilyError = createErrorClass('FamilyError', function(name) {
-  this.message = 'Column family not found: ' + name + '.';
+  this.message = `Column family not found: ${name}.`;
   this.code = 404;
 });
 
@@ -75,7 +75,7 @@ class Family {
       return name;
     }
 
-    return tableName + '/columnFamilies/' + name;
+    return `${tableName}/columnFamilies/${name}`;
   }
 
   /**

--- a/src/family.js
+++ b/src/family.js
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-var common = require('@google-cloud/common');
-var createErrorClass = require('create-error-class');
-var is = require('is');
+const common = require('@google-cloud/common');
+const createErrorClass = require('create-error-class');
+const is = require('is');
 
 /**
  * @private
  */
-var FamilyError = createErrorClass('FamilyError', function(name) {
+const FamilyError = createErrorClass('FamilyError', function(name) {
   this.message = 'Column family not found: ' + name + '.';
   this.code = 404;
 });
@@ -110,7 +110,7 @@ Family.formatName_ = function(tableName, name) {
  * // }
  */
 Family.formatRule_ = function(ruleObj) {
-  var rules = [];
+  const rules = [];
 
   if (ruleObj.age) {
     rules.push({
@@ -141,8 +141,8 @@ Family.formatRule_ = function(ruleObj) {
     throw new Error('No garbage collection rules were specified.');
   }
 
-  var rule = {};
-  var ruleType = ruleObj.union ? 'union' : 'intersection';
+  const rule = {};
+  const ruleType = ruleObj.union ? 'union' : 'intersection';
 
   rule[ruleType] = {
     rules,
@@ -300,15 +300,15 @@ Family.prototype.exists = function(gaxOptions, callback) {
  * });
  */
 Family.prototype.get = function(options, callback) {
-  var self = this;
+  const self = this;
 
   if (is.fn(options)) {
     callback = options;
     options = {};
   }
 
-  var autoCreate = !!options.autoCreate;
-  var gaxOptions = options.gaxOptions;
+  const autoCreate = !!options.autoCreate;
+  const gaxOptions = options.gaxOptions;
 
   this.getMetadata(gaxOptions, function(err, metadata) {
     if (err) {
@@ -347,7 +347,7 @@ Family.prototype.get = function(options, callback) {
  * });
  */
 Family.prototype.getMetadata = function(gaxOptions, callback) {
-  var self = this;
+  const self = this;
 
   if (is.fn(gaxOptions)) {
     callback = gaxOptions;
@@ -360,7 +360,7 @@ Family.prototype.getMetadata = function(gaxOptions, callback) {
       return;
     }
 
-    for (var i = 0, l = families.length; i < l; i++) {
+    for (let i = 0, l = families.length; i < l; i++) {
       if (families[i].id === self.id) {
         self.metadata = families[i].metadata;
         callback(null, self.metadata);
@@ -368,7 +368,7 @@ Family.prototype.getMetadata = function(gaxOptions, callback) {
       }
     }
 
-    var error = new FamilyError(self.id);
+    const error = new FamilyError(self.id);
     callback(error);
   });
 };
@@ -408,14 +408,14 @@ Family.prototype.getMetadata = function(gaxOptions, callback) {
  * });
  */
 Family.prototype.setMetadata = function(metadata, gaxOptions, callback) {
-  var self = this;
+  const self = this;
 
   if (is.fn(gaxOptions)) {
     callback = gaxOptions;
     gaxOptions = {};
   }
 
-  var mod = {
+  const mod = {
     id: this.familyName,
     update: {},
   };
@@ -424,7 +424,7 @@ Family.prototype.setMetadata = function(metadata, gaxOptions, callback) {
     mod.update.gcRule = Family.formatRule_(metadata.rule);
   }
 
-  var reqOpts = {
+  const reqOpts = {
     name: this.table.id,
     modifications: [mod],
   };

--- a/src/filter.js
+++ b/src/filter.js
@@ -889,7 +889,7 @@ Filter.prototype.toProto = function() {
 Filter.prototype.value = function(value) {
   if (!is.object(value)) {
     value = {
-      value: value,
+      value,
     };
   }
 

--- a/src/filter.js
+++ b/src/filter.js
@@ -14,18 +14,18 @@
  * limitations under the License.
  */
 
-var arrify = require('arrify');
-var createErrorClass = require('create-error-class');
-var extend = require('extend');
-var escapeStringRegexp = require('escape-string-regexp');
-var is = require('is');
+const arrify = require('arrify');
+const createErrorClass = require('create-error-class');
+const extend = require('extend');
+const escapeStringRegexp = require('escape-string-regexp');
+const is = require('is');
 
-var Mutation = require('./mutation.js');
+const Mutation = require('./mutation.js');
 
 /**
  * @private
  */
-var FilterError = createErrorClass('FilterError', function(filter) {
+const FilterError = createErrorClass('FilterError', function(filter) {
   this.message = 'Unknown filter: ' + filter + '.';
 });
 
@@ -151,7 +151,7 @@ Filter.convertToRegExpString = function(regex) {
  * // }
  */
 Filter.createRange = function(start, end, key) {
-  var range = {};
+  const range = {};
 
   if (start) {
     extend(range, createBound('start', start, key));
@@ -164,9 +164,9 @@ Filter.createRange = function(start, end, key) {
   return range;
 
   function createBound(boundName, boundData, key) {
-    var isInclusive = boundData.inclusive !== false;
-    var boundKey = boundName + key + (isInclusive ? 'Closed' : 'Open');
-    var bound = {};
+    const isInclusive = boundData.inclusive !== false;
+    const boundKey = boundName + key + (isInclusive ? 'Closed' : 'Open');
+    const bound = {};
 
     bound[boundKey] = Mutation.convertToBytes(boundData.value || boundData);
     return bound;
@@ -204,10 +204,10 @@ Filter.createRange = function(start, end, key) {
  * // }
  */
 Filter.parse = function(filters) {
-  var filter = new Filter();
+  const filter = new Filter();
 
   arrify(filters).forEach(function(filterObj) {
-    var key = Object.keys(filterObj)[0];
+    const key = Object.keys(filterObj)[0];
 
     if (!is.function(filter[key])) {
       throw new FilterError(key);
@@ -244,7 +244,7 @@ Filter.parse = function(filters) {
  * };
  */
 Filter.prototype.all = function(pass) {
-  var filterName = pass ? 'passAllFilter' : 'blockAllFilter';
+  const filterName = pass ? 'passAllFilter' : 'blockAllFilter';
 
   this.set(filterName, true);
 };
@@ -375,7 +375,7 @@ Filter.prototype.column = function(column) {
   }
 
   if (column.name) {
-    var name = Filter.convertToRegExpString(column.name);
+    let name = Filter.convertToRegExpString(column.name);
 
     name = Mutation.convertToBytes(name);
     this.set('columnQualifierRegexFilter', name);
@@ -386,7 +386,7 @@ Filter.prototype.column = function(column) {
   }
 
   if (column.start || column.end) {
-    var range = Filter.createRange(column.start, column.end, 'Qualifier');
+    const range = Filter.createRange(column.start, column.end, 'Qualifier');
 
     range.familyName = column.family;
     this.set('columnRangeFilter', range);
@@ -657,7 +657,7 @@ Filter.prototype.row = function(row) {
   }
 
   if (row.key) {
-    var key = Filter.convertToRegExpString(row.key);
+    let key = Filter.convertToRegExpString(row.key);
 
     key = Mutation.convertToBytes(key);
     this.set('rowKeyRegexFilter', key);
@@ -683,7 +683,7 @@ Filter.prototype.row = function(row) {
  * @param {*} value Filter value.
  */
 Filter.prototype.set = function(key, value) {
-  var filter = {};
+  const filter = {};
 
   filter[key] = value;
   this.filters_.push(filter);
@@ -763,7 +763,7 @@ Filter.prototype.sink = function(sink) {
  * ];
  */
 Filter.prototype.time = function(time) {
-  var range = Mutation.createTimeRange(time.start, time.end);
+  const range = Mutation.createTimeRange(time.start, time.end);
   this.set('timestampRangeFilter', range);
 };
 
@@ -892,14 +892,14 @@ Filter.prototype.value = function(value) {
   }
 
   if (value.value) {
-    var valueReg = Filter.convertToRegExpString(value.value);
+    let valueReg = Filter.convertToRegExpString(value.value);
 
     valueReg = Mutation.convertToBytes(valueReg);
     this.set('valueRegexFilter', valueReg);
   }
 
   if (value.start || value.end) {
-    var range = Filter.createRange(value.start, value.end, 'Value');
+    const range = Filter.createRange(value.start, value.end, 'Value');
 
     this.set('valueRangeFilter', range);
   }

--- a/src/filter.js
+++ b/src/filter.js
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-'use strict';
-
 var arrify = require('arrify');
 var createErrorClass = require('create-error-class');
 var extend = require('extend');

--- a/src/filter.js
+++ b/src/filter.js
@@ -74,840 +74,842 @@ const FilterError = createErrorClass('FilterError', function(filter) {
  * @class
  * @private
  */
-function Filter() {
-  this.filters_ = [];
-}
-
-/**
- * @throws TypeError
- *
- * Transforms Arrays into a simple regular expression for matching multiple
- * values.
- *
- * @param {regex|string|string[]} regex Either a plain regex, a regex in
- *     string form or an array of strings.
- *
- * @returns {string}
- *
- * @example
- * var regexString = Filter.convertToRegExpString(['a', 'b', 'c']);
- * // => '(a|b|c)'
- */
-Filter.convertToRegExpString = function(regex) {
-  if (is.regexp(regex)) {
-    return regex.toString().replace(/^\/|\/$/g, '');
+class Filter {
+  constructor() {
+    this.filters_ = [];
   }
 
-  if (is.array(regex)) {
-    return '(' + regex.map(Filter.convertToRegExpString).join('|') + ')';
-  }
-
-  if (is.string(regex)) {
-    return regex;
-  }
-
-  if (is.number(regex)) {
-    return regex.toString();
-  }
-
-  if (Buffer.isBuffer(regex)) {
-    return escapeStringRegexp(regex.toString());
-  }
-
-  throw new TypeError("Can't convert to RegExp String from unknown type.");
-};
-
-/**
- * Creates a range object. All bounds default to inclusive.
- *
- * @param {?object|string} start Lower bound value.
- * @param {?object|string} end Upper bound value.
- * @param {string} key Key used to create range value keys.
- *
- * @returns {object}
- *
- * @example
- * const Bigtable = require('@google-cloud/bigtable');
- * const Filter = Bigtable.Filter;
- *
- * var range = Filter.createRange('value1', 'value2', 'Test');
- * // {
- * //   startTestInclusive: new Buffer('value1'),
- * //   endTestExclusive: new Buffer('value2')
- * // }
- *
- * //-
- * // It's also possible to pass in objects to specify inclusive/exclusive
- * // bounds.
- * //-
- * var upperBound = {
- *   value: 'value3',
- *   inclusive: false
- * };
- *
- * var range = Filter.createRange(upperBound, null, 'Test2');
- * // => {
- * //   startTest2Exclusive: 'value3'
- * // }
- */
-Filter.createRange = function(start, end, key) {
-  const range = {};
-
-  if (start) {
-    extend(range, createBound('start', start, key));
-  }
-
-  if (end) {
-    extend(range, createBound('end', end, key));
-  }
-
-  return range;
-
-  function createBound(boundName, boundData, key) {
-    const isInclusive = boundData.inclusive !== false;
-    const boundKey = boundName + key + (isInclusive ? 'Closed' : 'Open');
-    const bound = {};
-
-    bound[boundKey] = Mutation.convertToBytes(boundData.value || boundData);
-    return bound;
-  }
-};
-
-/**
- * @throws FilterError
- *
- * Turns filters into proto friendly format.
- *
- * @param {object[]} filters The list of filters to be parsed.
- *
- * @returns {object}
- *
- * @example
- * var filter = Filter.parse([
- *   {
- *     family: 'my-family',
- *   }, {
- *     column: 'my-column'
- *   }
- * ]);
- * // {
- * //   chain: {
- * //     filters: [
- * //       {
- * //         familyNameRegexFilter: 'my-family'
- * //       },
- * //       {
- * //         columnQualifierRegexFilter: 'my-column'
- * //       }
- * //     ]
- * //   }
- * // }
- */
-Filter.parse = function(filters) {
-  const filter = new Filter();
-
-  arrify(filters).forEach(function(filterObj) {
-    const key = Object.keys(filterObj)[0];
-
-    if (!is.function(filter[key])) {
-      throw new FilterError(key);
+  /**
+   * @throws TypeError
+   *
+   * Transforms Arrays into a simple regular expression for matching multiple
+   * values.
+   *
+   * @param {regex|string|string[]} regex Either a plain regex, a regex in
+   *     string form or an array of strings.
+   *
+   * @returns {string}
+   *
+   * @example
+   * var regexString = Filter.convertToRegExpString(['a', 'b', 'c']);
+   * // => '(a|b|c)'
+   */
+  static convertToRegExpString(regex) {
+    if (is.regexp(regex)) {
+      return regex.toString().replace(/^\/|\/$/g, '');
     }
 
-    filter[key](filterObj[key]);
-  });
+    if (is.array(regex)) {
+      return '(' + regex.map(Filter.convertToRegExpString).join('|') + ')';
+    }
 
-  return filter.toProto();
-};
+    if (is.string(regex)) {
+      return regex;
+    }
 
-/**
- * Sets passAllFilter or blockAllFilter
- *
- * @param {boolean} pass Whether to passAllFilter or blockAllFilter
- *
- * Assign true for enabling passAllFilter and false for enabling blockAllFilter
- *
- * @example
- * //-
- * // Matches all cells, regardless of input. Functionally equivalent to
- * // leaving `filter` unset, but included for completeness.
- * //-
- * var filter = {
- *   all: true
- * };
- *
- * //-
- * // Does not match any cells, regardless of input. Useful for temporarily
- * // disabling just part of a filter.
- * //-
- * var filter = {
- *   all: false
- * };
- */
-Filter.prototype.all = function(pass) {
-  const filterName = pass ? 'passAllFilter' : 'blockAllFilter';
+    if (is.number(regex)) {
+      return regex.toString();
+    }
 
-  this.set(filterName, true);
-};
+    if (Buffer.isBuffer(regex)) {
+      return escapeStringRegexp(regex.toString());
+    }
 
-/**
- * Matches only cells from columns whose qualifiers satisfy the given RE2
- * regex.
- * @param {?regex|string|object} column Matching Column to filter with
- *
- * Note that, since column qualifiers can contain arbitrary bytes, the '\C'
- * escape sequence must be used if a true wildcard is desired. The '.'
- * character will not match the new line character '\n', which may be
- * present in a binary qualifier.
- *
- * @example
- * //-
- * // Using the following filter, we would retrieve the `tjefferson` and
- * // `gwashington` columns.
- * //-
- * var filter = [
- *   {
- *     column: /[a-z]+on$/
- *   }
- * ];
- *
- * //-
- * // You can also provide a string (optionally containing regexp characters)
- * // for simple column filters.
- * //-
- * var filter = [
- *   {
- *     column: 'gwashington'
- *   }
- * ];
- *
- * //-
- * // Or you can provide an array of strings if you wish to match against
- * // multiple columns.
- * //-
- * var filter = [
- *   {
- *     column: [
- *       'gwashington',
- *       'tjefferson'
- *     ]
- *   }
- * ];
- *
- * //-
- * // If you wish to use additional column filters, consider using the following
- * // syntax.
- * //-
- * var filter = [
- *   {
- *     column: {
- *       name: 'gwashington'
- *     }
- *   }
- * ];
- *
- *
- * //-
- * // <h4>Column Cell Limits</h4>
- * //
- * // Matches only the most recent number of versions within each column. For
- * // example, if the `versions` is set to 2, this filter would only match
- * // columns updated at the two most recent timestamps.
- * //
- * // If duplicate cells are present, as is possible when using an
- * // {@link Filter#interleave} filter, each copy of the cell is
- * // counted separately.
- * //-
- * var filter = [
- *   {
- *     column: {
- *       cellLimit: 2
- *     }
- *   }
- * ];
- *
- * //-
- * // <h4>Column Ranges</h4>
- * //
- * // Specifies a contiguous range of columns within a single column family.
- * // The range spans from <column_family>:<start_qualifier> to
- * // <column_family>:<end_qualifier>, where both bounds can be either
- * // inclusive or exclusive. By default both are inclusive.
- * //
- * // When the `start` bound is omitted it is interpreted as an empty string.
- * // When the `end` bound is omitted it is interpreted as Infinity.
- * //-
- * var filter = [
- *   {
- *     column: {
- *       family: 'follows',
- *       start: 'gwashington',
- *       end: 'tjefferson'
- *     }
- *   }
- * ];
- *
- * //-
- * // By default, both the `start` and `end` bounds are inclusive. You can
- * // override these by providing an object explicity stating whether or not it
- * // is `inclusive`.
- * //-
- * var filter = [
- *   {
- *     column: {
- *       family: 'follows',
- *       start: {
- *         value: 'gwashington',
- *         inclusive: false
- *       },
- *       end: {
- *         value: 'jadams',
- *         inclusive: false
- *       }
- *     }
- *   }
- * ];
- */
-Filter.prototype.column = function(column) {
-  if (!is.object(column)) {
-    column = {
-      name: column,
+    throw new TypeError("Can't convert to RegExp String from unknown type.");
+  }
+
+  /**
+   * Creates a range object. All bounds default to inclusive.
+   *
+   * @param {?object|string} start Lower bound value.
+   * @param {?object|string} end Upper bound value.
+   * @param {string} key Key used to create range value keys.
+   *
+   * @returns {object}
+   *
+   * @example
+   * const Bigtable = require('@google-cloud/bigtable');
+   * const Filter = Bigtable.Filter;
+   *
+   * var range = Filter.createRange('value1', 'value2', 'Test');
+   * // {
+   * //   startTestInclusive: new Buffer('value1'),
+   * //   endTestExclusive: new Buffer('value2')
+   * // }
+   *
+   * //-
+   * // It's also possible to pass in objects to specify inclusive/exclusive
+   * // bounds.
+   * //-
+   * var upperBound = {
+   *   value: 'value3',
+   *   inclusive: false
+   * };
+   *
+   * var range = Filter.createRange(upperBound, null, 'Test2');
+   * // => {
+   * //   startTest2Exclusive: 'value3'
+   * // }
+   */
+  static createRange(start, end, key) {
+    const range = {};
+
+    if (start) {
+      extend(range, createBound('start', start, key));
+    }
+
+    if (end) {
+      extend(range, createBound('end', end, key));
+    }
+
+    return range;
+
+    function createBound(boundName, boundData, key) {
+      const isInclusive = boundData.inclusive !== false;
+      const boundKey = boundName + key + (isInclusive ? 'Closed' : 'Open');
+      const bound = {};
+
+      bound[boundKey] = Mutation.convertToBytes(boundData.value || boundData);
+      return bound;
+    }
+  }
+
+  /**
+   * @throws FilterError
+   *
+   * Turns filters into proto friendly format.
+   *
+   * @param {object[]} filters The list of filters to be parsed.
+   *
+   * @returns {object}
+   *
+   * @example
+   * var filter = Filter.parse([
+   *   {
+   *     family: 'my-family',
+   *   }, {
+   *     column: 'my-column'
+   *   }
+   * ]);
+   * // {
+   * //   chain: {
+   * //     filters: [
+   * //       {
+   * //         familyNameRegexFilter: 'my-family'
+   * //       },
+   * //       {
+   * //         columnQualifierRegexFilter: 'my-column'
+   * //       }
+   * //     ]
+   * //   }
+   * // }
+   */
+  static parse(filters) {
+    const filter = new Filter();
+
+    arrify(filters).forEach(function(filterObj) {
+      const key = Object.keys(filterObj)[0];
+
+      if (!is.function(filter[key])) {
+        throw new FilterError(key);
+      }
+
+      filter[key](filterObj[key]);
+    });
+
+    return filter.toProto();
+  }
+
+  /**
+   * Sets passAllFilter or blockAllFilter
+   *
+   * @param {boolean} pass Whether to passAllFilter or blockAllFilter
+   *
+   * Assign true for enabling passAllFilter and false for enabling blockAllFilter
+   *
+   * @example
+   * //-
+   * // Matches all cells, regardless of input. Functionally equivalent to
+   * // leaving `filter` unset, but included for completeness.
+   * //-
+   * var filter = {
+   *   all: true
+   * };
+   *
+   * //-
+   * // Does not match any cells, regardless of input. Useful for temporarily
+   * // disabling just part of a filter.
+   * //-
+   * var filter = {
+   *   all: false
+   * };
+   */
+  all(pass) {
+    const filterName = pass ? 'passAllFilter' : 'blockAllFilter';
+
+    this.set(filterName, true);
+  }
+
+  /**
+   * Matches only cells from columns whose qualifiers satisfy the given RE2
+   * regex.
+   * @param {?regex|string|object} column Matching Column to filter with
+   *
+   * Note that, since column qualifiers can contain arbitrary bytes, the '\C'
+   * escape sequence must be used if a true wildcard is desired. The '.'
+   * character will not match the new line character '\n', which may be
+   * present in a binary qualifier.
+   *
+   * @example
+   * //-
+   * // Using the following filter, we would retrieve the `tjefferson` and
+   * // `gwashington` columns.
+   * //-
+   * var filter = [
+   *   {
+   *     column: /[a-z]+on$/
+   *   }
+   * ];
+   *
+   * //-
+   * // You can also provide a string (optionally containing regexp characters)
+   * // for simple column filters.
+   * //-
+   * var filter = [
+   *   {
+   *     column: 'gwashington'
+   *   }
+   * ];
+   *
+   * //-
+   * // Or you can provide an array of strings if you wish to match against
+   * // multiple columns.
+   * //-
+   * var filter = [
+   *   {
+   *     column: [
+   *       'gwashington',
+   *       'tjefferson'
+   *     ]
+   *   }
+   * ];
+   *
+   * //-
+   * // If you wish to use additional column filters, consider using the following
+   * // syntax.
+   * //-
+   * var filter = [
+   *   {
+   *     column: {
+   *       name: 'gwashington'
+   *     }
+   *   }
+   * ];
+   *
+   *
+   * //-
+   * // <h4>Column Cell Limits</h4>
+   * //
+   * // Matches only the most recent number of versions within each column. For
+   * // example, if the `versions` is set to 2, this filter would only match
+   * // columns updated at the two most recent timestamps.
+   * //
+   * // If duplicate cells are present, as is possible when using an
+   * // {@link Filter#interleave} filter, each copy of the cell is
+   * // counted separately.
+   * //-
+   * var filter = [
+   *   {
+   *     column: {
+   *       cellLimit: 2
+   *     }
+   *   }
+   * ];
+   *
+   * //-
+   * // <h4>Column Ranges</h4>
+   * //
+   * // Specifies a contiguous range of columns within a single column family.
+   * // The range spans from <column_family>:<start_qualifier> to
+   * // <column_family>:<end_qualifier>, where both bounds can be either
+   * // inclusive or exclusive. By default both are inclusive.
+   * //
+   * // When the `start` bound is omitted it is interpreted as an empty string.
+   * // When the `end` bound is omitted it is interpreted as Infinity.
+   * //-
+   * var filter = [
+   *   {
+   *     column: {
+   *       family: 'follows',
+   *       start: 'gwashington',
+   *       end: 'tjefferson'
+   *     }
+   *   }
+   * ];
+   *
+   * //-
+   * // By default, both the `start` and `end` bounds are inclusive. You can
+   * // override these by providing an object explicity stating whether or not it
+   * // is `inclusive`.
+   * //-
+   * var filter = [
+   *   {
+   *     column: {
+   *       family: 'follows',
+   *       start: {
+   *         value: 'gwashington',
+   *         inclusive: false
+   *       },
+   *       end: {
+   *         value: 'jadams',
+   *         inclusive: false
+   *       }
+   *     }
+   *   }
+   * ];
+   */
+  column(column) {
+    if (!is.object(column)) {
+      column = {
+        name: column,
+      };
+    }
+
+    if (column.name) {
+      let name = Filter.convertToRegExpString(column.name);
+
+      name = Mutation.convertToBytes(name);
+      this.set('columnQualifierRegexFilter', name);
+    }
+
+    if (is.number(column.cellLimit)) {
+      this.set('cellsPerColumnLimitFilter', column.cellLimit);
+    }
+
+    if (column.start || column.end) {
+      const range = Filter.createRange(column.start, column.end, 'Qualifier');
+
+      range.familyName = column.family;
+      this.set('columnRangeFilter', range);
+    }
+  }
+
+  /**
+   * A filter which evaluates one of two possible filters, depending on
+   * whether or not a `test` filter outputs any cells from the input row.
+   *
+   * IMPORTANT NOTE: The `test` filter does not execute atomically with the
+   * pass and fail filters, which may lead to inconsistent or unexpected
+   * results. Additionally, condition filters have poor performance, especially
+   * when filters are set for the fail condition.
+   *
+   * @param {object} condition Condition to filter.
+   *
+   * @example
+   * //-
+   * // In the following example we're creating a filter that will check if
+   * // `gwashington` follows `tjefferson`. If he does, we'll get all of the
+   * // `gwashington` data. If he does not, we'll instead return all of the
+   * // `tjefferson` data.
+   * //-
+   * var filter = [
+   *   {
+   *     condition: {
+   *       // If `test` outputs any cells, then `pass` will be evaluated on the
+   *       // input row. Otherwise `fail` will be evaluated.
+   *       test: [
+   *         {
+   *           row: 'gwashington'
+   *         },
+   *         {
+   *           family: 'follows'
+   *         },
+   *         {
+   *           column: 'tjefferson'
+   *         }
+   *       ],
+   *
+   *       // If omitted, no results will be returned in the true case.
+   *       pass: [
+   *         {
+   *           row: 'gwashington'
+   *         }
+   *       ],
+   *
+   *       // If omitted, no results will be returned in the false case.
+   *       fail: [
+   *         {
+   *           row: 'tjefferson'
+   *         }
+   *       ]
+   *     }
+   *   }
+   * ];
+   */
+  condition(condition) {
+    this.set('condition', {
+      predicateFilter: Filter.parse(condition.test),
+      trueFilter: Filter.parse(condition.pass),
+      falseFilter: Filter.parse(condition.fail),
+    });
+  }
+
+  /**
+   * Matches only cells from columns whose families satisfy the given RE2
+   * regex. For technical reasons, the regex must not contain the ':'
+   * character, even if it is not being used as a literal.
+   * Note that, since column families cannot contain the new line character
+   * '\n', it is sufficient to use '.' as a full wildcard when matching
+   * column family names.
+   *
+   * @param {regex} family Expression to filter family
+   *
+   * @example
+   * var filter = [
+   *   {
+   *     family: 'follows'
+   *   }
+   * ];
+   */
+  family(family) {
+    family = Filter.convertToRegExpString(family);
+    this.set('familyNameRegexFilter', family);
+  }
+
+  /**
+   * Applies several filters to the data in parallel and combines the results.
+   *
+   * @param {object} filters The elements of "filters" all process a copy of the input row, and the
+   * results are pooled, sorted, and combined into a single output row.
+   * If multiple cells are produced with the same column and timestamp,
+   * they will all appear in the output row in an unspecified mutual order.
+   * All interleaved filters are executed atomically.
+   *
+   * @example
+   * //-
+   * // In the following example, we're creating a filter that will retrieve
+   * // results for entries that were either created between December 17th, 2015
+   * // and March 22nd, 2016 or entries that have data for `follows:tjefferson`.
+   * //-
+   * var filter = [
+   *   {
+   *     interleave: [
+   *       [
+   *         {
+   *           time: {
+   *             start: new Date('December 17, 2015'),
+   *             end: new Date('March 22, 2016')
+   *           }
+   *         }
+   *       ],
+   *       [
+   *         {
+   *           family: 'follows'
+   *         },
+   *         {
+   *           column: 'tjefferson'
+   *         }
+   *       ]
+   *     ]
+   *   }
+   * ];
+   */
+  interleave(filters) {
+    this.set('interleave', {
+      filters: filters.map(Filter.parse),
+    });
+  }
+
+  /**
+   * Applies the given label to all cells in the output row. This allows
+   * the client to determine which results were produced from which part of
+   * the filter.
+   *
+   * @param {string} label Label to determine filter point
+   * Values must be at most 15 characters in length, and match the RE2
+   * pattern [a-z0-9\\-]+
+   *
+   * Due to a technical limitation, it is not currently possible to apply
+   * multiple labels to a cell. As a result, a chain filter may have no more than
+   * one sub-filter which contains a apply label transformer. It is okay for
+   * an {@link Filter#interleave} to contain multiple apply label
+   * transformers, as they will be applied to separate copies of the input. This
+   * may be relaxed in the future.
+   *
+   * @example
+   * var filter = {
+   *   label: 'my-label'
+   * };
+   */
+  label(label) {
+    this.set('applyLabelTransformer', label);
+  }
+
+  /**
+   * Matches only cells from rows whose keys satisfy the given RE2 regex. In
+   * other words, passes through the entire row when the key matches, and
+   * otherwise produces an empty row.
+   *
+   * @param {?regex|string|string[]} row Row format to Filter
+   *
+   * Note that, since row keys can contain arbitrary bytes, the '\C' escape
+   * sequence must be used if a true wildcard is desired. The '.' character
+   * will not match the new line character '\n', which may be present in a
+   * binary key.
+   *
+   * @example
+   * //-
+   * // In the following example we'll use a regular expression to match all
+   * // row keys ending with the letters "on", which would then yield
+   * // `gwashington` and `tjefferson`.
+   * //-
+   * var filter = [
+   *   {
+   *     row: /[a-z]+on$/
+   *   }
+   * ];
+   *
+   * //-
+   * // You can also provide a string (optionally containing regexp characters)
+   * // for simple key filters.
+   * //-
+   * var filter = [
+   *   {
+   *     row: 'gwashington'
+   *   }
+   * ];
+   *
+   * //-
+   * // Or you can provide an array of strings if you wish to match against
+   * // multiple keys.
+   * //-
+   * var filter = [
+   *   {
+   *     row: [
+   *       'gwashington',
+   *       'tjefferson'
+   *     ]
+   *   }
+   * ];
+   *
+   * //-
+   * // If you wish to use additional row filters, consider using the following
+   * // syntax.
+   * //-
+   * var filter = [
+   *   {
+   *     row: {
+   *       key: 'gwashington'
+   *     }
+   *   }
+   * ];
+   *
+   * //-
+   * // <h4>Row Samples</h4>
+   * //
+   * // Matches all cells from a row with probability p, and matches no cells
+   * // from the row with probability 1-p.
+   * //-
+   * var filter = [
+   *   {
+   *     row: {
+   *       sample: 1
+   *     }
+   *   }
+   * ];
+   *
+   * //-
+   * // <h4>Row Cell Offsets</h4>
+   * //
+   * // Skips the first N cells of each row, matching all subsequent cells.
+   * // If duplicate cells are present, as is possible when using an
+   * // {@link Filter#interleave}, each copy of the cell is counted
+   * // separately.
+   * //-
+   * var filter = [
+   *   {
+   *     row: {
+   *       cellOffset: 2
+   *     }
+   *   }
+   * ];
+   *
+   * //-
+   * // <h4>Row Cell Limits</h4>
+   * //
+   * // Matches only the first N cells of each row.
+   * // If duplicate cells are present, as is possible when using an
+   * // {@link Filter#interleave}, each copy of the cell is counted
+   * // separately.
+   * //-
+   * var filter = [
+   *   {
+   *     row: {
+   *       cellLimit: 4
+   *     }
+   *   }
+   * ];
+   */
+  row(row) {
+    if (!is.object(row)) {
+      row = {
+        key: row,
+      };
+    }
+
+    if (row.key) {
+      let key = Filter.convertToRegExpString(row.key);
+
+      key = Mutation.convertToBytes(key);
+      this.set('rowKeyRegexFilter', key);
+    }
+
+    if (row.sample) {
+      this.set('rowSampleFilter', row.sample);
+    }
+
+    if (is.number(row.cellOffset)) {
+      this.set('cellsPerRowOffsetFilter', row.cellOffset);
+    }
+
+    if (is.number(row.cellLimit)) {
+      this.set('cellsPerRowLimitFilter', row.cellLimit);
+    }
+  }
+
+  /**
+   * Stores a filter object.
+   *
+   * @param {string} key Filter name.
+   * @param {*} value Filter value.
+   */
+  set(key, value) {
+    const filter = {};
+
+    filter[key] = value;
+    this.filters_.push(filter);
+  }
+
+  /**
+   * This filter is meant for advanced use only. Hook for introspection into the
+   * filter. Outputs all cells directly to the output of the read rather than to
+   * any parent filter.
+   * Despite being excluded by the qualifier filter, a copy of every cell that
+   * reaches the sink is present in the final result.
+   * As with an {@link Filter#interleave} filter, duplicate cells are
+   * possible, and appear in an unspecified mutual order.
+   *
+   * Cannot be used within {@link Filter#condition} filter.
+   *
+   * @param {boolean} sink
+   *
+   * @example
+   * //-
+   * // Using the following filter, a copy of every cell that reaches the sink is
+   * // present in the final result, despite being excluded by the qualifier
+   * // filter
+   * //-
+   * var filter = [
+   *   {
+   *     family: 'follows'
+   *   },
+   *   {
+   *     interleave: [
+   *       [
+   *         {
+   *           all: true
+   *         }
+   *       ],
+   *       [
+   *         {
+   *           label: 'prezzy'
+   *         },
+   *         {
+   *           sink: true
+   *         }
+   *       ]
+   *     ]
+   *   },
+   *   {
+   *     column: 'gwashington'
+   *   }
+   * ];
+   *
+   * //-
+   * // As with an {@link Filter#interleave} filter, duplicate cells
+   * // are possible, and appear in an unspecified mutual order. In this case we
+   * // have a duplicates with multiple `gwashington` columns because one copy
+   * // passed through the {@link Filter#all} filter while the other was
+   * // passed through the {@link Filter#label} and sink. Note that one
+   * // copy has label "prezzy" while the other does not.
+   * //-
+   */
+  sink(sink) {
+    this.set('sink', sink);
+  }
+
+  /**
+   * Matches only cells with timestamps within the given range.
+   *
+   * @param {object} time Start and End time Object
+   *
+   * @example
+   * var filter = [
+   *   {
+   *     time: {
+   *       start: new Date('December 17, 2006 03:24:00'),
+   *       end: new Date()
+   *     }
+   *   }
+   * ];
+   */
+  time(time) {
+    const range = Mutation.createTimeRange(time.start, time.end);
+    this.set('timestampRangeFilter', range);
+  }
+
+  /**
+   * If we detect multiple filters, we'll assume it's a chain filter and the
+   * execution of the filters will be the order in which they were specified.
+   */
+  toProto() {
+    if (!this.filters_.length) {
+      return null;
+    }
+
+    if (this.filters_.length === 1) {
+      return this.filters_[0];
+    }
+
+    return {
+      chain: {
+        filters: this.filters_,
+      },
     };
   }
 
-  if (column.name) {
-    let name = Filter.convertToRegExpString(column.name);
+  /**
+   * Matches only cells with values that satisfy the given regular expression.
+   * Note that, since cell values can contain arbitrary bytes, the '\C' escape
+   * sequence must be used if a true wildcard is desired. The '.' character
+   * will not match the new line character '\n', which may be present in a
+   * binary value.
+   *
+   * @param {?string|string[]|object} value Value to filter cells
+   *
+   * @example
+   * var filter = [
+   *   {
+   *     value: /[0-9]/
+   *   }
+   * ];
+   *
+   * //-
+   * // You can also provide a string (optionally containing regexp characters)
+   * // for value filters.
+   * //-
+   * var filter = [
+   *   {
+   *     value: '1'
+   *   }
+   * ];
+   *
+   * //-
+   * // You can also provide an array of strings if you wish to match against
+   * // multiple values.
+   * //-
+   * var filter = [
+   *   {
+   *     value: ['1', '9']
+   *   }
+   * ];
+   *
+   * //-
+   * // Or you can provide a Buffer or an array of Buffers if you wish to match
+   * // against specfic binary value(s).
+   * //-
+   * var userInputedFaces = [Buffer.from('.|.'), Buffer.from(':-)')];
+   * var filter = [
+   *   {
+   *     value: userInputedFaces
+   *   }
+   * ];
+   *
+   * //-
+   * // <h4>Value Ranges</h4>
+   * //
+   * // Specifies a contigous range of values.
+   * //
+   * // When the `start` bound is omitted it is interpreted as an empty string.
+   * // When the `end` bound is omitted it is interpreted as Infinity.
+   * //-
+   * var filter = [
+   *   {
+   *     value: {
+   *       start: '1',
+   *       end: '9'
+   *     }
+   *   }
+   * ];
+   *
+   * //-
+   * // By default, both the `start` and `end` bounds are inclusive. You can
+   * // override these by providing an object explicity stating whether or not it
+   * // is `inclusive`.
+   * //-
+   * var filter = [
+   *   {
+   *     value: {
+   *       start: {
+   *         value: '1',
+   *         inclusive: false
+   *       },
+   *       end: {
+   *         value: '9',
+   *         inclusive: false
+   *       }
+   *     }
+   *   }
+   * ];
+   *
+   * //-
+   * // <h4>Strip Values</h4>
+   * //
+   * // Replaces each cell's value with an emtpy string.
+   * //-
+   * var filter = [
+   *   {
+   *     value: {
+   *       strip: true
+   *     }
+   *   }
+   * ];
+   */
+  value(value) {
+    if (!is.object(value)) {
+      value = {
+        value,
+      };
+    }
 
-    name = Mutation.convertToBytes(name);
-    this.set('columnQualifierRegexFilter', name);
+    if (value.value) {
+      let valueReg = Filter.convertToRegExpString(value.value);
+
+      valueReg = Mutation.convertToBytes(valueReg);
+      this.set('valueRegexFilter', valueReg);
+    }
+
+    if (value.start || value.end) {
+      const range = Filter.createRange(value.start, value.end, 'Value');
+
+      this.set('valueRangeFilter', range);
+    }
+
+    if (value.strip) {
+      this.set('stripValueTransformer', value.strip);
+    }
   }
-
-  if (is.number(column.cellLimit)) {
-    this.set('cellsPerColumnLimitFilter', column.cellLimit);
-  }
-
-  if (column.start || column.end) {
-    const range = Filter.createRange(column.start, column.end, 'Qualifier');
-
-    range.familyName = column.family;
-    this.set('columnRangeFilter', range);
-  }
-};
-
-/**
- * A filter which evaluates one of two possible filters, depending on
- * whether or not a `test` filter outputs any cells from the input row.
- *
- * IMPORTANT NOTE: The `test` filter does not execute atomically with the
- * pass and fail filters, which may lead to inconsistent or unexpected
- * results. Additionally, condition filters have poor performance, especially
- * when filters are set for the fail condition.
- *
- * @param {object} condition Condition to filter.
- *
- * @example
- * //-
- * // In the following example we're creating a filter that will check if
- * // `gwashington` follows `tjefferson`. If he does, we'll get all of the
- * // `gwashington` data. If he does not, we'll instead return all of the
- * // `tjefferson` data.
- * //-
- * var filter = [
- *   {
- *     condition: {
- *       // If `test` outputs any cells, then `pass` will be evaluated on the
- *       // input row. Otherwise `fail` will be evaluated.
- *       test: [
- *         {
- *           row: 'gwashington'
- *         },
- *         {
- *           family: 'follows'
- *         },
- *         {
- *           column: 'tjefferson'
- *         }
- *       ],
- *
- *       // If omitted, no results will be returned in the true case.
- *       pass: [
- *         {
- *           row: 'gwashington'
- *         }
- *       ],
- *
- *       // If omitted, no results will be returned in the false case.
- *       fail: [
- *         {
- *           row: 'tjefferson'
- *         }
- *       ]
- *     }
- *   }
- * ];
- */
-Filter.prototype.condition = function(condition) {
-  this.set('condition', {
-    predicateFilter: Filter.parse(condition.test),
-    trueFilter: Filter.parse(condition.pass),
-    falseFilter: Filter.parse(condition.fail),
-  });
-};
-
-/**
- * Matches only cells from columns whose families satisfy the given RE2
- * regex. For technical reasons, the regex must not contain the ':'
- * character, even if it is not being used as a literal.
- * Note that, since column families cannot contain the new line character
- * '\n', it is sufficient to use '.' as a full wildcard when matching
- * column family names.
- *
- * @param {regex} family Expression to filter family
- *
- * @example
- * var filter = [
- *   {
- *     family: 'follows'
- *   }
- * ];
- */
-Filter.prototype.family = function(family) {
-  family = Filter.convertToRegExpString(family);
-  this.set('familyNameRegexFilter', family);
-};
-
-/**
- * Applies several filters to the data in parallel and combines the results.
- *
- * @param {object} filters The elements of "filters" all process a copy of the input row, and the
- * results are pooled, sorted, and combined into a single output row.
- * If multiple cells are produced with the same column and timestamp,
- * they will all appear in the output row in an unspecified mutual order.
- * All interleaved filters are executed atomically.
- *
- * @example
- * //-
- * // In the following example, we're creating a filter that will retrieve
- * // results for entries that were either created between December 17th, 2015
- * // and March 22nd, 2016 or entries that have data for `follows:tjefferson`.
- * //-
- * var filter = [
- *   {
- *     interleave: [
- *       [
- *         {
- *           time: {
- *             start: new Date('December 17, 2015'),
- *             end: new Date('March 22, 2016')
- *           }
- *         }
- *       ],
- *       [
- *         {
- *           family: 'follows'
- *         },
- *         {
- *           column: 'tjefferson'
- *         }
- *       ]
- *     ]
- *   }
- * ];
- */
-Filter.prototype.interleave = function(filters) {
-  this.set('interleave', {
-    filters: filters.map(Filter.parse),
-  });
-};
-
-/**
- * Applies the given label to all cells in the output row. This allows
- * the client to determine which results were produced from which part of
- * the filter.
- *
- * @param {string} label Label to determine filter point
- * Values must be at most 15 characters in length, and match the RE2
- * pattern [a-z0-9\\-]+
- *
- * Due to a technical limitation, it is not currently possible to apply
- * multiple labels to a cell. As a result, a chain filter may have no more than
- * one sub-filter which contains a apply label transformer. It is okay for
- * an {@link Filter#interleave} to contain multiple apply label
- * transformers, as they will be applied to separate copies of the input. This
- * may be relaxed in the future.
- *
- * @example
- * var filter = {
- *   label: 'my-label'
- * };
- */
-Filter.prototype.label = function(label) {
-  this.set('applyLabelTransformer', label);
-};
-
-/**
- * Matches only cells from rows whose keys satisfy the given RE2 regex. In
- * other words, passes through the entire row when the key matches, and
- * otherwise produces an empty row.
- *
- * @param {?regex|string|string[]} row Row format to Filter
- *
- * Note that, since row keys can contain arbitrary bytes, the '\C' escape
- * sequence must be used if a true wildcard is desired. The '.' character
- * will not match the new line character '\n', which may be present in a
- * binary key.
- *
- * @example
- * //-
- * // In the following example we'll use a regular expression to match all
- * // row keys ending with the letters "on", which would then yield
- * // `gwashington` and `tjefferson`.
- * //-
- * var filter = [
- *   {
- *     row: /[a-z]+on$/
- *   }
- * ];
- *
- * //-
- * // You can also provide a string (optionally containing regexp characters)
- * // for simple key filters.
- * //-
- * var filter = [
- *   {
- *     row: 'gwashington'
- *   }
- * ];
- *
- * //-
- * // Or you can provide an array of strings if you wish to match against
- * // multiple keys.
- * //-
- * var filter = [
- *   {
- *     row: [
- *       'gwashington',
- *       'tjefferson'
- *     ]
- *   }
- * ];
- *
- * //-
- * // If you wish to use additional row filters, consider using the following
- * // syntax.
- * //-
- * var filter = [
- *   {
- *     row: {
- *       key: 'gwashington'
- *     }
- *   }
- * ];
- *
- * //-
- * // <h4>Row Samples</h4>
- * //
- * // Matches all cells from a row with probability p, and matches no cells
- * // from the row with probability 1-p.
- * //-
- * var filter = [
- *   {
- *     row: {
- *       sample: 1
- *     }
- *   }
- * ];
- *
- * //-
- * // <h4>Row Cell Offsets</h4>
- * //
- * // Skips the first N cells of each row, matching all subsequent cells.
- * // If duplicate cells are present, as is possible when using an
- * // {@link Filter#interleave}, each copy of the cell is counted
- * // separately.
- * //-
- * var filter = [
- *   {
- *     row: {
- *       cellOffset: 2
- *     }
- *   }
- * ];
- *
- * //-
- * // <h4>Row Cell Limits</h4>
- * //
- * // Matches only the first N cells of each row.
- * // If duplicate cells are present, as is possible when using an
- * // {@link Filter#interleave}, each copy of the cell is counted
- * // separately.
- * //-
- * var filter = [
- *   {
- *     row: {
- *       cellLimit: 4
- *     }
- *   }
- * ];
- */
-Filter.prototype.row = function(row) {
-  if (!is.object(row)) {
-    row = {
-      key: row,
-    };
-  }
-
-  if (row.key) {
-    let key = Filter.convertToRegExpString(row.key);
-
-    key = Mutation.convertToBytes(key);
-    this.set('rowKeyRegexFilter', key);
-  }
-
-  if (row.sample) {
-    this.set('rowSampleFilter', row.sample);
-  }
-
-  if (is.number(row.cellOffset)) {
-    this.set('cellsPerRowOffsetFilter', row.cellOffset);
-  }
-
-  if (is.number(row.cellLimit)) {
-    this.set('cellsPerRowLimitFilter', row.cellLimit);
-  }
-};
-
-/**
- * Stores a filter object.
- *
- * @param {string} key Filter name.
- * @param {*} value Filter value.
- */
-Filter.prototype.set = function(key, value) {
-  const filter = {};
-
-  filter[key] = value;
-  this.filters_.push(filter);
-};
-
-/**
- * This filter is meant for advanced use only. Hook for introspection into the
- * filter. Outputs all cells directly to the output of the read rather than to
- * any parent filter.
- * Despite being excluded by the qualifier filter, a copy of every cell that
- * reaches the sink is present in the final result.
- * As with an {@link Filter#interleave} filter, duplicate cells are
- * possible, and appear in an unspecified mutual order.
- *
- * Cannot be used within {@link Filter#condition} filter.
- *
- * @param {boolean} sink
- *
- * @example
- * //-
- * // Using the following filter, a copy of every cell that reaches the sink is
- * // present in the final result, despite being excluded by the qualifier
- * // filter
- * //-
- * var filter = [
- *   {
- *     family: 'follows'
- *   },
- *   {
- *     interleave: [
- *       [
- *         {
- *           all: true
- *         }
- *       ],
- *       [
- *         {
- *           label: 'prezzy'
- *         },
- *         {
- *           sink: true
- *         }
- *       ]
- *     ]
- *   },
- *   {
- *     column: 'gwashington'
- *   }
- * ];
- *
- * //-
- * // As with an {@link Filter#interleave} filter, duplicate cells
- * // are possible, and appear in an unspecified mutual order. In this case we
- * // have a duplicates with multiple `gwashington` columns because one copy
- * // passed through the {@link Filter#all} filter while the other was
- * // passed through the {@link Filter#label} and sink. Note that one
- * // copy has label "prezzy" while the other does not.
- * //-
- */
-Filter.prototype.sink = function(sink) {
-  this.set('sink', sink);
-};
-
-/**
- * Matches only cells with timestamps within the given range.
- *
- * @param {object} time Start and End time Object
- *
- * @example
- * var filter = [
- *   {
- *     time: {
- *       start: new Date('December 17, 2006 03:24:00'),
- *       end: new Date()
- *     }
- *   }
- * ];
- */
-Filter.prototype.time = function(time) {
-  const range = Mutation.createTimeRange(time.start, time.end);
-  this.set('timestampRangeFilter', range);
-};
-
-/**
- * If we detect multiple filters, we'll assume it's a chain filter and the
- * execution of the filters will be the order in which they were specified.
- */
-Filter.prototype.toProto = function() {
-  if (!this.filters_.length) {
-    return null;
-  }
-
-  if (this.filters_.length === 1) {
-    return this.filters_[0];
-  }
-
-  return {
-    chain: {
-      filters: this.filters_,
-    },
-  };
-};
-
-/**
- * Matches only cells with values that satisfy the given regular expression.
- * Note that, since cell values can contain arbitrary bytes, the '\C' escape
- * sequence must be used if a true wildcard is desired. The '.' character
- * will not match the new line character '\n', which may be present in a
- * binary value.
- *
- * @param {?string|string[]|object} value Value to filter cells
- *
- * @example
- * var filter = [
- *   {
- *     value: /[0-9]/
- *   }
- * ];
- *
- * //-
- * // You can also provide a string (optionally containing regexp characters)
- * // for value filters.
- * //-
- * var filter = [
- *   {
- *     value: '1'
- *   }
- * ];
- *
- * //-
- * // You can also provide an array of strings if you wish to match against
- * // multiple values.
- * //-
- * var filter = [
- *   {
- *     value: ['1', '9']
- *   }
- * ];
- *
- * //-
- * // Or you can provide a Buffer or an array of Buffers if you wish to match
- * // against specfic binary value(s).
- * //-
- * var userInputedFaces = [Buffer.from('.|.'), Buffer.from(':-)')];
- * var filter = [
- *   {
- *     value: userInputedFaces
- *   }
- * ];
- *
- * //-
- * // <h4>Value Ranges</h4>
- * //
- * // Specifies a contigous range of values.
- * //
- * // When the `start` bound is omitted it is interpreted as an empty string.
- * // When the `end` bound is omitted it is interpreted as Infinity.
- * //-
- * var filter = [
- *   {
- *     value: {
- *       start: '1',
- *       end: '9'
- *     }
- *   }
- * ];
- *
- * //-
- * // By default, both the `start` and `end` bounds are inclusive. You can
- * // override these by providing an object explicity stating whether or not it
- * // is `inclusive`.
- * //-
- * var filter = [
- *   {
- *     value: {
- *       start: {
- *         value: '1',
- *         inclusive: false
- *       },
- *       end: {
- *         value: '9',
- *         inclusive: false
- *       }
- *     }
- *   }
- * ];
- *
- * //-
- * // <h4>Strip Values</h4>
- * //
- * // Replaces each cell's value with an emtpy string.
- * //-
- * var filter = [
- *   {
- *     value: {
- *       strip: true
- *     }
- *   }
- * ];
- */
-Filter.prototype.value = function(value) {
-  if (!is.object(value)) {
-    value = {
-      value,
-    };
-  }
-
-  if (value.value) {
-    let valueReg = Filter.convertToRegExpString(value.value);
-
-    valueReg = Mutation.convertToBytes(valueReg);
-    this.set('valueRegexFilter', valueReg);
-  }
-
-  if (value.start || value.end) {
-    const range = Filter.createRange(value.start, value.end, 'Value');
-
-    this.set('valueRangeFilter', range);
-  }
-
-  if (value.strip) {
-    this.set('stripValueTransformer', value.strip);
-  }
-};
+}
 
 module.exports = Filter;
 module.exports.FilterError = FilterError;

--- a/src/filter.js
+++ b/src/filter.js
@@ -26,7 +26,7 @@ const Mutation = require('./mutation.js');
  * @private
  */
 const FilterError = createErrorClass('FilterError', function(filter) {
-  this.message = 'Unknown filter: ' + filter + '.';
+  this.message = `Unknown filter: ${filter}.`;
 });
 
 /**
@@ -100,7 +100,7 @@ class Filter {
     }
 
     if (is.array(regex)) {
-      return '(' + regex.map(Filter.convertToRegExpString).join('|') + ')';
+      return `(${regex.map(Filter.convertToRegExpString).join('|')})`;
     }
 
     if (is.string(regex)) {

--- a/src/index.js
+++ b/src/index.js
@@ -337,10 +337,6 @@ const v2 = require('./v2');
  * });
  */
 function Bigtable(options) {
-  if (!(this instanceof Bigtable)) {
-    return new Bigtable(options);
-  }
-
   options = common.util.normalizeArguments(this, options);
 
   // Determine what scopes are needed.
@@ -804,6 +800,14 @@ Bigtable.Cluster = Cluster;
  * @type {Constructor}
  */
 Bigtable.Instance = Instance;
+
+// Allow creating a `Bigtable` instance without using the `new` keyword.
+/* eslint-disable-next-line no-class-assign */
+Bigtable = new Proxy(Bigtable, {
+  apply(target, thisArg, argumentsList) {
+    return new target(...argumentsList);
+  },
+});
 
 /**
  * The default export of the `@google-cloud/bigtable` package is the

--- a/src/index.js
+++ b/src/index.js
@@ -716,7 +716,7 @@ Bigtable.prototype.request = function(config, callback) {
           currentRetryAttempt: 0,
           objectMode: true,
           shouldRetryFn: GrpcService.shouldRetryRequest_,
-          request: function() {
+          request() {
             gaxStream = requestFn();
             return gaxStream;
           },

--- a/src/index.js
+++ b/src/index.js
@@ -348,7 +348,7 @@ class Bigtable {
     ];
     for (let clientClass of clientClasses) {
       for (let scope of clientClass.scopes) {
-        if (scopes.indexOf(scope) === -1) {
+        if (!scopes.includes(scope)) {
           scopes.push(scope);
         }
       }

--- a/src/index.js
+++ b/src/index.js
@@ -359,7 +359,7 @@ function Bigtable(options) {
     {
       libName: 'gccl',
       libVersion: PKG.version,
-      scopes: scopes,
+      scopes,
       'grpc.max_send_message_length': -1,
       'grpc.max_receive_message_length': -1,
     },
@@ -539,7 +539,7 @@ Bigtable.prototype.createInstance = function(name, options, callback) {
     {
       client: 'BigtableInstanceAdminClient',
       method: 'createInstance',
-      reqOpts: reqOpts,
+      reqOpts,
       gaxOpts: options.gaxOptions,
     },
     function(...args) {
@@ -598,7 +598,7 @@ Bigtable.prototype.getInstances = function(gaxOptions, callback) {
     {
       client: 'BigtableInstanceAdminClient',
       method: 'listInstances',
-      reqOpts: reqOpts,
+      reqOpts,
       gaxOpts: gaxOptions,
     },
     function(err, resp) {

--- a/src/index.js
+++ b/src/index.js
@@ -14,20 +14,20 @@
  * limitations under the License.
  */
 
-var arrify = require('arrify');
-var common = require('@google-cloud/common');
-var extend = require('extend');
-var GrpcService = require('@google-cloud/common-grpc').Service;
-var googleAuth = require('google-auto-auth');
-var grpc = require('google-gax').grpc().grpc;
-var is = require('is');
-var retryRequest = require('retry-request');
-var streamEvents = require('stream-events');
-var through = require('through2');
+const arrify = require('arrify');
+const common = require('@google-cloud/common');
+const extend = require('extend');
+const GrpcService = require('@google-cloud/common-grpc').Service;
+const googleAuth = require('google-auto-auth');
+const grpc = require('google-gax').grpc().grpc;
+const is = require('is');
+const retryRequest = require('retry-request');
+const streamEvents = require('stream-events');
+const through = require('through2');
 
-var AppProfile = require('./app-profile');
-var Cluster = require('./cluster.js');
-var Instance = require('./instance.js');
+const AppProfile = require('./app-profile');
+const Cluster = require('./cluster.js');
+const Instance = require('./instance.js');
 
 const PKG = require('../package.json');
 const v2 = require('./v2');
@@ -364,18 +364,18 @@ function Bigtable(options) {
     options
   );
 
-  var defaultBaseUrl = 'bigtable.googleapis.com';
-  var defaultAdminBaseUrl = 'bigtableadmin.googleapis.com';
+  const defaultBaseUrl = 'bigtable.googleapis.com';
+  const defaultAdminBaseUrl = 'bigtableadmin.googleapis.com';
 
-  var customEndpoint =
+  const customEndpoint =
     options.apiEndpoint || process.env.BIGTABLE_EMULATOR_HOST;
   this.customEndpoint = customEndpoint;
 
-  var customEndpointBaseUrl;
-  var customEndpointPort;
+  let customEndpointBaseUrl;
+  let customEndpointPort;
 
   if (customEndpoint) {
-    var customEndpointParts = customEndpoint.split(':');
+    const customEndpointParts = customEndpoint.split(':');
     customEndpointBaseUrl = customEndpointParts[0];
     customEndpointPort = customEndpointParts[1];
   }
@@ -499,14 +499,14 @@ function Bigtable(options) {
  * });
  */
 Bigtable.prototype.createInstance = function(name, options, callback) {
-  var self = this;
+  const self = this;
 
   if (is.function(options)) {
     callback = options;
     options = {};
   }
 
-  var reqOpts = {
+  const reqOpts = {
     parent: this.projectName,
     instanceId: name,
     instance: {
@@ -581,14 +581,14 @@ Bigtable.prototype.createInstance = function(name, options, callback) {
  * });
  */
 Bigtable.prototype.getInstances = function(gaxOptions, callback) {
-  var self = this;
+  const self = this;
 
   if (is.function(gaxOptions)) {
     callback = gaxOptions;
     gaxOptions = {};
   }
 
-  var reqOpts = {
+  const reqOpts = {
     parent: this.projectName,
   };
 
@@ -605,8 +605,8 @@ Bigtable.prototype.getInstances = function(gaxOptions, callback) {
         return;
       }
 
-      var instances = resp.instances.map(function(instanceData) {
-        var instance = self.instance(instanceData.name);
+      const instances = resp.instances.map(function(instanceData) {
+        const instance = self.instance(instanceData.name);
         instance.metadata = instanceData;
         return instance;
       });
@@ -636,11 +636,11 @@ Bigtable.prototype.instance = function(name) {
  * @param {function} [callback] Callback function.
  */
 Bigtable.prototype.request = function(config, callback) {
-  var self = this;
-  var isStreamMode = !callback;
+  const self = this;
+  const isStreamMode = !callback;
 
-  var gaxStream;
-  var stream;
+  let gaxStream;
+  let stream;
 
   if (isStreamMode) {
     stream = streamEvents(through.obj());
@@ -665,7 +665,7 @@ Bigtable.prototype.request = function(config, callback) {
         return;
       }
 
-      var gaxClient = self.api[config.client];
+      let gaxClient = self.api[config.client];
 
       if (!gaxClient) {
         // Lazily instantiate client.
@@ -673,13 +673,13 @@ Bigtable.prototype.request = function(config, callback) {
         self.api[config.client] = gaxClient;
       }
 
-      var reqOpts = extend(true, {}, config.reqOpts);
+      let reqOpts = extend(true, {}, config.reqOpts);
 
       if (projectId !== '{{projectId}}') {
         reqOpts = common.util.replaceProjectIdToken(reqOpts, projectId);
       }
 
-      var requestFn = gaxClient[config.method].bind(
+      const requestFn = gaxClient[config.method].bind(
         gaxClient,
         reqOpts,
         config.gaxOpts
@@ -709,7 +709,7 @@ Bigtable.prototype.request = function(config, callback) {
 
       // @TODO: remove `retry-request` when gax supports retryable streams.
       // https://github.com/googleapis/gax-nodejs/blob/ec0c8b0805c31d8a91ea69cb19fe50f42a38bf87/lib/streaming.js#L230
-      var retryOpts = extend(
+      const retryOpts = extend(
         {
           currentRetryAttempt: 0,
           objectMode: true,
@@ -741,9 +741,9 @@ Bigtable.prototype.request = function(config, callback) {
  * @param {string} callback.projectId The detected project ID.
  */
 Bigtable.prototype.getProjectId_ = function(callback) {
-  var self = this;
+  const self = this;
 
-  var projectIdRequired =
+  const projectIdRequired =
     this.projectId === '{{projectId}}' && !this.customEndpoint;
 
   if (!projectIdRequired) {

--- a/src/index.js
+++ b/src/index.js
@@ -422,7 +422,7 @@ class Bigtable {
     this.auth = googleAuth(options);
     this.projectId = options.projectId || '{{projectId}}';
     this.appProfileId = options.appProfileId;
-    this.projectName = 'projects/' + this.projectId;
+    this.projectName = `projects/${this.projectId}`;
   }
 
   /**

--- a/src/index.js
+++ b/src/index.js
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-'use strict';
-
 var arrify = require('arrify');
 var common = require('@google-cloud/common');
 var extend = require('extend');

--- a/src/index.js
+++ b/src/index.js
@@ -713,6 +713,7 @@ class Bigtable {
         const retryOpts = extend(
           {
             currentRetryAttempt: 0,
+            noResponseRetries: 0,
             objectMode: true,
             shouldRetryFn: GrpcService.shouldRetryRequest_,
             request() {

--- a/src/index.js
+++ b/src/index.js
@@ -802,14 +802,6 @@ Bigtable.Cluster = Cluster;
  */
 Bigtable.Instance = Instance;
 
-// Allow creating a `Bigtable` instance without using the `new` keyword.
-/* eslint-disable-next-line no-class-assign */
-Bigtable = new Proxy(Bigtable, {
-  apply(target, thisArg, argumentsList) {
-    return new target(...argumentsList);
-  },
-});
-
 /**
  * The default export of the `@google-cloud/bigtable` package is the
  * {@link Bigtable} class.

--- a/src/instance.js
+++ b/src/instance.js
@@ -216,7 +216,7 @@ Instance.prototype.createAppProfile = function(name, options, callback) {
     {
       client: 'BigtableInstanceAdminClient',
       method: 'createAppProfile',
-      reqOpts: reqOpts,
+      reqOpts,
       gaxOpts: options.gaxOptions,
     },
     function(...args) {
@@ -324,7 +324,7 @@ Instance.prototype.createCluster = function(name, options, callback) {
     {
       client: 'BigtableInstanceAdminClient',
       method: 'createCluster',
-      reqOpts: reqOpts,
+      reqOpts,
       gaxOpts: options.gaxOptions,
     },
     function(...args) {
@@ -446,7 +446,7 @@ Instance.prototype.createTable = function(name, options, callback) {
   if (options.splits) {
     reqOpts.initialSplits = options.splits.map(function(key) {
       return {
-        key: key,
+        key,
       };
     });
   }
@@ -475,7 +475,7 @@ Instance.prototype.createTable = function(name, options, callback) {
     {
       client: 'BigtableTableAdminClient',
       method: 'createTable',
-      reqOpts: reqOpts,
+      reqOpts,
       gaxOpts: options.gaxOptions,
     },
     function(...args) {
@@ -672,7 +672,7 @@ Instance.prototype.getAppProfiles = function(gaxOptions, callback) {
     {
       client: 'BigtableInstanceAdminClient',
       method: 'listAppProfiles',
-      reqOpts: reqOpts,
+      reqOpts,
       gaxOpts: gaxOptions,
     },
     function(err, resp) {
@@ -737,7 +737,7 @@ Instance.prototype.getClusters = function(gaxOptions, callback) {
     {
       client: 'BigtableInstanceAdminClient',
       method: 'listClusters',
-      reqOpts: reqOpts,
+      reqOpts,
       gaxOpts: gaxOptions,
     },
     function(err, resp) {
@@ -880,7 +880,7 @@ Instance.prototype.getTables = function(options, callback) {
     {
       client: 'BigtableTableAdminClient',
       method: 'listTables',
-      reqOpts: reqOpts,
+      reqOpts,
       gaxOpts: options.gaxOptions,
     },
     function(...args) {

--- a/src/instance.js
+++ b/src/instance.js
@@ -451,7 +451,10 @@ class Instance {
     }
 
     if (options.families) {
-      const columnFamilies = options.families.reduce(function(families, family) {
+      const columnFamilies = options.families.reduce(function(
+        families,
+        family
+      ) {
         if (is.string(family)) {
           family = {
             name: family,
@@ -465,7 +468,8 @@ class Instance {
         }
 
         return families;
-      }, {});
+      },
+      {});
 
       reqOpts.table.columnFamilies = columnFamilies;
     }

--- a/src/instance.js
+++ b/src/instance.js
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-var common = require('@google-cloud/common');
-var extend = require('extend');
-var is = require('is');
+const common = require('@google-cloud/common');
+const extend = require('extend');
+const is = require('is');
 
-var AppProfile = require('./app-profile.js');
-var Cluster = require('./cluster.js');
-var Family = require('./family.js');
-var Table = require('./table.js');
+const AppProfile = require('./app-profile.js');
+const Cluster = require('./cluster.js');
+const Family = require('./family.js');
+const Table = require('./table.js');
 
 /**
  * Create an Instance object to interact with a Compute instance.
@@ -39,7 +39,7 @@ var Table = require('./table.js');
 function Instance(bigtable, name) {
   this.bigtable = bigtable;
 
-  var id = name;
+  let id = name;
 
   if (id.indexOf('/') === -1) {
     id = bigtable.projectName + '/instances/' + name;
@@ -62,7 +62,7 @@ function Instance(bigtable, name) {
  * // 1
  */
 Instance.getTypeType_ = function(type) {
-  var types = {
+  const types = {
     unspecified: 0,
     production: 1,
     development: 2,
@@ -286,14 +286,14 @@ Instance.prototype.createAppProfile = function(name, options, callback) {
  * });
  */
 Instance.prototype.createCluster = function(name, options, callback) {
-  var self = this;
+  const self = this;
 
   if (is.function(options)) {
     callback = options;
     options = {};
   }
 
-  var reqOpts = {
+  const reqOpts = {
     parent: this.id,
     clusterId: name,
   };
@@ -314,7 +314,7 @@ Instance.prototype.createCluster = function(name, options, callback) {
   }
 
   if (options.storage) {
-    var storageType = Cluster.getStorageType_(options.storage);
+    const storageType = Cluster.getStorageType_(options.storage);
     reqOpts.cluster.defaultStorageType = storageType;
   }
 
@@ -418,7 +418,7 @@ Instance.prototype.createCluster = function(name, options, callback) {
  * });
  */
 Instance.prototype.createTable = function(name, options, callback) {
-  var self = this;
+  const self = this;
 
   if (!name) {
     throw new Error('A name is required to create a table.');
@@ -431,7 +431,7 @@ Instance.prototype.createTable = function(name, options, callback) {
     options = {};
   }
 
-  var reqOpts = {
+  const reqOpts = {
     parent: this.id,
     tableId: name,
     table: {
@@ -450,14 +450,14 @@ Instance.prototype.createTable = function(name, options, callback) {
   }
 
   if (options.families) {
-    var columnFamilies = options.families.reduce(function(families, family) {
+    const columnFamilies = options.families.reduce(function(families, family) {
       if (is.string(family)) {
         family = {
           name: family,
         };
       }
 
-      var columnFamily = (families[family.name] = {});
+      const columnFamily = (families[family.name] = {});
 
       if (family.rule) {
         columnFamily.gcRule = Family.formatRule_(family.rule);
@@ -478,7 +478,7 @@ Instance.prototype.createTable = function(name, options, callback) {
     },
     function(...args) {
       if (args[1]) {
-        var table = self.table(args[1].name);
+        const table = self.table(args[1].name);
         table.metadata = args[1];
         args.splice(1, 0, table);
       }
@@ -614,7 +614,7 @@ Instance.prototype.exists = function(gaxOptions, callback) {
  * });
  */
 Instance.prototype.get = function(gaxOptions, callback) {
-  var self = this;
+  const self = this;
 
   if (is.fn(gaxOptions)) {
     callback = gaxOptions;
@@ -655,14 +655,14 @@ Instance.prototype.get = function(gaxOptions, callback) {
  * });
  */
 Instance.prototype.getAppProfiles = function(gaxOptions, callback) {
-  var self = this;
+  const self = this;
 
   if (is.function(gaxOptions)) {
     callback = gaxOptions;
     gaxOptions = {};
   }
 
-  var reqOpts = {
+  const reqOpts = {
     parent: this.id,
   };
 
@@ -679,8 +679,8 @@ Instance.prototype.getAppProfiles = function(gaxOptions, callback) {
         return;
       }
 
-      var appProfiles = resp.map(function(appProfileObj) {
-        var appProfile = self.appProfile(appProfileObj.name);
+      const appProfiles = resp.map(function(appProfileObj) {
+        const appProfile = self.appProfile(appProfileObj.name);
         appProfile.metadata = appProfileObj;
         return appProfile;
       });
@@ -720,14 +720,14 @@ Instance.prototype.getAppProfiles = function(gaxOptions, callback) {
  * });
  */
 Instance.prototype.getClusters = function(gaxOptions, callback) {
-  var self = this;
+  const self = this;
 
   if (is.function(gaxOptions)) {
     callback = gaxOptions;
     gaxOptions = {};
   }
 
-  var reqOpts = {
+  const reqOpts = {
     parent: this.id,
   };
 
@@ -744,8 +744,8 @@ Instance.prototype.getClusters = function(gaxOptions, callback) {
         return;
       }
 
-      var clusters = resp.clusters.map(function(clusterObj) {
-        var cluster = self.cluster(clusterObj.name);
+      const clusters = resp.clusters.map(function(clusterObj) {
+        const cluster = self.cluster(clusterObj.name);
         cluster.metadata = clusterObj;
         return cluster;
       });
@@ -781,7 +781,7 @@ Instance.prototype.getClusters = function(gaxOptions, callback) {
  * });
  */
 Instance.prototype.getMetadata = function(gaxOptions, callback) {
-  var self = this;
+  const self = this;
 
   if (is.fn(gaxOptions)) {
     callback = gaxOptions;
@@ -860,14 +860,14 @@ Instance.prototype.getMetadata = function(gaxOptions, callback) {
  * });
  */
 Instance.prototype.getTables = function(options, callback) {
-  var self = this;
+  const self = this;
 
   if (is.function(options)) {
     callback = options;
     options = {};
   }
 
-  var reqOpts = extend({}, options, {
+  const reqOpts = extend({}, options, {
     parent: this.id,
     view: Table.VIEWS[options.view || 'unspecified'],
   });
@@ -884,8 +884,8 @@ Instance.prototype.getTables = function(options, callback) {
     function(...args) {
       if (args[1]) {
         args[1] = args[1].map(function(tableObj) {
-          var name = tableObj.name.split('/').pop();
-          var table = self.table(name);
+          const name = tableObj.name.split('/').pop();
+          const table = self.table(name);
           table.metadata = tableObj;
           return table;
         });
@@ -962,7 +962,7 @@ Instance.prototype.getTablesStream = common.paginator.streamify('getTables');
  * });
  */
 Instance.prototype.setMetadata = function(metadata, gaxOptions, callback) {
-  var self = this;
+  const self = this;
 
   if (is.fn(gaxOptions)) {
     callback = gaxOptions;

--- a/src/instance.js
+++ b/src/instance.js
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-'use strict';
-
 var common = require('@google-cloud/common');
 var extend = require('extend');
 var is = require('is');

--- a/src/instance.js
+++ b/src/instance.js
@@ -36,865 +36,940 @@ const Table = require('./table.js');
  * const bigtable = new Bigtable();
  * const instance = bigtable.instance('my-instance');
  */
-function Instance(bigtable, name) {
-  this.bigtable = bigtable;
+class Instance {
+  constructor(bigtable, name) {
+    this.bigtable = bigtable;
 
-  let id = name;
+    let id = name;
 
-  if (id.indexOf('/') === -1) {
-    id = bigtable.projectName + '/instances/' + name;
-  }
-
-  this.id = id;
-  this.name = id.split('/').pop();
-}
-
-/**
- * Maps the instance type to the proper integer.
- *
- * @private
- *
- * @param {string} type The instance type (production, development).
- * @returns {number}
- *
- * @example
- * Instance.getTypeType_('production');
- * // 1
- */
-Instance.getTypeType_ = function(type) {
-  const types = {
-    unspecified: 0,
-    production: 1,
-    development: 2,
-  };
-
-  if (is.string(type)) {
-    type = type.toLowerCase();
-  }
-
-  return types[type] || types.unspecified;
-};
-
-/**
- * Get a reference to a Bigtable App Profile.
- *
- * @param {string} name The name of the app profile.
- * @returns {AppProfile}
- */
-Instance.prototype.appProfile = function(name) {
-  return new AppProfile(this, name);
-};
-
-/**
- * Create an instance.
- *
- * @param {object} [options] See {@link Bigtable#createInstance}.
- * @param {object} [options.gaxOptions]  Request configuration options, outlined
- *     here: https://googleapis.github.io/gax-nodejs/global.html#CallOptions.
- * @param {function} callback The callback function.
- * @param {?error} callback.err An error returned while making this
- *     request.
- * @param {Instance} callback.instance The newly created
- *     instance.
- * @param {Operation} callback.operation An operation object that can be used
- *     to check the status of the request.
- * @param {object} callback.apiResponse The full API response.
- *
- * @example
- * const Bigtable = require('@google-cloud/bigtable');
- * const bigtable = new Bigtable();
- * const instance = bigtable.instance('my-instance');
- *
- * instance.create(function(err, instance, operation, apiResponse) {
- *   if (err) {
- *     // Error handling omitted.
- *   }
- *
- *   operation
- *     .on('error', console.error)
- *     .on('complete', function() {
- *       // The instance was created successfully.
- *     });
- * });
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * instance.create().then(function(data) {
- *   var instance = data[0];
- *   var operation = data[1];
- *   var apiResponse = data[2];
- * });
- */
-Instance.prototype.create = function(options, callback) {
-  if (is.fn(options)) {
-    callback = options;
-    options = {};
-  }
-
-  this.bigtable.createInstance(this.name, options, callback);
-};
-
-/**
- * Create an app profile.
- *
- * @param {string} name The name to be used when referring to the new
- *     app profile within its instance.
- * @param {object} options AppProfile creation options.
- * @param {'any'|Cluster} options.routing  The routing policy for all
- *     read/write requests which use this app profile. This can be either the
- *     string 'any' or a cluster of an instance. This value is required when
- *     creating the app profile and optional when setting the metadata.
- * @param {object} [options.gaxOptions]  Request configuration options, outlined
- *     here: https://googleapis.github.io/gax-nodejs/global.html#CallOptions.
- * @param {boolean} [options.allowTransactionalWrites] Whether or not
- *     CheckAndMutateRow and ReadModifyWriteRow requests are allowed by this
- *     app profile. It is unsafe to send these requests to the same
- *     table/row/column in multiple clusters. This is only used when the
- *     routing value is a cluster.
- * @param {string} [options.description] The long form description of the use
- *     case for this AppProfile.
- * @param {string} [options.ignoreWarnings] Whether to ignore safety checks
- *     when creating the app profile
- * @param {function} callback The callback function.
- * @param {?error} callback.err An error returned while making this request.
- * @param {Cluster} callback.appProfile The newly created app profile.
- *
- * @example
- * const Bigtable = require('@google-cloud/bigtable');
- * const bigtable = new Bigtable();
- * const instance = bigtable.instance('my-instance');
- * const cluster = instance.cluster('my-cluster');
- *
- * const callback = function(err, appProfile, apiResponse) {
- *   // `appProfile` is an AppProfile object.
- * };
- *
- * const options = {
- *   routing: cluster,
- *   allowTransactionalWrites: true,
- *   ignoreWarnings: true,
- * };
- *
- * instance.createAppProfile('my-app-profile', options, callback);
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * instance.createAppProfile('my-app-profile', options).then(function(data) {
- *   const appProfile = data[0];
- *   const apiResponse = data[1];
- * });
- */
-Instance.prototype.createAppProfile = function(name, options, callback) {
-  const self = this;
-
-  if (is.function(options)) {
-    callback = options;
-    options = {};
-  }
-
-  if (!options.routing) {
-    throw new Error('An app profile must contain a routing policy.');
-  }
-
-  const appProfile = AppProfile.formatAppProfile_(options);
-
-  const reqOpts = {
-    parent: this.id,
-    appProfileId: name,
-    appProfile,
-  };
-
-  if (is.boolean(options.ignoreWarnings)) {
-    reqOpts.ignoreWarnings = options.ignoreWarnings;
-  }
-
-  this.bigtable.request(
-    {
-      client: 'BigtableInstanceAdminClient',
-      method: 'createAppProfile',
-      reqOpts,
-      gaxOpts: options.gaxOptions,
-    },
-    function(...args) {
-      if (args[1]) {
-        args.splice(1, 0, self.appProfile(name));
-      }
-
-      callback(...args);
+    if (id.indexOf('/') === -1) {
+      id = bigtable.projectName + '/instances/' + name;
     }
-  );
-};
 
-/**
- * Create a cluster.
- *
- * @param {string} name The name to be used when referring to the new
- *     cluster within its instance.
- * @param {object} [options] Cluster creation options.
- * @param {object} [options.gaxOptions]  Request configuration options, outlined
- *     here: https://googleapis.github.io/gax-nodejs/global.html#CallOptions.
- * @param {string} [options.location] The location where this cluster's nodes
- *     and storage reside. For best performance clients should be located as
- *     as close as possible to this cluster. Currently only zones are
- *     supported.
- * @param {number} [options.nodes] The number of nodes allocated to this
- *     cluster. More nodes enable higher throughput and more consistent
- *     performance.
- * @param {string} [options.storage] The type of storage used by this cluster
- *     to serve its parent instance's tables. Options are 'hdd' or 'ssd'.
- * @param {function} callback The callback function.
- * @param {?error} callback.err An error returned while making this request.
- * @param {Cluster} callback.cluster The newly created
- *     cluster.
- * @param {Operation} callback.operation An operation object that can be used
- *     to check the status of the request.
- *
- * @example
- * const Bigtable = require('@google-cloud/bigtable');
- * const bigtable = new Bigtable();
- * const instance = bigtable.instance('my-instance');
- *
- * const callback = function(err, cluster, operation, apiResponse) {
- *   if (err) {
- *     // Error handling omitted.
- *   }
- *
- *   operation
- *     .on('error', console.log)
- *     .on('complete', function() {
- *       // The cluster was created successfully.
- *     });
- * };
- *
- * const options = {
- *   location: 'us-central1-b',
- *   nodes: 3,
- *   storage: 'ssd'
- * };
- *
- * instance.createCluster('my-cluster', options, callback);
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * instance.createCluster('my-cluster', options).then(function(data) {
- *   const cluster = data[0];
- *   const operation = data[1];
- *   const apiResponse = data[2];
- * });
- */
-Instance.prototype.createCluster = function(name, options, callback) {
-  const self = this;
-
-  if (is.function(options)) {
-    callback = options;
-    options = {};
+    this.id = id;
+    this.name = id.split('/').pop();
   }
 
-  const reqOpts = {
-    parent: this.id,
-    clusterId: name,
-  };
+  /**
+   * Maps the instance type to the proper integer.
+   *
+   * @private
+   *
+   * @param {string} type The instance type (production, development).
+   * @returns {number}
+   *
+   * @example
+   * Instance.getTypeType_('production');
+   * // 1
+   */
+  static getTypeType_(type) {
+    const types = {
+      unspecified: 0,
+      production: 1,
+      development: 2,
+    };
 
-  if (!is.empty(options)) {
-    reqOpts.cluster = {};
+    if (is.string(type)) {
+      type = type.toLowerCase();
+    }
+
+    return types[type] || types.unspecified;
   }
 
-  if (options.location) {
-    reqOpts.cluster.location = Cluster.getLocation_(
-      this.bigtable.projectId,
-      options.location
+  /**
+   * Get a reference to a Bigtable App Profile.
+   *
+   * @param {string} name The name of the app profile.
+   * @returns {AppProfile}
+   */
+  appProfile(name) {
+    return new AppProfile(this, name);
+  }
+
+  /**
+   * Create an instance.
+   *
+   * @param {object} [options] See {@link Bigtable#createInstance}.
+   * @param {object} [options.gaxOptions]  Request configuration options, outlined
+   *     here: https://googleapis.github.io/gax-nodejs/global.html#CallOptions.
+   * @param {function} callback The callback function.
+   * @param {?error} callback.err An error returned while making this
+   *     request.
+   * @param {Instance} callback.instance The newly created
+   *     instance.
+   * @param {Operation} callback.operation An operation object that can be used
+   *     to check the status of the request.
+   * @param {object} callback.apiResponse The full API response.
+   *
+   * @example
+   * const Bigtable = require('@google-cloud/bigtable');
+   * const bigtable = new Bigtable();
+   * const instance = bigtable.instance('my-instance');
+   *
+   * instance.create(function(err, instance, operation, apiResponse) {
+   *   if (err) {
+   *     // Error handling omitted.
+   *   }
+   *
+   *   operation
+   *     .on('error', console.error)
+   *     .on('complete', function() {
+   *       // The instance was created successfully.
+   *     });
+   * });
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * instance.create().then(function(data) {
+   *   var instance = data[0];
+   *   var operation = data[1];
+   *   var apiResponse = data[2];
+   * });
+   */
+  create(options, callback) {
+    if (is.fn(options)) {
+      callback = options;
+      options = {};
+    }
+
+    this.bigtable.createInstance(this.name, options, callback);
+  }
+
+  /**
+   * Create an app profile.
+   *
+   * @param {string} name The name to be used when referring to the new
+   *     app profile within its instance.
+   * @param {object} options AppProfile creation options.
+   * @param {'any'|Cluster} options.routing  The routing policy for all
+   *     read/write requests which use this app profile. This can be either the
+   *     string 'any' or a cluster of an instance. This value is required when
+   *     creating the app profile and optional when setting the metadata.
+   * @param {object} [options.gaxOptions]  Request configuration options, outlined
+   *     here: https://googleapis.github.io/gax-nodejs/global.html#CallOptions.
+   * @param {boolean} [options.allowTransactionalWrites] Whether or not
+   *     CheckAndMutateRow and ReadModifyWriteRow requests are allowed by this
+   *     app profile. It is unsafe to send these requests to the same
+   *     table/row/column in multiple clusters. This is only used when the
+   *     routing value is a cluster.
+   * @param {string} [options.description] The long form description of the use
+   *     case for this AppProfile.
+   * @param {string} [options.ignoreWarnings] Whether to ignore safety checks
+   *     when creating the app profile
+   * @param {function} callback The callback function.
+   * @param {?error} callback.err An error returned while making this request.
+   * @param {Cluster} callback.appProfile The newly created app profile.
+   *
+   * @example
+   * const Bigtable = require('@google-cloud/bigtable');
+   * const bigtable = new Bigtable();
+   * const instance = bigtable.instance('my-instance');
+   * const cluster = instance.cluster('my-cluster');
+   *
+   * const callback = function(err, appProfile, apiResponse) {
+   *   // `appProfile` is an AppProfile object.
+   * };
+   *
+   * const options = {
+   *   routing: cluster,
+   *   allowTransactionalWrites: true,
+   *   ignoreWarnings: true,
+   * };
+   *
+   * instance.createAppProfile('my-app-profile', options, callback);
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * instance.createAppProfile('my-app-profile', options).then(function(data) {
+   *   const appProfile = data[0];
+   *   const apiResponse = data[1];
+   * });
+   */
+  createAppProfile(name, options, callback) {
+    const self = this;
+
+    if (is.function(options)) {
+      callback = options;
+      options = {};
+    }
+
+    if (!options.routing) {
+      throw new Error('An app profile must contain a routing policy.');
+    }
+
+    const appProfile = AppProfile.formatAppProfile_(options);
+
+    const reqOpts = {
+      parent: this.id,
+      appProfileId: name,
+      appProfile,
+    };
+
+    if (is.boolean(options.ignoreWarnings)) {
+      reqOpts.ignoreWarnings = options.ignoreWarnings;
+    }
+
+    this.bigtable.request(
+      {
+        client: 'BigtableInstanceAdminClient',
+        method: 'createAppProfile',
+        reqOpts,
+        gaxOpts: options.gaxOptions,
+      },
+      function(...args) {
+        if (args[1]) {
+          args.splice(1, 0, self.appProfile(name));
+        }
+
+        callback(...args);
+      }
     );
   }
 
-  if (options.nodes) {
-    reqOpts.cluster.serveNodes = options.nodes;
+  /**
+   * Create a cluster.
+   *
+   * @param {string} name The name to be used when referring to the new
+   *     cluster within its instance.
+   * @param {object} [options] Cluster creation options.
+   * @param {object} [options.gaxOptions]  Request configuration options, outlined
+   *     here: https://googleapis.github.io/gax-nodejs/global.html#CallOptions.
+   * @param {string} [options.location] The location where this cluster's nodes
+   *     and storage reside. For best performance clients should be located as
+   *     as close as possible to this cluster. Currently only zones are
+   *     supported.
+   * @param {number} [options.nodes] The number of nodes allocated to this
+   *     cluster. More nodes enable higher throughput and more consistent
+   *     performance.
+   * @param {string} [options.storage] The type of storage used by this cluster
+   *     to serve its parent instance's tables. Options are 'hdd' or 'ssd'.
+   * @param {function} callback The callback function.
+   * @param {?error} callback.err An error returned while making this request.
+   * @param {Cluster} callback.cluster The newly created
+   *     cluster.
+   * @param {Operation} callback.operation An operation object that can be used
+   *     to check the status of the request.
+   *
+   * @example
+   * const Bigtable = require('@google-cloud/bigtable');
+   * const bigtable = new Bigtable();
+   * const instance = bigtable.instance('my-instance');
+   *
+   * const callback = function(err, cluster, operation, apiResponse) {
+   *   if (err) {
+   *     // Error handling omitted.
+   *   }
+   *
+   *   operation
+   *     .on('error', console.log)
+   *     .on('complete', function() {
+   *       // The cluster was created successfully.
+   *     });
+   * };
+   *
+   * const options = {
+   *   location: 'us-central1-b',
+   *   nodes: 3,
+   *   storage: 'ssd'
+   * };
+   *
+   * instance.createCluster('my-cluster', options, callback);
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * instance.createCluster('my-cluster', options).then(function(data) {
+   *   const cluster = data[0];
+   *   const operation = data[1];
+   *   const apiResponse = data[2];
+   * });
+   */
+  createCluster(name, options, callback) {
+    const self = this;
+
+    if (is.function(options)) {
+      callback = options;
+      options = {};
+    }
+
+    const reqOpts = {
+      parent: this.id,
+      clusterId: name,
+    };
+
+    if (!is.empty(options)) {
+      reqOpts.cluster = {};
+    }
+
+    if (options.location) {
+      reqOpts.cluster.location = Cluster.getLocation_(
+        this.bigtable.projectId,
+        options.location
+      );
+    }
+
+    if (options.nodes) {
+      reqOpts.cluster.serveNodes = options.nodes;
+    }
+
+    if (options.storage) {
+      const storageType = Cluster.getStorageType_(options.storage);
+      reqOpts.cluster.defaultStorageType = storageType;
+    }
+
+    this.bigtable.request(
+      {
+        client: 'BigtableInstanceAdminClient',
+        method: 'createCluster',
+        reqOpts,
+        gaxOpts: options.gaxOptions,
+      },
+      function(...args) {
+        if (args[1]) {
+          args.splice(1, 0, self.cluster(name));
+        }
+
+        callback(...args);
+      }
+    );
   }
 
-  if (options.storage) {
-    const storageType = Cluster.getStorageType_(options.storage);
-    reqOpts.cluster.defaultStorageType = storageType;
+  /**
+   * Create a table on your Bigtable instance.
+   *
+   * @see [Designing Your Schema]{@link https://cloud.google.com/bigtable/docs/schema-design}
+   * @see [Splitting Keys]{@link https://cloud.google.com/bigtable/docs/managing-tables#splits}
+   *
+   * @throws {error} If a name is not provided.
+   *
+   * @param {string} name The name of the table.
+   * @param {object} [options] Table creation options.
+   * @param {object|string[]} [options.families] Column families to be created
+   *     within the table.
+   * @param {object} [options.gaxOptions] Request configuration options, outlined
+   *     here: https://googleapis.github.io/gax-nodejs/CallSettings.html.
+   * @param {string[]} [options.splits] Initial
+   *    [split keys](https://cloud.google.com/bigtable/docs/managing-tables#splits).
+   * @param {function} callback The callback function.
+   * @param {?error} callback.err An error returned while making this request.
+   * @param {Table} callback.table The newly created table.
+   * @param {object} callback.apiResponse The full API response.
+   *
+   * @example
+   * const Bigtable = require('@google-cloud/bigtable');
+   * const bigtable = new Bigtable();
+   * const instance = bigtable.instance('my-instance');
+   *
+   * const callback = function(err, table, apiResponse) {
+   *   // `table` is a Table object.
+   * };
+   *
+   * instance.createTable('prezzy', callback);
+   *
+   * //-
+   * // Optionally specify column families to be created within the table.
+   * //-
+   * const options = {
+   *   families: ['follows']
+   * };
+   *
+   * instance.createTable('prezzy', options, callback);
+   *
+   * //-
+   * // You can also specify garbage collection rules for your column families.
+   * // See {@link Table#createFamily} for more information about
+   * // column families and garbage collection rules.
+   * //-
+   * const options = {
+   *   families: [
+   *     {
+   *       name: 'follows',
+   *       rule:  {
+   *         age: {
+   *           seconds: 0,
+   *           nanos: 5000
+   *         },
+   *         versions: 3,
+   *         union: true
+   *       }
+   *     }
+   *   ]
+   * };
+   *
+   * instance.createTable('prezzy', options, callback);
+   *
+   * //-
+   * // Pre-split the table based on the row key to spread the load across
+   * // multiple Cloud Bigtable nodes.
+   * //-
+   * const options = {
+   *   splits: ['10', '20']
+   * };
+   *
+   * instance.createTable('prezzy', options, callback);
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * instance.createTable('prezzy', options).then(function(data) {
+   *   const table = data[0];
+   *   const apiResponse = data[1];
+   * });
+   */
+  createTable(name, options, callback) {
+    const self = this;
+
+    if (!name) {
+      throw new Error('A name is required to create a table.');
+    }
+
+    options = options || {};
+
+    if (is.function(options)) {
+      callback = options;
+      options = {};
+    }
+
+    const reqOpts = {
+      parent: this.id,
+      tableId: name,
+      table: {
+        // The granularity at which timestamps are stored in the table.
+        // Currently only milliseconds is supported, so it's not configurable.
+        granularity: 0,
+      },
+    };
+
+    if (options.splits) {
+      reqOpts.initialSplits = options.splits.map(function(key) {
+        return {
+          key,
+        };
+      });
+    }
+
+    if (options.families) {
+      const columnFamilies = options.families.reduce(function(families, family) {
+        if (is.string(family)) {
+          family = {
+            name: family,
+          };
+        }
+
+        const columnFamily = (families[family.name] = {});
+
+        if (family.rule) {
+          columnFamily.gcRule = Family.formatRule_(family.rule);
+        }
+
+        return families;
+      }, {});
+
+      reqOpts.table.columnFamilies = columnFamilies;
+    }
+
+    this.bigtable.request(
+      {
+        client: 'BigtableTableAdminClient',
+        method: 'createTable',
+        reqOpts,
+        gaxOpts: options.gaxOptions,
+      },
+      function(...args) {
+        if (args[1]) {
+          const table = self.table(args[1].name);
+          table.metadata = args[1];
+          args.splice(1, 0, table);
+        }
+
+        callback(...args);
+      }
+    );
   }
 
-  this.bigtable.request(
-    {
-      client: 'BigtableInstanceAdminClient',
-      method: 'createCluster',
-      reqOpts,
-      gaxOpts: options.gaxOptions,
-    },
-    function(...args) {
-      if (args[1]) {
-        args.splice(1, 0, self.cluster(name));
+  /**
+   * Get a reference to a Bigtable Cluster.
+   *
+   * @param {string} name The name of the cluster.
+   * @returns {Cluster}
+   */
+  cluster(name) {
+    return new Cluster(this, name);
+  }
+
+  /**
+   * Delete the instance.
+   *
+   * @param {object} [gaxOptions] Request configuration options, outlined here:
+   *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
+   * @param {function} [callback] The callback function.
+   * @param {?error} callback.err An error returned while making this
+   *     request.
+   * @param {object} callback.apiResponse The full API response.
+   *
+   * @example
+   * const Bigtable = require('@google-cloud/bigtable');
+   * const bigtable = new Bigtable();
+   * const instance = bigtable.instance('my-instance');
+   *
+   * instance.delete(function(err, apiResponse) {});
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * instance.delete().then(function(data) {
+   *   var apiResponse = data[0];
+   * });
+   */
+  delete(gaxOptions, callback) {
+    if (is.fn(gaxOptions)) {
+      callback = gaxOptions;
+      gaxOptions = {};
+    }
+
+    this.bigtable.request(
+      {
+        client: 'BigtableInstanceAdminClient',
+        method: 'deleteInstance',
+        reqOpts: {
+          name: this.id,
+        },
+        gaxOpts: gaxOptions,
+      },
+      callback
+    );
+  }
+
+  /**
+   * Check if an instance exists.
+   *
+   * @param {object} [gaxOptions] Request configuration options, outlined
+   *     here: https://googleapis.github.io/gax-nodejs/CallSettings.html.
+   * @param {function} callback The callback function.
+   * @param {?error} callback.err An error returned while making this
+   *     request.
+   * @param {boolean} callback.exists Whether the instance exists or not.
+   *
+   * @example
+   * const Bigtable = require('@google-cloud/bigtable');
+   * const bigtable = new Bigtable();
+   * const instance = bigtable.instance('my-instance');
+   *
+   * instance.exists(function(err, exists) {});
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * instance.exists().then(function(data) {
+   *   var exists = data[0];
+   * });
+   */
+  exists(gaxOptions, callback) {
+    if (is.fn(gaxOptions)) {
+      callback = gaxOptions;
+      gaxOptions = {};
+    }
+
+    this.getMetadata(gaxOptions, function(err) {
+      if (err) {
+        if (err.code === 5) {
+          callback(null, false);
+          return;
+        }
+
+        callback(err);
+        return;
       }
 
-      callback(...args);
-    }
-  );
-};
-
-/**
- * Create a table on your Bigtable instance.
- *
- * @see [Designing Your Schema]{@link https://cloud.google.com/bigtable/docs/schema-design}
- * @see [Splitting Keys]{@link https://cloud.google.com/bigtable/docs/managing-tables#splits}
- *
- * @throws {error} If a name is not provided.
- *
- * @param {string} name The name of the table.
- * @param {object} [options] Table creation options.
- * @param {object|string[]} [options.families] Column families to be created
- *     within the table.
- * @param {object} [options.gaxOptions] Request configuration options, outlined
- *     here: https://googleapis.github.io/gax-nodejs/CallSettings.html.
- * @param {string[]} [options.splits] Initial
- *    [split keys](https://cloud.google.com/bigtable/docs/managing-tables#splits).
- * @param {function} callback The callback function.
- * @param {?error} callback.err An error returned while making this request.
- * @param {Table} callback.table The newly created table.
- * @param {object} callback.apiResponse The full API response.
- *
- * @example
- * const Bigtable = require('@google-cloud/bigtable');
- * const bigtable = new Bigtable();
- * const instance = bigtable.instance('my-instance');
- *
- * const callback = function(err, table, apiResponse) {
- *   // `table` is a Table object.
- * };
- *
- * instance.createTable('prezzy', callback);
- *
- * //-
- * // Optionally specify column families to be created within the table.
- * //-
- * const options = {
- *   families: ['follows']
- * };
- *
- * instance.createTable('prezzy', options, callback);
- *
- * //-
- * // You can also specify garbage collection rules for your column families.
- * // See {@link Table#createFamily} for more information about
- * // column families and garbage collection rules.
- * //-
- * const options = {
- *   families: [
- *     {
- *       name: 'follows',
- *       rule:  {
- *         age: {
- *           seconds: 0,
- *           nanos: 5000
- *         },
- *         versions: 3,
- *         union: true
- *       }
- *     }
- *   ]
- * };
- *
- * instance.createTable('prezzy', options, callback);
- *
- * //-
- * // Pre-split the table based on the row key to spread the load across
- * // multiple Cloud Bigtable nodes.
- * //-
- * const options = {
- *   splits: ['10', '20']
- * };
- *
- * instance.createTable('prezzy', options, callback);
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * instance.createTable('prezzy', options).then(function(data) {
- *   const table = data[0];
- *   const apiResponse = data[1];
- * });
- */
-Instance.prototype.createTable = function(name, options, callback) {
-  const self = this;
-
-  if (!name) {
-    throw new Error('A name is required to create a table.');
-  }
-
-  options = options || {};
-
-  if (is.function(options)) {
-    callback = options;
-    options = {};
-  }
-
-  const reqOpts = {
-    parent: this.id,
-    tableId: name,
-    table: {
-      // The granularity at which timestamps are stored in the table.
-      // Currently only milliseconds is supported, so it's not configurable.
-      granularity: 0,
-    },
-  };
-
-  if (options.splits) {
-    reqOpts.initialSplits = options.splits.map(function(key) {
-      return {
-        key,
-      };
+      callback(null, true);
     });
   }
 
-  if (options.families) {
-    const columnFamilies = options.families.reduce(function(families, family) {
-      if (is.string(family)) {
-        family = {
-          name: family,
-        };
-      }
+  /**
+   * Get an instance if it exists.
+   *
+   * @param {object} [gaxOptions] Request configuration options, outlined here:
+   *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
+   * @param {function} callback The callback function.
+   * @param {?error} callback.error An error returned while making this request.
+   * @param {Instance} callback.instance The Instance object.
+   * @param {object} callback.apiResponse The resource as it exists in the API.
+   *
+   * @example
+   * const Bigtable = require('@google-cloud/bigtable');
+   * const bigtable = new Bigtable();
+   * const instance = bigtable.instance('my-instance');
+   *
+   * instance.get(function(err, instance, apiResponse) {
+   *   // The `instance` data has been populated.
+   * });
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * instance.get().then(function(data) {
+   *   var instance = data[0];
+   *   var apiResponse = data[1];
+   * });
+   */
+  get(gaxOptions, callback) {
+    const self = this;
 
-      const columnFamily = (families[family.name] = {});
-
-      if (family.rule) {
-        columnFamily.gcRule = Family.formatRule_(family.rule);
-      }
-
-      return families;
-    }, {});
-
-    reqOpts.table.columnFamilies = columnFamilies;
-  }
-
-  this.bigtable.request(
-    {
-      client: 'BigtableTableAdminClient',
-      method: 'createTable',
-      reqOpts,
-      gaxOpts: options.gaxOptions,
-    },
-    function(...args) {
-      if (args[1]) {
-        const table = self.table(args[1].name);
-        table.metadata = args[1];
-        args.splice(1, 0, table);
-      }
-
-      callback(...args);
+    if (is.fn(gaxOptions)) {
+      callback = gaxOptions;
+      gaxOptions = {};
     }
-  );
-};
 
-/**
- * Get a reference to a Bigtable Cluster.
- *
- * @param {string} name The name of the cluster.
- * @returns {Cluster}
- */
-Instance.prototype.cluster = function(name) {
-  return new Cluster(this, name);
-};
-
-/**
- * Delete the instance.
- *
- * @param {object} [gaxOptions] Request configuration options, outlined here:
- *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
- * @param {function} [callback] The callback function.
- * @param {?error} callback.err An error returned while making this
- *     request.
- * @param {object} callback.apiResponse The full API response.
- *
- * @example
- * const Bigtable = require('@google-cloud/bigtable');
- * const bigtable = new Bigtable();
- * const instance = bigtable.instance('my-instance');
- *
- * instance.delete(function(err, apiResponse) {});
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * instance.delete().then(function(data) {
- *   var apiResponse = data[0];
- * });
- */
-Instance.prototype.delete = function(gaxOptions, callback) {
-  if (is.fn(gaxOptions)) {
-    callback = gaxOptions;
-    gaxOptions = {};
+    this.getMetadata(gaxOptions, function(err, metadata) {
+      callback(err, err ? null : self, metadata);
+    });
   }
 
-  this.bigtable.request(
-    {
-      client: 'BigtableInstanceAdminClient',
-      method: 'deleteInstance',
-      reqOpts: {
-        name: this.id,
+  /**
+   * Get App Profile objects for this instance.
+   *
+   * @param {object} [gaxOptions] Request configuration options, outlined here:
+   *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
+   * @param {function} callback The callback function.
+   * @param {?error} callback.error An error returned while making this request.
+   * @param {AppProfile[]} callback.appProfiles List of all AppProfiles.
+   * @param {object} callback.apiResponse The full API response.
+   *
+   * @example
+   * const Bigtable = require('@google-cloud/bigtable');
+   * const bigtable = new Bigtable();
+   * const instance = bigtable.instance('my-instance');
+   *
+   * instance.getAppProfiles(function(err, appProfiles) {
+   *   if (!err) {
+   *     // `appProfiles` is an array of AppProfile objects.
+   *   }
+   * });
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * instance.getAppProfiles().then(function(data) {
+   *   const appProfiles = data[0];
+   * });
+   */
+  getAppProfiles(gaxOptions, callback) {
+    const self = this;
+
+    if (is.function(gaxOptions)) {
+      callback = gaxOptions;
+      gaxOptions = {};
+    }
+
+    const reqOpts = {
+      parent: this.id,
+    };
+
+    this.bigtable.request(
+      {
+        client: 'BigtableInstanceAdminClient',
+        method: 'listAppProfiles',
+        reqOpts,
+        gaxOpts: gaxOptions,
       },
-      gaxOpts: gaxOptions,
-    },
-    callback
-  );
-};
+      function(err, resp) {
+        if (err) {
+          callback(err);
+          return;
+        }
 
-/**
- * Check if an instance exists.
- *
- * @param {object} [gaxOptions] Request configuration options, outlined
- *     here: https://googleapis.github.io/gax-nodejs/CallSettings.html.
- * @param {function} callback The callback function.
- * @param {?error} callback.err An error returned while making this
- *     request.
- * @param {boolean} callback.exists Whether the instance exists or not.
- *
- * @example
- * const Bigtable = require('@google-cloud/bigtable');
- * const bigtable = new Bigtable();
- * const instance = bigtable.instance('my-instance');
- *
- * instance.exists(function(err, exists) {});
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * instance.exists().then(function(data) {
- *   var exists = data[0];
- * });
- */
-Instance.prototype.exists = function(gaxOptions, callback) {
-  if (is.fn(gaxOptions)) {
-    callback = gaxOptions;
-    gaxOptions = {};
-  }
-
-  this.getMetadata(gaxOptions, function(err) {
-    if (err) {
-      if (err.code === 5) {
-        callback(null, false);
-        return;
-      }
-
-      callback(err);
-      return;
-    }
-
-    callback(null, true);
-  });
-};
-
-/**
- * Get an instance if it exists.
- *
- * @param {object} [gaxOptions] Request configuration options, outlined here:
- *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
- * @param {function} callback The callback function.
- * @param {?error} callback.error An error returned while making this request.
- * @param {Instance} callback.instance The Instance object.
- * @param {object} callback.apiResponse The resource as it exists in the API.
- *
- * @example
- * const Bigtable = require('@google-cloud/bigtable');
- * const bigtable = new Bigtable();
- * const instance = bigtable.instance('my-instance');
- *
- * instance.get(function(err, instance, apiResponse) {
- *   // The `instance` data has been populated.
- * });
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * instance.get().then(function(data) {
- *   var instance = data[0];
- *   var apiResponse = data[1];
- * });
- */
-Instance.prototype.get = function(gaxOptions, callback) {
-  const self = this;
-
-  if (is.fn(gaxOptions)) {
-    callback = gaxOptions;
-    gaxOptions = {};
-  }
-
-  this.getMetadata(gaxOptions, function(err, metadata) {
-    callback(err, err ? null : self, metadata);
-  });
-};
-
-/**
- * Get App Profile objects for this instance.
- *
- * @param {object} [gaxOptions] Request configuration options, outlined here:
- *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
- * @param {function} callback The callback function.
- * @param {?error} callback.error An error returned while making this request.
- * @param {AppProfile[]} callback.appProfiles List of all AppProfiles.
- * @param {object} callback.apiResponse The full API response.
- *
- * @example
- * const Bigtable = require('@google-cloud/bigtable');
- * const bigtable = new Bigtable();
- * const instance = bigtable.instance('my-instance');
- *
- * instance.getAppProfiles(function(err, appProfiles) {
- *   if (!err) {
- *     // `appProfiles` is an array of AppProfile objects.
- *   }
- * });
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * instance.getAppProfiles().then(function(data) {
- *   const appProfiles = data[0];
- * });
- */
-Instance.prototype.getAppProfiles = function(gaxOptions, callback) {
-  const self = this;
-
-  if (is.function(gaxOptions)) {
-    callback = gaxOptions;
-    gaxOptions = {};
-  }
-
-  const reqOpts = {
-    parent: this.id,
-  };
-
-  this.bigtable.request(
-    {
-      client: 'BigtableInstanceAdminClient',
-      method: 'listAppProfiles',
-      reqOpts,
-      gaxOpts: gaxOptions,
-    },
-    function(err, resp) {
-      if (err) {
-        callback(err);
-        return;
-      }
-
-      const appProfiles = resp.map(function(appProfileObj) {
-        const appProfile = self.appProfile(appProfileObj.name);
-        appProfile.metadata = appProfileObj;
-        return appProfile;
-      });
-
-      callback(null, appProfiles, resp);
-    }
-  );
-};
-
-/**
- * Get Cluster objects for all of your clusters.
- *
- * @param {object} [gaxOptions] Request configuration options, outlined here:
- *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
- * @param {function} callback The callback function.
- * @param {?error} callback.error An error returned while making this request.
- * @param {Cluster[]} callback.clusters List of all
- *     Clusters.
- * @param {object} callback.apiResponse The full API response.
- *
- * @example
- * const Bigtable = require('@google-cloud/bigtable');
- * const bigtable = new Bigtable();
- * const instance = bigtable.instance('my-instance');
- *
- * instance.getClusters(function(err, clusters) {
- *   if (!err) {
- *     // `clusters` is an array of Cluster objects.
- *   }
- * });
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * instance.getClusters().then(function(data) {
- *   const clusters = data[0];
- * });
- */
-Instance.prototype.getClusters = function(gaxOptions, callback) {
-  const self = this;
-
-  if (is.function(gaxOptions)) {
-    callback = gaxOptions;
-    gaxOptions = {};
-  }
-
-  const reqOpts = {
-    parent: this.id,
-  };
-
-  this.bigtable.request(
-    {
-      client: 'BigtableInstanceAdminClient',
-      method: 'listClusters',
-      reqOpts,
-      gaxOpts: gaxOptions,
-    },
-    function(err, resp) {
-      if (err) {
-        callback(err);
-        return;
-      }
-
-      const clusters = resp.clusters.map(function(clusterObj) {
-        const cluster = self.cluster(clusterObj.name);
-        cluster.metadata = clusterObj;
-        return cluster;
-      });
-
-      callback(null, clusters, resp);
-    }
-  );
-};
-
-/**
- * Get the instance metadata.
- *
- * @param {object} [gaxOptions] Request configuration options, outlined here:
- *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
- * @param {function} callback The callback function.
- * @param {?error} callback.err An error returned while making this
- *     request.
- * @param {object} callback.metadata The metadata.
- *
- * @example
- * const Bigtable = require('@google-cloud/bigtable');
- * const bigtable = new Bigtable();
- * const instance = bigtable.instance('my-instance');
- *
- * instance.getMetadata(function(err, metadata) {});
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * instance.getMetadata().then(function(data) {
- *   var metadata = data[0];
- *   var apiResponse = data[1];
- * });
- */
-Instance.prototype.getMetadata = function(gaxOptions, callback) {
-  const self = this;
-
-  if (is.fn(gaxOptions)) {
-    callback = gaxOptions;
-    gaxOptions = {};
-  }
-
-  this.bigtable.request(
-    {
-      client: 'BigtableInstanceAdminClient',
-      method: 'getInstance',
-      reqOpts: {
-        name: this.id,
-      },
-      gaxOpts: gaxOptions,
-    },
-    function(...args) {
-      if (args[1]) {
-        self.metadata = args[1];
-      }
-
-      callback(...args);
-    }
-  );
-};
-
-/**
- * Get Table objects for all the tables in your Compute instance.
- *
- * @param {object} [options] Query object.
- * @param {boolean} [options.autoPaginate=true] Have pagination handled
- *     automatically.
- * @param {object} [options.gaxOptions] Request configuration options, outlined
- *     here: https://googleapis.github.io/gax-nodejs/global.html#CallOptions.
- * @param {number} [options.maxApiCalls] Maximum number of API calls to make.
- * @param {number} [options.maxResults] Maximum number of items to return.
- * @param {string} [options.pageToken] A previously-returned page token
- *     representing part of a larger set of results to view.
- * @param {string} [options.view] View over the table's fields. Possible options
- *     are 'name', 'schema' or 'full'. Default: 'name'.
- * @param {function} callback The callback function.
- * @param {?error} callback.err An error returned while making this request.
- * @param {Table[]} callback.tables List of all Tables.
- * @param {object} callback.apiResponse The full API response.
- *
- * @example
- * const Bigtable = require('@google-cloud/bigtable');
- * const bigtable = new Bigtable();
- * const instance = bigtable.instance('my-instance');
- *
- * instance.getTables(function(err, tables) {
- *   if (!err) {
- *     // `tables` is an array of Table objects.
- *   }
- * });
- *
- * //-
- * // To control how many API requests are made and page through the results
- * // manually, set `autoPaginate` to false.
- * //-
- * const callback = function(err, tables, nextQuery, apiResponse) {
- *   if (nextQuery) {
- *     // More results exist.
- *     instance.getTables(nextQuery, calback);
- *   }
- * };
- *
- * instance.getTables({
- *   autoPaginate: false
- * }, callback);
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * instance.getTables().then(function(data) {
- *   const tables = data[0];
- * });
- */
-Instance.prototype.getTables = function(options, callback) {
-  const self = this;
-
-  if (is.function(options)) {
-    callback = options;
-    options = {};
-  }
-
-  const reqOpts = extend({}, options, {
-    parent: this.id,
-    view: Table.VIEWS[options.view || 'unspecified'],
-  });
-
-  delete reqOpts.gaxOptions;
-
-  this.bigtable.request(
-    {
-      client: 'BigtableTableAdminClient',
-      method: 'listTables',
-      reqOpts,
-      gaxOpts: options.gaxOptions,
-    },
-    function(...args) {
-      if (args[1]) {
-        args[1] = args[1].map(function(tableObj) {
-          const name = tableObj.name.split('/').pop();
-          const table = self.table(name);
-          table.metadata = tableObj;
-          return table;
+        const appProfiles = resp.map(function(appProfileObj) {
+          const appProfile = self.appProfile(appProfileObj.name);
+          appProfile.metadata = appProfileObj;
+          return appProfile;
         });
-      }
 
-      callback(...args);
+        callback(null, appProfiles, resp);
+      }
+    );
+  }
+
+  /**
+   * Get Cluster objects for all of your clusters.
+   *
+   * @param {object} [gaxOptions] Request configuration options, outlined here:
+   *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
+   * @param {function} callback The callback function.
+   * @param {?error} callback.error An error returned while making this request.
+   * @param {Cluster[]} callback.clusters List of all
+   *     Clusters.
+   * @param {object} callback.apiResponse The full API response.
+   *
+   * @example
+   * const Bigtable = require('@google-cloud/bigtable');
+   * const bigtable = new Bigtable();
+   * const instance = bigtable.instance('my-instance');
+   *
+   * instance.getClusters(function(err, clusters) {
+   *   if (!err) {
+   *     // `clusters` is an array of Cluster objects.
+   *   }
+   * });
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * instance.getClusters().then(function(data) {
+   *   const clusters = data[0];
+   * });
+   */
+  getClusters(gaxOptions, callback) {
+    const self = this;
+
+    if (is.function(gaxOptions)) {
+      callback = gaxOptions;
+      gaxOptions = {};
     }
-  );
-};
+
+    const reqOpts = {
+      parent: this.id,
+    };
+
+    this.bigtable.request(
+      {
+        client: 'BigtableInstanceAdminClient',
+        method: 'listClusters',
+        reqOpts,
+        gaxOpts: gaxOptions,
+      },
+      function(err, resp) {
+        if (err) {
+          callback(err);
+          return;
+        }
+
+        const clusters = resp.clusters.map(function(clusterObj) {
+          const cluster = self.cluster(clusterObj.name);
+          cluster.metadata = clusterObj;
+          return cluster;
+        });
+
+        callback(null, clusters, resp);
+      }
+    );
+  }
+
+  /**
+   * Get the instance metadata.
+   *
+   * @param {object} [gaxOptions] Request configuration options, outlined here:
+   *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
+   * @param {function} callback The callback function.
+   * @param {?error} callback.err An error returned while making this
+   *     request.
+   * @param {object} callback.metadata The metadata.
+   *
+   * @example
+   * const Bigtable = require('@google-cloud/bigtable');
+   * const bigtable = new Bigtable();
+   * const instance = bigtable.instance('my-instance');
+   *
+   * instance.getMetadata(function(err, metadata) {});
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * instance.getMetadata().then(function(data) {
+   *   var metadata = data[0];
+   *   var apiResponse = data[1];
+   * });
+   */
+  getMetadata(gaxOptions, callback) {
+    const self = this;
+
+    if (is.fn(gaxOptions)) {
+      callback = gaxOptions;
+      gaxOptions = {};
+    }
+
+    this.bigtable.request(
+      {
+        client: 'BigtableInstanceAdminClient',
+        method: 'getInstance',
+        reqOpts: {
+          name: this.id,
+        },
+        gaxOpts: gaxOptions,
+      },
+      function(...args) {
+        if (args[1]) {
+          self.metadata = args[1];
+        }
+
+        callback(...args);
+      }
+    );
+  }
+
+  /**
+   * Get Table objects for all the tables in your Compute instance.
+   *
+   * @param {object} [options] Query object.
+   * @param {boolean} [options.autoPaginate=true] Have pagination handled
+   *     automatically.
+   * @param {object} [options.gaxOptions] Request configuration options, outlined
+   *     here: https://googleapis.github.io/gax-nodejs/global.html#CallOptions.
+   * @param {number} [options.maxApiCalls] Maximum number of API calls to make.
+   * @param {number} [options.maxResults] Maximum number of items to return.
+   * @param {string} [options.pageToken] A previously-returned page token
+   *     representing part of a larger set of results to view.
+   * @param {string} [options.view] View over the table's fields. Possible options
+   *     are 'name', 'schema' or 'full'. Default: 'name'.
+   * @param {function} callback The callback function.
+   * @param {?error} callback.err An error returned while making this request.
+   * @param {Table[]} callback.tables List of all Tables.
+   * @param {object} callback.apiResponse The full API response.
+   *
+   * @example
+   * const Bigtable = require('@google-cloud/bigtable');
+   * const bigtable = new Bigtable();
+   * const instance = bigtable.instance('my-instance');
+   *
+   * instance.getTables(function(err, tables) {
+   *   if (!err) {
+   *     // `tables` is an array of Table objects.
+   *   }
+   * });
+   *
+   * //-
+   * // To control how many API requests are made and page through the results
+   * // manually, set `autoPaginate` to false.
+   * //-
+   * const callback = function(err, tables, nextQuery, apiResponse) {
+   *   if (nextQuery) {
+   *     // More results exist.
+   *     instance.getTables(nextQuery, calback);
+   *   }
+   * };
+   *
+   * instance.getTables({
+   *   autoPaginate: false
+   * }, callback);
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * instance.getTables().then(function(data) {
+   *   const tables = data[0];
+   * });
+   */
+  getTables(options, callback) {
+    const self = this;
+
+    if (is.function(options)) {
+      callback = options;
+      options = {};
+    }
+
+    const reqOpts = extend({}, options, {
+      parent: this.id,
+      view: Table.VIEWS[options.view || 'unspecified'],
+    });
+
+    delete reqOpts.gaxOptions;
+
+    this.bigtable.request(
+      {
+        client: 'BigtableTableAdminClient',
+        method: 'listTables',
+        reqOpts,
+        gaxOpts: options.gaxOptions,
+      },
+      function(...args) {
+        if (args[1]) {
+          args[1] = args[1].map(function(tableObj) {
+            const name = tableObj.name.split('/').pop();
+            const table = self.table(name);
+            table.metadata = tableObj;
+            return table;
+          });
+        }
+
+        callback(...args);
+      }
+    );
+  }
+
+  /**
+   * Set the instance metadata.
+   *
+   * @param {object} metadata Metadata object.
+   * @param {string} metadata.displayName The descriptive name for this
+   *     instance as it appears in UIs. It can be changed at any time, but
+   *     should be kept globally unique to avoid confusion.
+   * @param {object} [gaxOptions] Request configuration options, outlined here:
+   *     https://googleapis.github.io/gax-nodejs/global.html#CallOptions.
+   * @param {function} callback The callback function.
+   * @param {?error} callback.err An error returned while making this
+   *     request.
+   * @param {object} callback.apiResponse The full API response.
+   *
+   * @example
+   * const Bigtable = require('@google-cloud/bigtable');
+   * const bigtable = new Bigtable();
+   * const instance = bigtable.instance('my-instance');
+   *
+   * var metadata = {
+   *   displayName: 'updated-name'
+   * };
+   *
+   * instance.setMetadata(metadata, function(err, apiResponse) {});
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * instance.setMetadata(metadata).then(function(data) {
+   *   var apiResponse = data[0];
+   * });
+   */
+  setMetadata(metadata, gaxOptions, callback) {
+    const self = this;
+
+    if (is.fn(gaxOptions)) {
+      callback = gaxOptions;
+      gaxOptions = {};
+    }
+
+    this.bigtable.request(
+      {
+        client: 'BigtableInstanceAdminClient',
+        method: 'updateInstance',
+        reqOpts: extend({name: this.id}, metadata),
+        gaxOpts: gaxOptions,
+      },
+      function(...args) {
+        if (args[1]) {
+          self.metadata = args[1];
+        }
+
+        callback(...args);
+      }
+    );
+  }
+
+  /**
+   * Get a reference to a Bigtable table.
+   *
+   * @param {string} name The name of the table.
+   * @returns {Table}
+   *
+   * @example
+   * const Bigtable = require('@google-cloud/bigtable');
+   * const bigtable = new Bigtable();
+   * const instance = bigtable.instance('my-instance');
+   * const table = instance.table('presidents');
+   */
+  table(name) {
+    return new Table(this, name);
+  }
+}
 
 /**
  * Get {@link Table} objects for all the tables in your Compute
@@ -928,79 +1003,6 @@ Instance.prototype.getTables = function(options, callback) {
  *   });
  */
 Instance.prototype.getTablesStream = common.paginator.streamify('getTables');
-
-/**
- * Set the instance metadata.
- *
- * @param {object} metadata Metadata object.
- * @param {string} metadata.displayName The descriptive name for this
- *     instance as it appears in UIs. It can be changed at any time, but
- *     should be kept globally unique to avoid confusion.
- * @param {object} [gaxOptions] Request configuration options, outlined here:
- *     https://googleapis.github.io/gax-nodejs/global.html#CallOptions.
- * @param {function} callback The callback function.
- * @param {?error} callback.err An error returned while making this
- *     request.
- * @param {object} callback.apiResponse The full API response.
- *
- * @example
- * const Bigtable = require('@google-cloud/bigtable');
- * const bigtable = new Bigtable();
- * const instance = bigtable.instance('my-instance');
- *
- * var metadata = {
- *   displayName: 'updated-name'
- * };
- *
- * instance.setMetadata(metadata, function(err, apiResponse) {});
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * instance.setMetadata(metadata).then(function(data) {
- *   var apiResponse = data[0];
- * });
- */
-Instance.prototype.setMetadata = function(metadata, gaxOptions, callback) {
-  const self = this;
-
-  if (is.fn(gaxOptions)) {
-    callback = gaxOptions;
-    gaxOptions = {};
-  }
-
-  this.bigtable.request(
-    {
-      client: 'BigtableInstanceAdminClient',
-      method: 'updateInstance',
-      reqOpts: extend({name: this.id}, metadata),
-      gaxOpts: gaxOptions,
-    },
-    function(...args) {
-      if (args[1]) {
-        self.metadata = args[1];
-      }
-
-      callback(...args);
-    }
-  );
-};
-
-/**
- * Get a reference to a Bigtable table.
- *
- * @param {string} name The name of the table.
- * @returns {Table}
- *
- * @example
- * const Bigtable = require('@google-cloud/bigtable');
- * const bigtable = new Bigtable();
- * const instance = bigtable.instance('my-instance');
- * const table = instance.table('presidents');
- */
-Instance.prototype.table = function(name) {
-  return new Table(this, name);
-};
 
 /*! Developer Documentation
  *

--- a/src/instance.js
+++ b/src/instance.js
@@ -43,7 +43,7 @@ class Instance {
     let id = name;
 
     if (id.indexOf('/') === -1) {
-      id = bigtable.projectName + '/instances/' + name;
+      id = `${bigtable.projectName}/instances/${name}`;
     }
 
     this.id = id;

--- a/src/instance.js
+++ b/src/instance.js
@@ -42,7 +42,7 @@ class Instance {
 
     let id = name;
 
-    if (id.indexOf('/') === -1) {
+    if (!id.includes('/')) {
       id = `${bigtable.projectName}/instances/${name}`;
     }
 

--- a/src/mutation.js
+++ b/src/mutation.js
@@ -178,13 +178,13 @@ Mutation.encodeSetCell = function(data) {
       }
 
       var setCell = {
-        familyName: familyName,
+        familyName,
         columnQualifier: Mutation.convertToBytes(cellName),
         timestampMicros: timestamp,
         value: Mutation.convertToBytes(cell.value),
       };
 
-      mutations.push({setCell: setCell});
+      mutations.push({setCell});
     });
   });
 
@@ -281,7 +281,7 @@ Mutation.encodeDelete = function(data) {
       deleteFromColumn: {
         familyName: column.family,
         columnQualifier: Mutation.convertToBytes(column.qualifier),
-        timeRange: timeRange,
+        timeRange,
       },
     };
   });

--- a/src/mutation.js
+++ b/src/mutation.js
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-var arrify = require('arrify');
-var Buffer = require('safe-buffer').Buffer;
-var Long = require('long');
-var is = require('is');
+const arrify = require('arrify');
+const Buffer = require('safe-buffer').Buffer;
+const Long = require('long');
+const is = require('is');
 
 /**
  * Formats table mutations to be in the expected proto format.
@@ -48,7 +48,7 @@ function Mutation(mutation) {
  * INSERT => setCell
  * DELETE => deleteFrom*
  */
-var methods = (Mutation.methods = {
+const methods = (Mutation.methods = {
   INSERT: 'insert',
   DELETE: 'delete',
 });
@@ -64,9 +64,9 @@ var methods = (Mutation.methods = {
  * @returns {string|number|buffer}
  */
 Mutation.convertFromBytes = function(bytes, options) {
-  var buf = bytes instanceof Buffer ? bytes : Buffer.from(bytes, 'base64');
+  const buf = bytes instanceof Buffer ? bytes : Buffer.from(bytes, 'base64');
   if (options && options.isPossibleNumber && buf.length === 8) {
-    var num = Long.fromBytes(buf).toNumber();
+    const num = Long.fromBytes(buf).toNumber();
 
     if (Number.MIN_SAFE_INTEGER < num && num < Number.MAX_SAFE_INTEGER) {
       return num;
@@ -110,7 +110,7 @@ Mutation.convertToBytes = function(data) {
  * @returns {object}
  */
 Mutation.createTimeRange = function(start, end) {
-  var range = {};
+  const range = {};
 
   if (is.date(start)) {
     range.startTimestampMicros = start.getTime() * 1000;
@@ -155,13 +155,13 @@ Mutation.createTimeRange = function(start, end) {
  * // ]
  */
 Mutation.encodeSetCell = function(data) {
-  var mutations = [];
+  const mutations = [];
 
   Object.keys(data).forEach(function(familyName) {
-    var family = data[familyName];
+    const family = data[familyName];
 
     Object.keys(family).forEach(function(cellName) {
-      var cell = family[cellName];
+      let cell = family[cellName];
 
       if (!is.object(cell) || cell instanceof Buffer) {
         cell = {
@@ -169,13 +169,13 @@ Mutation.encodeSetCell = function(data) {
         };
       }
 
-      var timestamp = cell.timestamp || new Date();
+      let timestamp = cell.timestamp || new Date();
 
       if (is.date(timestamp)) {
         timestamp = timestamp.getTime() * 1000;
       }
 
-      var setCell = {
+      const setCell = {
         familyName,
         columnQualifier: Mutation.convertToBytes(cellName),
         timestampMicros: timestamp,
@@ -256,7 +256,7 @@ Mutation.encodeDelete = function(data) {
       };
     }
 
-    var column = Mutation.parseColumnName(mutation.column);
+    const column = Mutation.parseColumnName(mutation.column);
 
     if (!column.qualifier) {
       return {
@@ -266,7 +266,7 @@ Mutation.encodeDelete = function(data) {
       };
     }
 
-    var timeRange;
+    let timeRange;
 
     if (mutation.time) {
       timeRange = Mutation.createTimeRange(
@@ -313,7 +313,7 @@ Mutation.parse = function(mutation) {
  * // }
  */
 Mutation.parseColumnName = function(column) {
-  var parts = column.split(':');
+  const parts = column.split(':');
 
   return {
     family: parts[0],
@@ -327,7 +327,7 @@ Mutation.parseColumnName = function(column) {
  * @returns {object}
  */
 Mutation.prototype.toProto = function() {
-  var mutation = {};
+  const mutation = {};
 
   if (this.key) {
     mutation.rowKey = Mutation.convertToBytes(this.key);

--- a/src/mutation.js
+++ b/src/mutation.js
@@ -36,10 +36,301 @@ const is = require('is');
  *   }
  * });
  */
-function Mutation(mutation) {
-  this.key = mutation.key;
-  this.method = mutation.method;
-  this.data = mutation.data;
+class Mutation {
+  constructor(mutation) {
+    this.key = mutation.key;
+    this.method = mutation.method;
+    this.data = mutation.data;
+  }
+
+  /**
+   * Parses "bytes" returned from proto service.
+   *
+   * @param {string} bytes - Base64 encoded string.
+   * @param {object} [options] Options to device return types
+   * @param {boolean} [options.isPossibleNumber] Check if byte is number
+   * @param {object} [options.userOptions]
+   * @param {boolean} [options.userOptions.decode] Check if decode is required
+   * @returns {string|number|buffer}
+   */
+  static convertFromBytes(bytes, options) {
+    const buf = bytes instanceof Buffer ? bytes : Buffer.from(bytes, 'base64');
+    if (options && options.isPossibleNumber && buf.length === 8) {
+      const num = Long.fromBytes(buf).toNumber();
+
+      if (Number.MIN_SAFE_INTEGER < num && num < Number.MAX_SAFE_INTEGER) {
+        return num;
+      }
+    }
+
+    if (options && options.userOptions && options.userOptions.decode === false) {
+      return buf;
+    }
+
+    return buf.toString();
+  }
+
+  /**
+   * Converts data into a buffer for proto service.
+   *
+   * @param {string} data - The data to be sent.
+   * @returns {buffer}
+   */
+  static convertToBytes(data) {
+    if (data instanceof Buffer) {
+      return data;
+    }
+
+    if (is.number(data)) {
+      return Buffer.from(Long.fromNumber(data).toBytesBE());
+    }
+
+    try {
+      return Buffer.from(data);
+    } catch (e) {
+      return data;
+    }
+  }
+
+  /**
+   * Takes date objects and creates a time range.
+   *
+   * @param {date} start - The start date.
+   * @param {date} end - The end date.
+   * @returns {object}
+   */
+  static createTimeRange(start, end) {
+    const range = {};
+
+    if (is.date(start)) {
+      range.startTimestampMicros = start.getTime() * 1000;
+    }
+
+    if (is.date(end)) {
+      range.endTimestampMicros = end.getTime() * 1000;
+    }
+
+    return range;
+  }
+
+  /**
+   * Formats an `insert` mutation to what the proto service expects.
+   *
+   * @param {object} data - The entity data.
+   * @returns {object[]}
+   *
+   * @example
+   * Mutation.encodeSetCell({
+   *   follows: {
+   *     gwashington: 1,
+   *     alincoln: 1
+   *   }
+   * });
+   * // [
+   * //   {
+   * //     setCell: {
+   * //       familyName: 'follows',
+   * //       columnQualifier: 'gwashington', // as buffer
+   * //       timestampMicros: -1, // -1 means to use the server time
+   * //       value: 1 // as buffer
+   * //     }
+   * //   }, {
+   * //     setCell: {
+   * //       familyName: 'follows',
+   * //       columnQualifier: 'alincoln', // as buffer
+   * //       timestampMicros: new Date(), // uses the client's current time
+   * //       value: 1 // as buffer
+   * //     }
+   * //   }
+   * // ]
+   */
+  static encodeSetCell(data) {
+    const mutations = [];
+
+    Object.keys(data).forEach(function(familyName) {
+      const family = data[familyName];
+
+      Object.keys(family).forEach(function(cellName) {
+        let cell = family[cellName];
+
+        if (!is.object(cell) || cell instanceof Buffer) {
+          cell = {
+            value: cell,
+          };
+        }
+
+        let timestamp = cell.timestamp || new Date();
+
+        if (is.date(timestamp)) {
+          timestamp = timestamp.getTime() * 1000;
+        }
+
+        const setCell = {
+          familyName,
+          columnQualifier: Mutation.convertToBytes(cellName),
+          timestampMicros: timestamp,
+          value: Mutation.convertToBytes(cell.value),
+        };
+
+        mutations.push({setCell});
+      });
+    });
+
+    return mutations;
+  }
+
+  /**
+   * Formats a `delete` mutation to what the proto service expects. Depending
+   * on what data is supplied to this method, it will return an object that can
+   * will do one of the following:
+   *
+   * * Delete specific cells from a column.
+   * * Delete all cells contained with a specific family.
+   * * Delete all cells from an entire rows.
+   *
+   * @param {object} data - The entry data.
+   * @returns {object}
+   *
+   * @example
+   * Mutation.encodeDelete([
+   *   'follows:gwashington'
+   * ]);
+   * // {
+   * //   deleteFromColumn: {
+   * //     familyName: 'follows',
+   * //     columnQualifier: 'gwashington', // as buffer
+   * //     timeRange: null // optional
+   * //   }
+   * // }
+   *
+   * Mutation.encodeDelete([
+   *   'follows'
+   * ]);
+   * // {
+   * //   deleteFromFamily: {
+   * //     familyName: 'follows'
+   * //   }
+   * // }
+   *
+   * Mutation.encodeDelete();
+   * // {
+   * //   deleteFromRow: {}
+   * // }
+   *
+   * //-
+   * // It's also possible to specify a time range when deleting specific columns.
+   * //-
+   * Mutation.encodeDelete([
+   *   {
+   *     column: 'follows:gwashington',
+   *     time: {
+   *       start: new Date('March 21, 2000'),
+   *       end: new Date('March 21, 2001')
+   *     }
+   *   }
+   * ]);
+   */
+  static encodeDelete(data) {
+    if (!data) {
+      return [
+        {
+          deleteFromRow: {},
+        },
+      ];
+    }
+
+    return arrify(data).map(function(mutation) {
+      if (is.string(mutation)) {
+        mutation = {
+          column: mutation,
+        };
+      }
+
+      const column = Mutation.parseColumnName(mutation.column);
+
+      if (!column.qualifier) {
+        return {
+          deleteFromFamily: {
+            familyName: column.family,
+          },
+        };
+      }
+
+      let timeRange;
+
+      if (mutation.time) {
+        timeRange = Mutation.createTimeRange(
+          mutation.time.start,
+          mutation.time.end
+        );
+      }
+
+      return {
+        deleteFromColumn: {
+          familyName: column.family,
+          columnQualifier: Mutation.convertToBytes(column.qualifier),
+          timeRange,
+        },
+      };
+    });
+  }
+
+  /**
+   * Creates a new Mutation object and returns the proto JSON form.
+   *
+   * @param {object} mutation - The entity data.
+   * @returns {object}
+   */
+  static parse(mutation) {
+    if (!(mutation instanceof Mutation)) {
+      mutation = new Mutation(mutation);
+    }
+
+    return mutation.toProto();
+  }
+
+  /**
+   * Parses a column name into an object.
+   *
+   * @param {string} column - The column name.
+   * @returns {object}
+   *
+   * @example
+   * Mutation.parseColumnName('follows:gwashington');
+   * // {
+   * //  family: 'follows',
+   * //  qualifier: 'gwashington'
+   * // }
+   */
+  static parseColumnName(column) {
+    const parts = column.split(':');
+
+    return {
+      family: parts[0],
+      qualifier: parts[1],
+    };
+  }
+
+  /**
+   * Converts the mutation object into proto friendly JSON.
+   *
+   * @returns {object}
+   */
+  toProto() {
+    const mutation = {};
+
+    if (this.key) {
+      mutation.rowKey = Mutation.convertToBytes(this.key);
+    }
+
+    if (this.method === methods.INSERT) {
+      mutation.mutations = Mutation.encodeSetCell(this.data);
+    } else if (this.method === methods.DELETE) {
+      mutation.mutations = Mutation.encodeDelete(this.data);
+    }
+
+    return mutation;
+  }
 }
 
 /**
@@ -52,294 +343,5 @@ const methods = (Mutation.methods = {
   INSERT: 'insert',
   DELETE: 'delete',
 });
-
-/**
- * Parses "bytes" returned from proto service.
- *
- * @param {string} bytes - Base64 encoded string.
- * @param {object} [options] Options to device return types
- * @param {boolean} [options.isPossibleNumber] Check if byte is number
- * @param {object} [options.userOptions]
- * @param {boolean} [options.userOptions.decode] Check if decode is required
- * @returns {string|number|buffer}
- */
-Mutation.convertFromBytes = function(bytes, options) {
-  const buf = bytes instanceof Buffer ? bytes : Buffer.from(bytes, 'base64');
-  if (options && options.isPossibleNumber && buf.length === 8) {
-    const num = Long.fromBytes(buf).toNumber();
-
-    if (Number.MIN_SAFE_INTEGER < num && num < Number.MAX_SAFE_INTEGER) {
-      return num;
-    }
-  }
-
-  if (options && options.userOptions && options.userOptions.decode === false) {
-    return buf;
-  }
-
-  return buf.toString();
-};
-
-/**
- * Converts data into a buffer for proto service.
- *
- * @param {string} data - The data to be sent.
- * @returns {buffer}
- */
-Mutation.convertToBytes = function(data) {
-  if (data instanceof Buffer) {
-    return data;
-  }
-
-  if (is.number(data)) {
-    return Buffer.from(Long.fromNumber(data).toBytesBE());
-  }
-
-  try {
-    return Buffer.from(data);
-  } catch (e) {
-    return data;
-  }
-};
-
-/**
- * Takes date objects and creates a time range.
- *
- * @param {date} start - The start date.
- * @param {date} end - The end date.
- * @returns {object}
- */
-Mutation.createTimeRange = function(start, end) {
-  const range = {};
-
-  if (is.date(start)) {
-    range.startTimestampMicros = start.getTime() * 1000;
-  }
-
-  if (is.date(end)) {
-    range.endTimestampMicros = end.getTime() * 1000;
-  }
-
-  return range;
-};
-
-/**
- * Formats an `insert` mutation to what the proto service expects.
- *
- * @param {object} data - The entity data.
- * @returns {object[]}
- *
- * @example
- * Mutation.encodeSetCell({
- *   follows: {
- *     gwashington: 1,
- *     alincoln: 1
- *   }
- * });
- * // [
- * //   {
- * //     setCell: {
- * //       familyName: 'follows',
- * //       columnQualifier: 'gwashington', // as buffer
- * //       timestampMicros: -1, // -1 means to use the server time
- * //       value: 1 // as buffer
- * //     }
- * //   }, {
- * //     setCell: {
- * //       familyName: 'follows',
- * //       columnQualifier: 'alincoln', // as buffer
- * //       timestampMicros: new Date(), // uses the client's current time
- * //       value: 1 // as buffer
- * //     }
- * //   }
- * // ]
- */
-Mutation.encodeSetCell = function(data) {
-  const mutations = [];
-
-  Object.keys(data).forEach(function(familyName) {
-    const family = data[familyName];
-
-    Object.keys(family).forEach(function(cellName) {
-      let cell = family[cellName];
-
-      if (!is.object(cell) || cell instanceof Buffer) {
-        cell = {
-          value: cell,
-        };
-      }
-
-      let timestamp = cell.timestamp || new Date();
-
-      if (is.date(timestamp)) {
-        timestamp = timestamp.getTime() * 1000;
-      }
-
-      const setCell = {
-        familyName,
-        columnQualifier: Mutation.convertToBytes(cellName),
-        timestampMicros: timestamp,
-        value: Mutation.convertToBytes(cell.value),
-      };
-
-      mutations.push({setCell});
-    });
-  });
-
-  return mutations;
-};
-
-/**
- * Formats a `delete` mutation to what the proto service expects. Depending
- * on what data is supplied to this method, it will return an object that can
- * will do one of the following:
- *
- * * Delete specific cells from a column.
- * * Delete all cells contained with a specific family.
- * * Delete all cells from an entire rows.
- *
- * @param {object} data - The entry data.
- * @returns {object}
- *
- * @example
- * Mutation.encodeDelete([
- *   'follows:gwashington'
- * ]);
- * // {
- * //   deleteFromColumn: {
- * //     familyName: 'follows',
- * //     columnQualifier: 'gwashington', // as buffer
- * //     timeRange: null // optional
- * //   }
- * // }
- *
- * Mutation.encodeDelete([
- *   'follows'
- * ]);
- * // {
- * //   deleteFromFamily: {
- * //     familyName: 'follows'
- * //   }
- * // }
- *
- * Mutation.encodeDelete();
- * // {
- * //   deleteFromRow: {}
- * // }
- *
- * //-
- * // It's also possible to specify a time range when deleting specific columns.
- * //-
- * Mutation.encodeDelete([
- *   {
- *     column: 'follows:gwashington',
- *     time: {
- *       start: new Date('March 21, 2000'),
- *       end: new Date('March 21, 2001')
- *     }
- *   }
- * ]);
- */
-Mutation.encodeDelete = function(data) {
-  if (!data) {
-    return [
-      {
-        deleteFromRow: {},
-      },
-    ];
-  }
-
-  return arrify(data).map(function(mutation) {
-    if (is.string(mutation)) {
-      mutation = {
-        column: mutation,
-      };
-    }
-
-    const column = Mutation.parseColumnName(mutation.column);
-
-    if (!column.qualifier) {
-      return {
-        deleteFromFamily: {
-          familyName: column.family,
-        },
-      };
-    }
-
-    let timeRange;
-
-    if (mutation.time) {
-      timeRange = Mutation.createTimeRange(
-        mutation.time.start,
-        mutation.time.end
-      );
-    }
-
-    return {
-      deleteFromColumn: {
-        familyName: column.family,
-        columnQualifier: Mutation.convertToBytes(column.qualifier),
-        timeRange,
-      },
-    };
-  });
-};
-
-/**
- * Creates a new Mutation object and returns the proto JSON form.
- *
- * @param {object} mutation - The entity data.
- * @returns {object}
- */
-Mutation.parse = function(mutation) {
-  if (!(mutation instanceof Mutation)) {
-    mutation = new Mutation(mutation);
-  }
-
-  return mutation.toProto();
-};
-
-/**
- * Parses a column name into an object.
- *
- * @param {string} column - The column name.
- * @returns {object}
- *
- * @example
- * Mutation.parseColumnName('follows:gwashington');
- * // {
- * //  family: 'follows',
- * //  qualifier: 'gwashington'
- * // }
- */
-Mutation.parseColumnName = function(column) {
-  const parts = column.split(':');
-
-  return {
-    family: parts[0],
-    qualifier: parts[1],
-  };
-};
-
-/**
- * Converts the mutation object into proto friendly JSON.
- *
- * @returns {object}
- */
-Mutation.prototype.toProto = function() {
-  const mutation = {};
-
-  if (this.key) {
-    mutation.rowKey = Mutation.convertToBytes(this.key);
-  }
-
-  if (this.method === methods.INSERT) {
-    mutation.mutations = Mutation.encodeSetCell(this.data);
-  } else if (this.method === methods.DELETE) {
-    mutation.mutations = Mutation.encodeDelete(this.data);
-  }
-
-  return mutation;
-};
 
 module.exports = Mutation;

--- a/src/mutation.js
+++ b/src/mutation.js
@@ -63,7 +63,11 @@ class Mutation {
       }
     }
 
-    if (options && options.userOptions && options.userOptions.decode === false) {
+    if (
+      options &&
+      options.userOptions &&
+      options.userOptions.decode === false
+    ) {
       return buf;
     }
 

--- a/src/mutation.js
+++ b/src/mutation.js
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-'use strict';
-
 var arrify = require('arrify');
 var Buffer = require('safe-buffer').Buffer;
 var Long = require('long');

--- a/src/row.js
+++ b/src/row.js
@@ -200,7 +200,7 @@ Row.formatFamilies_ = function(families, options) {
         }
 
         return {
-          value: value,
+          value,
           timestamp: cell.timestampMicros,
           labels: cell.labels,
         };
@@ -363,14 +363,14 @@ Row.prototype.createRules = function(rules, gaxOptions, callback) {
     tableName: this.table.id,
     appProfileId: this.bigtable.appProfileId,
     rowKey: Mutation.convertToBytes(this.id),
-    rules: rules,
+    rules,
   };
 
   this.bigtable.request(
     {
       client: 'BigtableClient',
       method: 'readModifyWriteRow',
-      reqOpts: reqOpts,
+      reqOpts,
       gaxOpts: gaxOptions,
     },
     callback
@@ -602,7 +602,7 @@ Row.prototype.filter = function(filter, config, callback) {
     {
       client: 'BigtableClient',
       method: 'checkAndMutateRow',
-      reqOpts: reqOpts,
+      reqOpts,
       gaxOpts: config.gaxOptions,
     },
     function(err, apiResponse) {
@@ -713,7 +713,7 @@ Row.prototype.get = function(columns, options, callback) {
 
   var getRowsOptions = extend({}, options, {
     keys: [this.id],
-    filter: filter,
+    filter,
   });
 
   this.table.getRows(getRowsOptions, function(err, rows) {
@@ -842,7 +842,7 @@ Row.prototype.increment = function(column, value, gaxOptions, callback) {
   }
 
   var reqOpts = {
-    column: column,
+    column,
     increment: value,
   };
 

--- a/src/row.js
+++ b/src/row.js
@@ -99,7 +99,9 @@ class Row {
       row.data = row.data || {};
 
       if (chunk.rowKey) {
-        row.key = Mutation.convertFromBytes(chunk.rowKey, {userOptions: options});
+        row.key = Mutation.convertFromBytes(chunk.rowKey, {
+          userOptions: options,
+        });
       }
 
       if (chunk.familyName) {

--- a/src/row.js
+++ b/src/row.js
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-'use strict';
-
 var arrify = require('arrify');
 var common = require('@google-cloud/common');
 var createErrorClass = require('create-error-class');

--- a/src/row.js
+++ b/src/row.js
@@ -14,21 +14,21 @@
  * limitations under the License.
  */
 
-var arrify = require('arrify');
-var common = require('@google-cloud/common');
-var createErrorClass = require('create-error-class');
-var dotProp = require('dot-prop');
-var extend = require('extend');
-var flatten = require('lodash.flatten');
-var is = require('is');
+const arrify = require('arrify');
+const common = require('@google-cloud/common');
+const createErrorClass = require('create-error-class');
+const dotProp = require('dot-prop');
+const extend = require('extend');
+const flatten = require('lodash.flatten');
+const is = require('is');
 
-var Filter = require('./filter.js');
-var Mutation = require('./mutation.js');
+const Filter = require('./filter.js');
+const Mutation = require('./mutation.js');
 
 /**
  * @private
  */
-var RowError = createErrorClass('RowError', function(row) {
+const RowError = createErrorClass('RowError', function(row) {
   this.message = 'Unknown row: ' + row + '.';
   this.code = 404;
 });
@@ -85,15 +85,15 @@ function Row(table, key) {
  * // }
  */
 Row.formatChunks_ = function(chunks, options) {
-  var rows = [];
-  var familyName;
-  var qualifierName;
+  const rows = [];
+  let familyName;
+  let qualifierName;
 
   options = options || {};
 
   chunks.reduce(function(row, chunk) {
-    var family;
-    var qualifier;
+    let family;
+    let qualifier;
 
     row.data = row.data || {};
 
@@ -180,18 +180,18 @@ Row.formatChunks_ = function(chunks, options) {
  * // }
  */
 Row.formatFamilies_ = function(families, options) {
-  var data = {};
+  const data = {};
 
   options = options || {};
 
   families.forEach(function(family) {
-    var familyData = (data[family.name] = {});
+    const familyData = (data[family.name] = {});
 
     family.columns.forEach(function(column) {
-      var qualifier = Mutation.convertFromBytes(column.qualifier);
+      const qualifier = Mutation.convertFromBytes(column.qualifier);
 
       familyData[qualifier] = column.cells.map(function(cell) {
-        var value = cell.value;
+        let value = cell.value;
 
         if (options.decode !== false) {
           value = Mutation.convertFromBytes(value, {isPossibleNumber: true});
@@ -250,14 +250,14 @@ Row.formatFamilies_ = function(families, options) {
  * });
  */
 Row.prototype.create = function(options, callback) {
-  var self = this;
+  const self = this;
 
   if (is.function(options)) {
     callback = options;
     options = {};
   }
 
-  var entry = {
+  const entry = {
     key: this.id,
     data: options.entry,
     method: Mutation.methods.INSERT,
@@ -340,8 +340,8 @@ Row.prototype.createRules = function(rules, gaxOptions, callback) {
   }
 
   rules = arrify(rules).map(function(rule) {
-    var column = Mutation.parseColumnName(rule.column);
-    var ruleData = {
+    const column = Mutation.parseColumnName(rule.column);
+    const ruleData = {
       familyName: column.family,
       columnQualifier: Mutation.convertToBytes(column.qualifier),
     };
@@ -357,7 +357,7 @@ Row.prototype.createRules = function(rules, gaxOptions, callback) {
     return ruleData;
   });
 
-  var reqOpts = {
+  const reqOpts = {
     tableName: this.table.id,
     appProfileId: this.bigtable.appProfileId,
     rowKey: Mutation.convertToBytes(this.id),
@@ -401,7 +401,7 @@ Row.prototype.delete = function(gaxOptions, callback) {
     gaxOptions = {};
   }
 
-  var mutation = {
+  const mutation = {
     key: this.id,
     method: Mutation.methods.DELETE,
   };
@@ -458,7 +458,7 @@ Row.prototype.deleteCells = function(columns, gaxOptions, callback) {
     gaxOptions = {};
   }
 
-  var mutation = {
+  const mutation = {
     key: this.id,
     data: arrify(columns),
     method: Mutation.methods.DELETE,
@@ -587,7 +587,7 @@ Row.prototype.exists = function(gaxOptions, callback) {
  * });
  */
 Row.prototype.filter = function(filter, config, callback) {
-  var reqOpts = {
+  const reqOpts = {
     tableName: this.table.id,
     appProfileId: this.bigtable.appProfileId,
     rowKey: Mutation.convertToBytes(this.id),
@@ -666,7 +666,7 @@ Row.prototype.filter = function(filter, config, callback) {
  * });
  */
 Row.prototype.get = function(columns, options, callback) {
-  var self = this;
+  const self = this;
 
   if (!is.array(columns)) {
     callback = options;
@@ -679,13 +679,13 @@ Row.prototype.get = function(columns, options, callback) {
     options = {};
   }
 
-  var filter;
+  let filter;
   columns = arrify(columns);
 
   // if there is column filter
   if (columns.length) {
-    var filters = columns.map(Mutation.parseColumnName).map(column => {
-      var colmFilters = [{family: column.family}];
+    const filters = columns.map(Mutation.parseColumnName).map(column => {
+      const colmFilters = [{family: column.family}];
       if (column.qualifier) {
         colmFilters.push({column: column.qualifier});
       }
@@ -709,7 +709,7 @@ Row.prototype.get = function(columns, options, callback) {
     filter = arrify(filter).concat(options.filter);
   }
 
-  var getRowsOptions = extend({}, options, {
+  const getRowsOptions = extend({}, options, {
     keys: [this.id],
     filter,
   });
@@ -720,7 +720,7 @@ Row.prototype.get = function(columns, options, callback) {
       return;
     }
 
-    var row = rows[0];
+    const row = rows[0];
 
     if (!row) {
       err = new RowError(self.id);
@@ -839,7 +839,7 @@ Row.prototype.increment = function(column, value, gaxOptions, callback) {
     value = 1;
   }
 
-  var reqOpts = {
+  const reqOpts = {
     column,
     increment: value,
   };
@@ -850,8 +850,8 @@ Row.prototype.increment = function(column, value, gaxOptions, callback) {
       return;
     }
 
-    var data = Row.formatFamilies_(resp.row.families);
-    var value = dotProp.get(data, column.replace(':', '.'))[0].value;
+    const data = Row.formatFamilies_(resp.row.families);
+    const value = dotProp.get(data, column.replace(':', '.'))[0].value;
 
     callback(null, value, resp);
   });
@@ -905,7 +905,7 @@ Row.prototype.save = function(entry, gaxOptions, callback) {
     gaxOptions = {};
   }
 
-  var mutation = {
+  const mutation = {
     key: this.id,
     data: entry,
     method: Mutation.methods.INSERT,

--- a/src/row.js
+++ b/src/row.js
@@ -47,872 +47,874 @@ const RowError = createErrorClass('RowError', function(row) {
  * const table = instance.table('prezzy');
  * const row = table.row('gwashington');
  */
-function Row(table, key) {
-  this.bigtable = table.bigtable;
-  this.table = table;
-  this.id = key;
+class Row {
+  constructor(table, key) {
+    this.bigtable = table.bigtable;
+    this.table = table;
+    this.id = key;
 
-  this.data = {};
-}
-
-/**
- * Formats the row chunks into friendly format. Chunks contain 3 properties:
- *
- * `rowContents` The row contents, this essentially is all data pertaining
- *     to a single family.
- *
- * `commitRow` This is a boolean telling us the all previous chunks for this
- *     row are ok to consume.
- *
- * `resetRow` This is a boolean telling us that all the previous chunks are to
- *     be discarded.
- *
- * @private
- *
- * @param {chunk[]} chunks The list of chunks.
- * @param {object} [options] Formatting options.
- *
- * @example
- * Row.formatChunks_(chunks);
- * // {
- * //   follows: {
- * //     gwashington: [
- * //       {
- * //         value: 2
- * //       }
- * //     ]
- * //   }
- * // }
- */
-Row.formatChunks_ = function(chunks, options) {
-  const rows = [];
-  let familyName;
-  let qualifierName;
-
-  options = options || {};
-
-  chunks.reduce(function(row, chunk) {
-    let family;
-    let qualifier;
-
-    row.data = row.data || {};
-
-    if (chunk.rowKey) {
-      row.key = Mutation.convertFromBytes(chunk.rowKey, {userOptions: options});
-    }
-
-    if (chunk.familyName) {
-      familyName = chunk.familyName.value;
-    }
-
-    if (familyName) {
-      family = row.data[familyName] = row.data[familyName] || {};
-    }
-
-    if (chunk.qualifier) {
-      qualifierName = Mutation.convertFromBytes(chunk.qualifier.value, {
-        userOptions: options,
-      });
-    }
-
-    if (family && qualifierName) {
-      qualifier = family[qualifierName] = family[qualifierName] || [];
-    }
-
-    if (qualifier && chunk.value) {
-      qualifier.push({
-        value: Mutation.convertFromBytes(chunk.value, {userOptions: options}),
-        labels: chunk.labels,
-        timestamp: chunk.timestampMicros,
-        size: chunk.valueSize,
-      });
-    }
-
-    if (chunk.commitRow) {
-      rows.push(row);
-    }
-
-    if (chunk.commitRow || chunk.resetRow) {
-      familyName = qualifierName = null;
-      return {};
-    }
-
-    return row;
-  }, {});
-
-  return rows;
-};
-
-/**
- * Formats a rowContents object into friendly format.
- *
- * @private
- *
- * @param {object[]} families The row families.
- * @param {object} [options] Formatting options.
- *
- * @example
- * var families = [
- *   {
- *     name: 'follows',
- *     columns: [
- *       {
- *         qualifier: 'gwashington',
- *         cells: [
- *           {
- *             value: 2
- *           }
- *         ]
- *       }
- *     ]
- *   }
- * ];
- *
- * Row.formatFamilies_(families);
- * // {
- * //   follows: {
- * //     gwashington: [
- * //       {
- * //         value: 2
- * //       }
- * //     ]
- * //   }
- * // }
- */
-Row.formatFamilies_ = function(families, options) {
-  const data = {};
-
-  options = options || {};
-
-  families.forEach(function(family) {
-    const familyData = (data[family.name] = {});
-
-    family.columns.forEach(function(column) {
-      const qualifier = Mutation.convertFromBytes(column.qualifier);
-
-      familyData[qualifier] = column.cells.map(function(cell) {
-        let value = cell.value;
-
-        if (options.decode !== false) {
-          value = Mutation.convertFromBytes(value, {isPossibleNumber: true});
-        }
-
-        return {
-          value,
-          timestamp: cell.timestampMicros,
-          labels: cell.labels,
-        };
-      });
-    });
-  });
-
-  return data;
-};
-
-/**
- * Create a new row in your table.
- *
- * @param {object} [options] Configuration object.
- * @param {object} [options.entry] An entry. See {@link Table#insert}.
- * @param {object} [options.gaxOptions] Request configuration options, outlined
- *     here: https://googleapis.github.io/gax-nodejs/CallSettings.html.
- * @param {function} callback The callback function.
- * @param {?error} callback.err An error returned while making this
- *     request.
- * @param {Row} callback.row The newly created row object.
- * @param {object} callback.apiResponse The full API response.
- *
- * @example
- * var callback = function(err, apiResponse) {
- *   if (!err) {
- *     // Row successfully created
- *   }
- * };
- *
- * row.create(callback);
- *
- * //-
- * // Optionally, you can supply entry data.
- * //-
- * row.create({
- *   entry: {
- *     follows: {
- *       alincoln: 1
- *     }
- *   }
- * }, callback);
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * row.create().then(function(data) {
- *   var apiResponse = data[0];
- * });
- */
-Row.prototype.create = function(options, callback) {
-  const self = this;
-
-  if (is.function(options)) {
-    callback = options;
-    options = {};
+    this.data = {};
   }
 
-  const entry = {
-    key: this.id,
-    data: options.entry,
-    method: Mutation.methods.INSERT,
-  };
+  /**
+   * Formats the row chunks into friendly format. Chunks contain 3 properties:
+   *
+   * `rowContents` The row contents, this essentially is all data pertaining
+   *     to a single family.
+   *
+   * `commitRow` This is a boolean telling us the all previous chunks for this
+   *     row are ok to consume.
+   *
+   * `resetRow` This is a boolean telling us that all the previous chunks are to
+   *     be discarded.
+   *
+   * @private
+   *
+   * @param {chunk[]} chunks The list of chunks.
+   * @param {object} [options] Formatting options.
+   *
+   * @example
+   * Row.formatChunks_(chunks);
+   * // {
+   * //   follows: {
+   * //     gwashington: [
+   * //       {
+   * //         value: 2
+   * //       }
+   * //     ]
+   * //   }
+   * // }
+   */
+  static formatChunks_(chunks, options) {
+    const rows = [];
+    let familyName;
+    let qualifierName;
 
-  this.table.mutate(entry, options.gaxOptions, function(err, apiResponse) {
-    if (err) {
-      callback(err, null, apiResponse);
-      return;
-    }
+    options = options || {};
 
-    callback(null, self, apiResponse);
-  });
-};
+    chunks.reduce(function(row, chunk) {
+      let family;
+      let qualifier;
 
-/**
- * Update a row with rules specifying how the row's contents are to be
- * transformed into writes. Rules are applied in order, meaning that earlier
- * rules will affect the results of later ones.
- *
- * @throws {error} If no rules are provided.
- *
- * @param {object|object[]} rules The rules to apply to this row.
- * @param {object} [gaxOptions] Request configuration options, outlined here:
- *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
- * @param {function} callback The callback function.
- * @param {?error} callback.err An error returned while making this
- *     request.
- * @param {object} callback.apiResponse The full API response.
- *
- * @example
- * //-
- * // Add an increment amount to an existing value, if the targeted cell is
- * // unset, it will be treated as containing a zero.
- * //-
- * var callback = function(err, apiResponse) {
- *   if (!err) {
- *     // The rules have successfully been applied.
- *   }
- * };
- *
- * var rules = [
- *   {
- *     column: 'follows:gwashington',
- *     increment: 1
- *   }
- * ];
- *
- * row.createRules(rules, callback);
- *
- * //-
- * // You can also create a rule that will append data to an existing value.
- * // If the targeted cell is unset, it will be treated as a containing an
- * // empty string.
- * //-
- * var rules = [
- *   {
- *     column: 'follows:alincoln',
- *     append: ' Honest Abe!'
- *   }
- * ];
- *
- * row.createRules(rules, callback);
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * row.createRules(rules).then(function(data) {
- *   var apiResponse = data[0];
- * });
- */
-Row.prototype.createRules = function(rules, gaxOptions, callback) {
-  if (is.fn(gaxOptions)) {
-    callback = gaxOptions;
-    gaxOptions = {};
-  }
+      row.data = row.data || {};
 
-  if (!rules || rules.length === 0) {
-    throw new Error('At least one rule must be provided.');
-  }
-
-  rules = arrify(rules).map(function(rule) {
-    const column = Mutation.parseColumnName(rule.column);
-    const ruleData = {
-      familyName: column.family,
-      columnQualifier: Mutation.convertToBytes(column.qualifier),
-    };
-
-    if (rule.append) {
-      ruleData.appendValue = Mutation.convertToBytes(rule.append);
-    }
-
-    if (rule.increment) {
-      ruleData.incrementAmount = rule.increment;
-    }
-
-    return ruleData;
-  });
-
-  const reqOpts = {
-    tableName: this.table.id,
-    appProfileId: this.bigtable.appProfileId,
-    rowKey: Mutation.convertToBytes(this.id),
-    rules,
-  };
-
-  this.bigtable.request(
-    {
-      client: 'BigtableClient',
-      method: 'readModifyWriteRow',
-      reqOpts,
-      gaxOpts: gaxOptions,
-    },
-    callback
-  );
-};
-
-/**
- * Deletes all cells in the row.
- *
- * @param {object} [gaxOptions] Request configuration options, outlined here:
- *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
- * @param {function} callback The callback function.
- * @param {?error} callback.err An error returned while making this
- *     request.
- * @param {object} callback.apiResponse The full API response.
- *
- * @example
- * row.delete(function(err, apiResponse) {});
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * row.delete().then(function(data) {
- *   var apiResponse = data[0];
- * });
- */
-Row.prototype.delete = function(gaxOptions, callback) {
-  if (is.fn(gaxOptions)) {
-    callback = gaxOptions;
-    gaxOptions = {};
-  }
-
-  const mutation = {
-    key: this.id,
-    method: Mutation.methods.DELETE,
-  };
-
-  this.table.mutate(mutation, gaxOptions, callback);
-};
-
-/**
- * Delete specified cells from the row. See {@link Table#mutate}.
- *
- * @param {string[]} columns Column names for the cells to be deleted.
- * @param {object} [gaxOptions] Request configuration options, outlined here:
- *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
- * @param {function} callback The callback function.
- * @param {?error} callback.err An error returned while making this
- *     request.
- * @param {object} callback.apiResponse The full API response.
- *
- * @example
- * //-
- * // Delete individual cells.
- * //-
- * var callback = function(err, apiResponse) {
- *   if (!err) {
- *     // Cells were successfully deleted.
- *   }
- * };
- *
- * var cells = [
- *   'follows:gwashington'
- * ];
- *
- * row.deleteCells(cells, callback);
- *
- * //-
- * // Delete all cells within a family.
- * //-
- * var cells = [
- *   'follows',
- * ];
- *
- * row.deleteCells(cells, callback);
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * row.deleteCells(cells).then(function(data) {
- *   var apiResponse = data[0];
- * });
- */
-Row.prototype.deleteCells = function(columns, gaxOptions, callback) {
-  if (is.fn(gaxOptions)) {
-    callback = gaxOptions;
-    gaxOptions = {};
-  }
-
-  const mutation = {
-    key: this.id,
-    data: arrify(columns),
-    method: Mutation.methods.DELETE,
-  };
-
-  this.table.mutate(mutation, gaxOptions, callback);
-};
-
-/**
- * Check if the table row exists.
- *
- * @param {object} [gaxOptions] Request configuration options, outlined here:
- *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
- * @param {function} callback The callback function.
- * @param {?error} callback.err An error returned while making this
- *     request.
- * @param {boolean} callback.exists Whether the row exists or not.
- *
- * @example
- * row.exists(function(err, exists) {});
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * row.exists().then(function(data) {
- *   var exists = data[0];
- * });
- */
-Row.prototype.exists = function(gaxOptions, callback) {
-  if (is.fn(gaxOptions)) {
-    callback = gaxOptions;
-    gaxOptions = {};
-  }
-
-  this.getMetadata(gaxOptions, function(err) {
-    if (err) {
-      if (err instanceof RowError) {
-        callback(null, false);
-        return;
+      if (chunk.rowKey) {
+        row.key = Mutation.convertFromBytes(chunk.rowKey, {userOptions: options});
       }
 
-      callback(err);
-      return;
+      if (chunk.familyName) {
+        familyName = chunk.familyName.value;
+      }
+
+      if (familyName) {
+        family = row.data[familyName] = row.data[familyName] || {};
+      }
+
+      if (chunk.qualifier) {
+        qualifierName = Mutation.convertFromBytes(chunk.qualifier.value, {
+          userOptions: options,
+        });
+      }
+
+      if (family && qualifierName) {
+        qualifier = family[qualifierName] = family[qualifierName] || [];
+      }
+
+      if (qualifier && chunk.value) {
+        qualifier.push({
+          value: Mutation.convertFromBytes(chunk.value, {userOptions: options}),
+          labels: chunk.labels,
+          timestamp: chunk.timestampMicros,
+          size: chunk.valueSize,
+        });
+      }
+
+      if (chunk.commitRow) {
+        rows.push(row);
+      }
+
+      if (chunk.commitRow || chunk.resetRow) {
+        familyName = qualifierName = null;
+        return {};
+      }
+
+      return row;
+    }, {});
+
+    return rows;
+  }
+
+  /**
+   * Formats a rowContents object into friendly format.
+   *
+   * @private
+   *
+   * @param {object[]} families The row families.
+   * @param {object} [options] Formatting options.
+   *
+   * @example
+   * var families = [
+   *   {
+   *     name: 'follows',
+   *     columns: [
+   *       {
+   *         qualifier: 'gwashington',
+   *         cells: [
+   *           {
+   *             value: 2
+   *           }
+   *         ]
+   *       }
+   *     ]
+   *   }
+   * ];
+   *
+   * Row.formatFamilies_(families);
+   * // {
+   * //   follows: {
+   * //     gwashington: [
+   * //       {
+   * //         value: 2
+   * //       }
+   * //     ]
+   * //   }
+   * // }
+   */
+  static formatFamilies_(families, options) {
+    const data = {};
+
+    options = options || {};
+
+    families.forEach(function(family) {
+      const familyData = (data[family.name] = {});
+
+      family.columns.forEach(function(column) {
+        const qualifier = Mutation.convertFromBytes(column.qualifier);
+
+        familyData[qualifier] = column.cells.map(function(cell) {
+          let value = cell.value;
+
+          if (options.decode !== false) {
+            value = Mutation.convertFromBytes(value, {isPossibleNumber: true});
+          }
+
+          return {
+            value,
+            timestamp: cell.timestampMicros,
+            labels: cell.labels,
+          };
+        });
+      });
+    });
+
+    return data;
+  }
+
+  /**
+   * Create a new row in your table.
+   *
+   * @param {object} [options] Configuration object.
+   * @param {object} [options.entry] An entry. See {@link Table#insert}.
+   * @param {object} [options.gaxOptions] Request configuration options, outlined
+   *     here: https://googleapis.github.io/gax-nodejs/CallSettings.html.
+   * @param {function} callback The callback function.
+   * @param {?error} callback.err An error returned while making this
+   *     request.
+   * @param {Row} callback.row The newly created row object.
+   * @param {object} callback.apiResponse The full API response.
+   *
+   * @example
+   * var callback = function(err, apiResponse) {
+   *   if (!err) {
+   *     // Row successfully created
+   *   }
+   * };
+   *
+   * row.create(callback);
+   *
+   * //-
+   * // Optionally, you can supply entry data.
+   * //-
+   * row.create({
+   *   entry: {
+   *     follows: {
+   *       alincoln: 1
+   *     }
+   *   }
+   * }, callback);
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * row.create().then(function(data) {
+   *   var apiResponse = data[0];
+   * });
+   */
+  create(options, callback) {
+    const self = this;
+
+    if (is.function(options)) {
+      callback = options;
+      options = {};
     }
 
-    callback(null, true);
-  });
-};
+    const entry = {
+      key: this.id,
+      data: options.entry,
+      method: Mutation.methods.INSERT,
+    };
 
-/**
- * Mutates a row atomically based on the output of a filter. Depending on
- * whether or not any results are yielded, either the `onMatch` or `onNoMatch`
- * callback will be executed.
- *
- * @param {Filter} filter Filter to be applied to the contents of the row.
- * @param {object} config Configuration object.
- * @param {?object[]} config.onMatch A list of entries to be ran if a match is
- *     found.
- * @param {object[]} [config.onNoMatch] A list of entries to be ran if no
- *     matches are found.
- * @param {object} [config.gaxOptions] Request configuration options, outlined
- *     here: https://googleapis.github.io/gax-nodejs/global.html#CallOptions.
- * @param {function} callback The callback function.
- * @param {?error} callback.err An error returned while making this
- *     request.
- * @param {boolean} callback.matched Whether a match was found or not.
- *
- * @example
- * var callback = function(err, matched) {
- *   if (!err) {
- *     // `matched` will let us know if a match was found or not.
- *   }
- * };
- *
- * var filter = [
- *   {
- *     family: 'follows'
- *   },
- *   {
- *     column: 'alincoln',
- *   },
- *   {
- *     value: 1
- *   }
- * ];
- *
- * var config = {
- *   onMatch: [
- *     {
- *       method: 'insert',
- *       data: {
- *         follows: {
- *           jadams: 1
- *         }
- *       }
- *     }
- *   ]
- * };
- *
- * row.filter(filter, config, callback);
- *
- * //-
- * // Optionally, you can pass in an array of entries to be ran in the event
- * // that a match is not made.
- * //-
- * var config = {
- *   onNoMatch: [
- *     {
- *       method: 'insert',
- *       data: {
- *         follows: {
- *           jadams: 1
- *         }
- *       }
- *     }
- *   ]
- * };
- *
- * row.filter(filter, config, callback);
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * row.filter(filter, config).then(function(data) {
- *   var matched = data[0];
- * });
- */
-Row.prototype.filter = function(filter, config, callback) {
-  const reqOpts = {
-    tableName: this.table.id,
-    appProfileId: this.bigtable.appProfileId,
-    rowKey: Mutation.convertToBytes(this.id),
-    predicateFilter: Filter.parse(filter),
-    trueMutations: createFlatMutationsList(config.onMatch),
-    falseMutations: createFlatMutationsList(config.onNoMatch),
-  };
-
-  this.bigtable.request(
-    {
-      client: 'BigtableClient',
-      method: 'checkAndMutateRow',
-      reqOpts,
-      gaxOpts: config.gaxOptions,
-    },
-    function(err, apiResponse) {
+    this.table.mutate(entry, options.gaxOptions, function(err, apiResponse) {
       if (err) {
         callback(err, null, apiResponse);
         return;
       }
 
-      callback(null, apiResponse.predicateMatched, apiResponse);
-    }
-  );
-
-  function createFlatMutationsList(entries) {
-    entries = arrify(entries).map(function(entry) {
-      return Mutation.parse(entry).mutations;
+      callback(null, self, apiResponse);
     });
-
-    return flatten(entries);
-  }
-};
-
-/**
- * Get the row data. See {@link Table#getRows}.
- *
- * @param {string[]} [columns] List of specific columns to retrieve.
- * @param {object} [options] Configuration object.
- * @param {boolean} [options.decode=true] If set to `false` it will not decode Buffer
- *     values returned from Bigtable.
- * @param {object} [options.gaxOptions] Request configuration options, outlined
- *     here: https://googleapis.github.io/gax-nodejs/CallSettings.html.
- * @param {function} callback The callback function.
- * @param {?error} callback.err An error returned while making this
- *     request.
- * @param {Row} callback.row The updated Row object.
- *
- * @example
- * //-
- * // Use this method to grab an entire row
- * //-
- * var callback = function(err, row, apiResponse) {
- *   if (!err) {
- *     // `row.cells` has been updated.
- *   }
- * };
- *
- * row.get(callback);
- *
- * //-
- * // Or pass in an array of column names to populate specific cells.
- * // Under the hood this will create an interleave filter.
- * //-
- * row.get([
- *   'follows:gwashington',
- *   'follows:alincoln'
- * ], callback);
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * row.get().then(function(data) {
- *   var row = data[0];
- *   var apiResponse = data[1];
- * });
- */
-Row.prototype.get = function(columns, options, callback) {
-  const self = this;
-
-  if (!is.array(columns)) {
-    callback = options;
-    options = columns;
-    columns = [];
   }
 
-  if (is.function(options)) {
-    callback = options;
-    options = {};
-  }
+  /**
+   * Update a row with rules specifying how the row's contents are to be
+   * transformed into writes. Rules are applied in order, meaning that earlier
+   * rules will affect the results of later ones.
+   *
+   * @throws {error} If no rules are provided.
+   *
+   * @param {object|object[]} rules The rules to apply to this row.
+   * @param {object} [gaxOptions] Request configuration options, outlined here:
+   *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
+   * @param {function} callback The callback function.
+   * @param {?error} callback.err An error returned while making this
+   *     request.
+   * @param {object} callback.apiResponse The full API response.
+   *
+   * @example
+   * //-
+   * // Add an increment amount to an existing value, if the targeted cell is
+   * // unset, it will be treated as containing a zero.
+   * //-
+   * var callback = function(err, apiResponse) {
+   *   if (!err) {
+   *     // The rules have successfully been applied.
+   *   }
+   * };
+   *
+   * var rules = [
+   *   {
+   *     column: 'follows:gwashington',
+   *     increment: 1
+   *   }
+   * ];
+   *
+   * row.createRules(rules, callback);
+   *
+   * //-
+   * // You can also create a rule that will append data to an existing value.
+   * // If the targeted cell is unset, it will be treated as a containing an
+   * // empty string.
+   * //-
+   * var rules = [
+   *   {
+   *     column: 'follows:alincoln',
+   *     append: ' Honest Abe!'
+   *   }
+   * ];
+   *
+   * row.createRules(rules, callback);
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * row.createRules(rules).then(function(data) {
+   *   var apiResponse = data[0];
+   * });
+   */
+  createRules(rules, gaxOptions, callback) {
+    if (is.fn(gaxOptions)) {
+      callback = gaxOptions;
+      gaxOptions = {};
+    }
 
-  let filter;
-  columns = arrify(columns);
+    if (!rules || rules.length === 0) {
+      throw new Error('At least one rule must be provided.');
+    }
 
-  // if there is column filter
-  if (columns.length) {
-    const filters = columns.map(Mutation.parseColumnName).map(column => {
-      const colmFilters = [{family: column.family}];
-      if (column.qualifier) {
-        colmFilters.push({column: column.qualifier});
+    rules = arrify(rules).map(function(rule) {
+      const column = Mutation.parseColumnName(rule.column);
+      const ruleData = {
+        familyName: column.family,
+        columnQualifier: Mutation.convertToBytes(column.qualifier),
+      };
+
+      if (rule.append) {
+        ruleData.appendValue = Mutation.convertToBytes(rule.append);
       }
-      return colmFilters;
+
+      if (rule.increment) {
+        ruleData.incrementAmount = rule.increment;
+      }
+
+      return ruleData;
     });
 
-    // if there is more then one filter, make it type inteleave filter
-    if (filters.length > 1) {
-      filter = [
-        {
-          interleave: filters,
-        },
-      ];
-    } else {
-      filter = filters[0];
+    const reqOpts = {
+      tableName: this.table.id,
+      appProfileId: this.bigtable.appProfileId,
+      rowKey: Mutation.convertToBytes(this.id),
+      rules,
+    };
+
+    this.bigtable.request(
+      {
+        client: 'BigtableClient',
+        method: 'readModifyWriteRow',
+        reqOpts,
+        gaxOpts: gaxOptions,
+      },
+      callback
+    );
+  }
+
+  /**
+   * Deletes all cells in the row.
+   *
+   * @param {object} [gaxOptions] Request configuration options, outlined here:
+   *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
+   * @param {function} callback The callback function.
+   * @param {?error} callback.err An error returned while making this
+   *     request.
+   * @param {object} callback.apiResponse The full API response.
+   *
+   * @example
+   * row.delete(function(err, apiResponse) {});
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * row.delete().then(function(data) {
+   *   var apiResponse = data[0];
+   * });
+   */
+  delete(gaxOptions, callback) {
+    if (is.fn(gaxOptions)) {
+      callback = gaxOptions;
+      gaxOptions = {};
+    }
+
+    const mutation = {
+      key: this.id,
+      method: Mutation.methods.DELETE,
+    };
+
+    this.table.mutate(mutation, gaxOptions, callback);
+  }
+
+  /**
+   * Delete specified cells from the row. See {@link Table#mutate}.
+   *
+   * @param {string[]} columns Column names for the cells to be deleted.
+   * @param {object} [gaxOptions] Request configuration options, outlined here:
+   *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
+   * @param {function} callback The callback function.
+   * @param {?error} callback.err An error returned while making this
+   *     request.
+   * @param {object} callback.apiResponse The full API response.
+   *
+   * @example
+   * //-
+   * // Delete individual cells.
+   * //-
+   * var callback = function(err, apiResponse) {
+   *   if (!err) {
+   *     // Cells were successfully deleted.
+   *   }
+   * };
+   *
+   * var cells = [
+   *   'follows:gwashington'
+   * ];
+   *
+   * row.deleteCells(cells, callback);
+   *
+   * //-
+   * // Delete all cells within a family.
+   * //-
+   * var cells = [
+   *   'follows',
+   * ];
+   *
+   * row.deleteCells(cells, callback);
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * row.deleteCells(cells).then(function(data) {
+   *   var apiResponse = data[0];
+   * });
+   */
+  deleteCells(columns, gaxOptions, callback) {
+    if (is.fn(gaxOptions)) {
+      callback = gaxOptions;
+      gaxOptions = {};
+    }
+
+    const mutation = {
+      key: this.id,
+      data: arrify(columns),
+      method: Mutation.methods.DELETE,
+    };
+
+    this.table.mutate(mutation, gaxOptions, callback);
+  }
+
+  /**
+   * Check if the table row exists.
+   *
+   * @param {object} [gaxOptions] Request configuration options, outlined here:
+   *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
+   * @param {function} callback The callback function.
+   * @param {?error} callback.err An error returned while making this
+   *     request.
+   * @param {boolean} callback.exists Whether the row exists or not.
+   *
+   * @example
+   * row.exists(function(err, exists) {});
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * row.exists().then(function(data) {
+   *   var exists = data[0];
+   * });
+   */
+  exists(gaxOptions, callback) {
+    if (is.fn(gaxOptions)) {
+      callback = gaxOptions;
+      gaxOptions = {};
+    }
+
+    this.getMetadata(gaxOptions, function(err) {
+      if (err) {
+        if (err instanceof RowError) {
+          callback(null, false);
+          return;
+        }
+
+        callback(err);
+        return;
+      }
+
+      callback(null, true);
+    });
+  }
+
+  /**
+   * Mutates a row atomically based on the output of a filter. Depending on
+   * whether or not any results are yielded, either the `onMatch` or `onNoMatch`
+   * callback will be executed.
+   *
+   * @param {Filter} filter Filter to be applied to the contents of the row.
+   * @param {object} config Configuration object.
+   * @param {?object[]} config.onMatch A list of entries to be ran if a match is
+   *     found.
+   * @param {object[]} [config.onNoMatch] A list of entries to be ran if no
+   *     matches are found.
+   * @param {object} [config.gaxOptions] Request configuration options, outlined
+   *     here: https://googleapis.github.io/gax-nodejs/global.html#CallOptions.
+   * @param {function} callback The callback function.
+   * @param {?error} callback.err An error returned while making this
+   *     request.
+   * @param {boolean} callback.matched Whether a match was found or not.
+   *
+   * @example
+   * var callback = function(err, matched) {
+   *   if (!err) {
+   *     // `matched` will let us know if a match was found or not.
+   *   }
+   * };
+   *
+   * var filter = [
+   *   {
+   *     family: 'follows'
+   *   },
+   *   {
+   *     column: 'alincoln',
+   *   },
+   *   {
+   *     value: 1
+   *   }
+   * ];
+   *
+   * var config = {
+   *   onMatch: [
+   *     {
+   *       method: 'insert',
+   *       data: {
+   *         follows: {
+   *           jadams: 1
+   *         }
+   *       }
+   *     }
+   *   ]
+   * };
+   *
+   * row.filter(filter, config, callback);
+   *
+   * //-
+   * // Optionally, you can pass in an array of entries to be ran in the event
+   * // that a match is not made.
+   * //-
+   * var config = {
+   *   onNoMatch: [
+   *     {
+   *       method: 'insert',
+   *       data: {
+   *         follows: {
+   *           jadams: 1
+   *         }
+   *       }
+   *     }
+   *   ]
+   * };
+   *
+   * row.filter(filter, config, callback);
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * row.filter(filter, config).then(function(data) {
+   *   var matched = data[0];
+   * });
+   */
+  filter(filter, config, callback) {
+    const reqOpts = {
+      tableName: this.table.id,
+      appProfileId: this.bigtable.appProfileId,
+      rowKey: Mutation.convertToBytes(this.id),
+      predicateFilter: Filter.parse(filter),
+      trueMutations: createFlatMutationsList(config.onMatch),
+      falseMutations: createFlatMutationsList(config.onNoMatch),
+    };
+
+    this.bigtable.request(
+      {
+        client: 'BigtableClient',
+        method: 'checkAndMutateRow',
+        reqOpts,
+        gaxOpts: config.gaxOptions,
+      },
+      function(err, apiResponse) {
+        if (err) {
+          callback(err, null, apiResponse);
+          return;
+        }
+
+        callback(null, apiResponse.predicateMatched, apiResponse);
+      }
+    );
+
+    function createFlatMutationsList(entries) {
+      entries = arrify(entries).map(function(entry) {
+        return Mutation.parse(entry).mutations;
+      });
+
+      return flatten(entries);
     }
   }
 
-  // if there is also a second option.filter append to filter array
-  if (options.filter) {
-    filter = arrify(filter).concat(options.filter);
-  }
+  /**
+   * Get the row data. See {@link Table#getRows}.
+   *
+   * @param {string[]} [columns] List of specific columns to retrieve.
+   * @param {object} [options] Configuration object.
+   * @param {boolean} [options.decode=true] If set to `false` it will not decode Buffer
+   *     values returned from Bigtable.
+   * @param {object} [options.gaxOptions] Request configuration options, outlined
+   *     here: https://googleapis.github.io/gax-nodejs/CallSettings.html.
+   * @param {function} callback The callback function.
+   * @param {?error} callback.err An error returned while making this
+   *     request.
+   * @param {Row} callback.row The updated Row object.
+   *
+   * @example
+   * //-
+   * // Use this method to grab an entire row
+   * //-
+   * var callback = function(err, row, apiResponse) {
+   *   if (!err) {
+   *     // `row.cells` has been updated.
+   *   }
+   * };
+   *
+   * row.get(callback);
+   *
+   * //-
+   * // Or pass in an array of column names to populate specific cells.
+   * // Under the hood this will create an interleave filter.
+   * //-
+   * row.get([
+   *   'follows:gwashington',
+   *   'follows:alincoln'
+   * ], callback);
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * row.get().then(function(data) {
+   *   var row = data[0];
+   *   var apiResponse = data[1];
+   * });
+   */
+  get(columns, options, callback) {
+    const self = this;
 
-  const getRowsOptions = extend({}, options, {
-    keys: [this.id],
-    filter,
-  });
-
-  this.table.getRows(getRowsOptions, function(err, rows) {
-    if (err) {
-      callback(err);
-      return;
+    if (!is.array(columns)) {
+      callback = options;
+      options = columns;
+      columns = [];
     }
 
-    const row = rows[0];
-
-    if (!row) {
-      err = new RowError(self.id);
-      callback(err);
-      return;
+    if (is.function(options)) {
+      callback = options;
+      options = {};
     }
 
-    extend(true, self.data, row.data);
+    let filter;
+    columns = arrify(columns);
 
-    // If the user specifies column names, we'll return back the row data we
-    // received. Otherwise, we'll return the row itself in a typical
-    // GrpcServiceObject#get fashion.
-    callback(null, columns.length ? row.data : self);
-  });
-};
+    // if there is column filter
+    if (columns.length) {
+      const filters = columns.map(Mutation.parseColumnName).map(column => {
+        const colmFilters = [{family: column.family}];
+        if (column.qualifier) {
+          colmFilters.push({column: column.qualifier});
+        }
+        return colmFilters;
+      });
 
-/**
- * Get the row's metadata.
- *
- * @param {object} [options] Configuration object.
- * @param {boolean} [options.decode=true] If set to `false` it will not decode
- *     Buffer values returned from Bigtable.
- * @param {object} [options.gaxOptions] Request configuration options, outlined
- *     here: https://googleapis.github.io/gax-nodejs/CallSettings.html.
- * @param {function} callback The callback function.
- * @param {?error} callback.err An error returned while making this
- *     request.
- * @param {object} callback.metadata The row's metadata.
- *
- * @example
- * row.getMetadata(function(err, metadata, apiResponse) {});
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * row.getMetadata().then(function(data) {
- *   var metadata = data[0];
- *   var apiResponse = data[1];
- * });
- */
-Row.prototype.getMetadata = function(options, callback) {
-  if (is.function(options)) {
-    callback = options;
-    options = {};
-  }
-
-  this.get(options, function(err, row) {
-    if (err) {
-      callback(err);
-      return;
+      // if there is more then one filter, make it type inteleave filter
+      if (filters.length > 1) {
+        filter = [
+          {
+            interleave: filters,
+          },
+        ];
+      } else {
+        filter = filters[0];
+      }
     }
 
-    callback(null, row.metadata);
-  });
-};
-
-/**
- * Increment a specific column within the row. If the column does not
- * exist, it is automatically initialized to 0 before being incremented.
- *
- * @param {string} column The column we are incrementing a value in.
- * @param {number} [value] The amount to increment by, defaults to 1.
- * @param {object} [gaxOptions] Request configuration options, outlined here:
- *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
- * @param {function} callback The callback function.
- * @param {?error} callback.err An error returned while making this
- *     request.
- * @param {number} callback.value The updated value of the column.
- * @param {object} callback.apiResponse The full API response.
- *
- * @example
- * var callback = function(err, value, apiResponse) {
- *   if (!err) {
- *     // `value` is the value of the updated column.
- *   }
- * };
- *
- * row.increment('follows:gwashington', callback);
- *
- * //-
- * // Specify a custom amount to increment the column by.
- * //-
- * row.increment('follows:gwashington', 2, callback);
- *
- * //-
- * // To decrement a column, simply supply a negative value.
- * //-
- * row.increment('follows:gwashington', -1, callback);
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * row.increment('follows:gwashington').then(function(data) {
- *   var value = data[0];
- *   var apiResponse = data[1];
- * });
- */
-Row.prototype.increment = function(column, value, gaxOptions, callback) {
-  // increment('column', callback)
-  if (is.function(value)) {
-    callback = value;
-    value = 1;
-    gaxOptions = {};
-  }
-
-  // increment('column', value, callback)
-  if (is.function(gaxOptions)) {
-    callback = gaxOptions;
-    gaxOptions = {};
-  }
-
-  // increment('column', { gaxOptions }, callback)
-  if (is.object(value)) {
-    callback = gaxOptions;
-    gaxOptions = value;
-    value = 1;
-  }
-
-  const reqOpts = {
-    column,
-    increment: value,
-  };
-
-  this.createRules(reqOpts, gaxOptions, function(err, resp) {
-    if (err) {
-      callback(err, null, resp);
-      return;
+    // if there is also a second option.filter append to filter array
+    if (options.filter) {
+      filter = arrify(filter).concat(options.filter);
     }
 
-    const data = Row.formatFamilies_(resp.row.families);
-    const value = dotProp.get(data, column.replace(':', '.'))[0].value;
+    const getRowsOptions = extend({}, options, {
+      keys: [this.id],
+      filter,
+    });
 
-    callback(null, value, resp);
-  });
-};
+    this.table.getRows(getRowsOptions, function(err, rows) {
+      if (err) {
+        callback(err);
+        return;
+      }
 
-/**
- * Update the row cells.
- *
- * @param {object} key An entry object to be inserted into the row. See
- *     {@link Table#insert}.
- * @param {object} [gaxOptions] Request configuration options, outlined here:
- *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
- * @param {function} callback The callback function.
- * @param {?error} callback.err An error returned while making this
- *     request.
- * @param {object} callback.apiResponse The full API response.
- *
- * @example
- * var entry = {
- *   follows: {
- *     jadams: 1
- *   }
- * };
- *
- * //-
- * // Update a single cell.
- * //-
- * var callback = function(err, apiResponse) {
- *   if (!err) {
- *     // The row has been successfully updated.
- *   }
- * };
- *
- * row.save(entry, 1, callback);
- *
- * //-
- * // Or update several cells at once.
- * //-
- * row.save(entry, callback);
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * row.save(entry).then(function(data) {
- *   var apiResponse = data[0];
- * });
- */
-Row.prototype.save = function(entry, gaxOptions, callback) {
-  if (is.fn(gaxOptions)) {
-    callback = gaxOptions;
-    gaxOptions = {};
+      const row = rows[0];
+
+      if (!row) {
+        err = new RowError(self.id);
+        callback(err);
+        return;
+      }
+
+      extend(true, self.data, row.data);
+
+      // If the user specifies column names, we'll return back the row data we
+      // received. Otherwise, we'll return the row itself in a typical
+      // GrpcServiceObject#get fashion.
+      callback(null, columns.length ? row.data : self);
+    });
   }
 
-  const mutation = {
-    key: this.id,
-    data: entry,
-    method: Mutation.methods.INSERT,
-  };
+  /**
+   * Get the row's metadata.
+   *
+   * @param {object} [options] Configuration object.
+   * @param {boolean} [options.decode=true] If set to `false` it will not decode
+   *     Buffer values returned from Bigtable.
+   * @param {object} [options.gaxOptions] Request configuration options, outlined
+   *     here: https://googleapis.github.io/gax-nodejs/CallSettings.html.
+   * @param {function} callback The callback function.
+   * @param {?error} callback.err An error returned while making this
+   *     request.
+   * @param {object} callback.metadata The row's metadata.
+   *
+   * @example
+   * row.getMetadata(function(err, metadata, apiResponse) {});
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * row.getMetadata().then(function(data) {
+   *   var metadata = data[0];
+   *   var apiResponse = data[1];
+   * });
+   */
+  getMetadata(options, callback) {
+    if (is.function(options)) {
+      callback = options;
+      options = {};
+    }
 
-  this.table.mutate(mutation, gaxOptions, callback);
-};
+    this.get(options, function(err, row) {
+      if (err) {
+        callback(err);
+        return;
+      }
+
+      callback(null, row.metadata);
+    });
+  }
+
+  /**
+   * Increment a specific column within the row. If the column does not
+   * exist, it is automatically initialized to 0 before being incremented.
+   *
+   * @param {string} column The column we are incrementing a value in.
+   * @param {number} [value] The amount to increment by, defaults to 1.
+   * @param {object} [gaxOptions] Request configuration options, outlined here:
+   *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
+   * @param {function} callback The callback function.
+   * @param {?error} callback.err An error returned while making this
+   *     request.
+   * @param {number} callback.value The updated value of the column.
+   * @param {object} callback.apiResponse The full API response.
+   *
+   * @example
+   * var callback = function(err, value, apiResponse) {
+   *   if (!err) {
+   *     // `value` is the value of the updated column.
+   *   }
+   * };
+   *
+   * row.increment('follows:gwashington', callback);
+   *
+   * //-
+   * // Specify a custom amount to increment the column by.
+   * //-
+   * row.increment('follows:gwashington', 2, callback);
+   *
+   * //-
+   * // To decrement a column, simply supply a negative value.
+   * //-
+   * row.increment('follows:gwashington', -1, callback);
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * row.increment('follows:gwashington').then(function(data) {
+   *   var value = data[0];
+   *   var apiResponse = data[1];
+   * });
+   */
+  increment(column, value, gaxOptions, callback) {
+    // increment('column', callback)
+    if (is.function(value)) {
+      callback = value;
+      value = 1;
+      gaxOptions = {};
+    }
+
+    // increment('column', value, callback)
+    if (is.function(gaxOptions)) {
+      callback = gaxOptions;
+      gaxOptions = {};
+    }
+
+    // increment('column', { gaxOptions }, callback)
+    if (is.object(value)) {
+      callback = gaxOptions;
+      gaxOptions = value;
+      value = 1;
+    }
+
+    const reqOpts = {
+      column,
+      increment: value,
+    };
+
+    this.createRules(reqOpts, gaxOptions, function(err, resp) {
+      if (err) {
+        callback(err, null, resp);
+        return;
+      }
+
+      const data = Row.formatFamilies_(resp.row.families);
+      const value = dotProp.get(data, column.replace(':', '.'))[0].value;
+
+      callback(null, value, resp);
+    });
+  }
+
+  /**
+   * Update the row cells.
+   *
+   * @param {object} key An entry object to be inserted into the row. See
+   *     {@link Table#insert}.
+   * @param {object} [gaxOptions] Request configuration options, outlined here:
+   *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
+   * @param {function} callback The callback function.
+   * @param {?error} callback.err An error returned while making this
+   *     request.
+   * @param {object} callback.apiResponse The full API response.
+   *
+   * @example
+   * var entry = {
+   *   follows: {
+   *     jadams: 1
+   *   }
+   * };
+   *
+   * //-
+   * // Update a single cell.
+   * //-
+   * var callback = function(err, apiResponse) {
+   *   if (!err) {
+   *     // The row has been successfully updated.
+   *   }
+   * };
+   *
+   * row.save(entry, 1, callback);
+   *
+   * //-
+   * // Or update several cells at once.
+   * //-
+   * row.save(entry, callback);
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * row.save(entry).then(function(data) {
+   *   var apiResponse = data[0];
+   * });
+   */
+  save(entry, gaxOptions, callback) {
+    if (is.fn(gaxOptions)) {
+      callback = gaxOptions;
+      gaxOptions = {};
+    }
+
+    const mutation = {
+      key: this.id,
+      data: entry,
+      method: Mutation.methods.INSERT,
+    };
+
+    this.table.mutate(mutation, gaxOptions, callback);
+  }
+}
 
 /*! Developer Documentation
  *

--- a/src/row.js
+++ b/src/row.js
@@ -29,7 +29,7 @@ const Mutation = require('./mutation.js');
  * @private
  */
 const RowError = createErrorClass('RowError', function(row) {
-  this.message = 'Unknown row: ' + row + '.';
+  this.message = `Unknown row: ${row}.`;
   this.code = 404;
 });
 

--- a/src/table.js
+++ b/src/table.js
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-'use strict';
-
 var arrify = require('arrify');
 var common = require('@google-cloud/common');
 var commonGrpc = require('@google-cloud/common-grpc');

--- a/src/table.js
+++ b/src/table.js
@@ -74,7 +74,7 @@ class Table {
    * // 'projects/my-project/zones/my-zone/instances/my-instance/tables/my-table'
    */
   static formatName_(instanceName, name) {
-    if (name.indexOf('/') > -1) {
+    if (name.includes('/')) {
       return name;
     }
 

--- a/src/table.js
+++ b/src/table.js
@@ -811,7 +811,9 @@ class Table {
         return;
       }
 
-      const families = Object.keys(metadata.columnFamilies).map(function(familyId) {
+      const families = Object.keys(metadata.columnFamilies).map(function(
+        familyId
+      ) {
         const family = self.family(familyId);
         family.metadata = metadata.columnFamilies[familyId];
         return family;
@@ -1010,7 +1012,9 @@ class Table {
       gaxOptions = {};
     }
 
-    entries = arrify(entries).map(propAssign('method', Mutation.methods.INSERT));
+    entries = arrify(entries).map(
+      propAssign('method', Mutation.methods.INSERT)
+    );
 
     return this.mutate(entries, gaxOptions, callback);
   }

--- a/src/table.js
+++ b/src/table.js
@@ -78,7 +78,7 @@ class Table {
       return name;
     }
 
-    return instanceName + '/tables/' + name;
+    return `${instanceName}/tables/${name}`;
   }
 
   /**

--- a/src/table.js
+++ b/src/table.js
@@ -14,20 +14,20 @@
  * limitations under the License.
  */
 
-var arrify = require('arrify');
-var common = require('@google-cloud/common');
-var commonGrpc = require('@google-cloud/common-grpc');
-var concat = require('concat-stream');
-var flatten = require('lodash.flatten');
-var is = require('is');
-var propAssign = require('prop-assign');
-var pumpify = require('pumpify');
-var through = require('through2');
+const arrify = require('arrify');
+const common = require('@google-cloud/common');
+const commonGrpc = require('@google-cloud/common-grpc');
+const concat = require('concat-stream');
+const flatten = require('lodash.flatten');
+const is = require('is');
+const propAssign = require('prop-assign');
+const pumpify = require('pumpify');
+const through = require('through2');
 
-var Family = require('./family.js');
-var Filter = require('./filter.js');
-var Mutation = require('./mutation.js');
-var Row = require('./row.js');
+const Family = require('./family.js');
+const Filter = require('./filter.js');
+const Mutation = require('./mutation.js');
+const Row = require('./row.js');
 const ChunkTransformer = require('./chunktransformer.js');
 
 // See protos/google/rpc/code.proto
@@ -51,7 +51,7 @@ function Table(instance, name) {
   this.bigtable = instance.bigtable;
   this.instance = instance;
 
-  var id = Table.formatName_(instance.id, name);
+  const id = Table.formatName_(instance.id, name);
 
   this.id = id;
   this.name = id.split('/').pop();
@@ -112,13 +112,13 @@ Table.formatName_ = function(instanceName, name) {
  * // }
  */
 Table.createPrefixRange_ = function(start) {
-  var prefix = start.replace(new RegExp('[\xff]+$'), '');
-  var endKey = '';
+  const prefix = start.replace(new RegExp('[\xff]+$'), '');
+  let endKey = '';
 
   if (prefix) {
-    var position = prefix.length - 1;
-    var charCode = prefix.charCodeAt(position);
-    var nextChar = String.fromCharCode(charCode + 1);
+    const position = prefix.length - 1;
+    const charCode = prefix.charCodeAt(position);
+    const nextChar = String.fromCharCode(charCode + 1);
 
     endKey = prefix.substring(0, position) + nextChar;
   }
@@ -241,7 +241,7 @@ Table.prototype.create = function(options, callback) {
  * };
  */
 Table.prototype.createFamily = function(name, options, callback) {
-  var self = this;
+  const self = this;
 
   if (is.function(options)) {
     callback = options;
@@ -252,7 +252,7 @@ Table.prototype.createFamily = function(name, options, callback) {
     throw new Error('A name is required to create a family.');
   }
 
-  var mod = {
+  const mod = {
     id: name,
     create: {},
   };
@@ -261,7 +261,7 @@ Table.prototype.createFamily = function(name, options, callback) {
     mod.create.gcRule = Family.formatRule_(options.rule);
   }
 
-  var reqOpts = {
+  const reqOpts = {
     name: this.id,
     modifications: [mod],
   };
@@ -279,7 +279,7 @@ Table.prototype.createFamily = function(name, options, callback) {
         return;
       }
 
-      var family = self.family(resp.name);
+      const family = self.family(resp.name);
       family.metadata = resp;
 
       callback(null, family, resp);
@@ -389,7 +389,7 @@ Table.prototype.createFamily = function(name, options, callback) {
  * });
  */
 Table.prototype.createReadStream = function(options) {
-  var self = this;
+  const self = this;
 
   options = options || {};
   let maxRetries = is.number(this.maxRetries) ? this.maxRetries : 3;
@@ -437,12 +437,12 @@ Table.prototype.createReadStream = function(options) {
     let lastRowKey = chunkTransformer ? chunkTransformer.lastRowKey : '';
     chunkTransformer = new ChunkTransformer({decode: options.decode});
 
-    var reqOpts = {
+    const reqOpts = {
       tableName: this.id,
       appProfileId: this.bigtable.appProfileId,
     };
 
-    var retryOpts = {
+    const retryOpts = {
       currentRetryAttempt: numRequestsMade,
     };
 
@@ -649,7 +649,7 @@ Table.prototype.deleteRows = function(prefix, gaxOptions, callback) {
     throw new Error('A prefix is required for deleteRows.');
   }
 
-  var reqOpts = {
+  const reqOpts = {
     name: this.id,
     rowKeyPrefix: Mutation.convertToBytes(prefix),
   };
@@ -756,15 +756,15 @@ Table.prototype.family = function(name) {
  * });
  */
 Table.prototype.get = function(options, callback) {
-  var self = this;
+  const self = this;
 
   if (is.fn(options)) {
     callback = options;
     options = {};
   }
 
-  var autoCreate = !!options.autoCreate;
-  var gaxOptions = options.gaxOptions;
+  const autoCreate = !!options.autoCreate;
+  const gaxOptions = options.gaxOptions;
 
   this.getMetadata({gaxOptions}, function(err, metadata) {
     if (err) {
@@ -810,7 +810,7 @@ Table.prototype.get = function(options, callback) {
  * });
  */
 Table.prototype.getFamilies = function(gaxOptions, callback) {
-  var self = this;
+  const self = this;
 
   if (is.fn(gaxOptions)) {
     callback = gaxOptions;
@@ -823,8 +823,8 @@ Table.prototype.getFamilies = function(gaxOptions, callback) {
       return;
     }
 
-    var families = Object.keys(metadata.columnFamilies).map(function(familyId) {
-      var family = self.family(familyId);
+    const families = Object.keys(metadata.columnFamilies).map(function(familyId) {
+      const family = self.family(familyId);
       family.metadata = metadata.columnFamilies[familyId];
       return family;
     });
@@ -862,14 +862,14 @@ Table.prototype.getFamilies = function(gaxOptions, callback) {
  * });
  */
 Table.prototype.getMetadata = function(options, callback) {
-  var self = this;
+  const self = this;
 
   if (is.function(options)) {
     callback = options;
     options = {};
   }
 
-  var reqOpts = {
+  const reqOpts = {
     name: this.id,
     view: Table.VIEWS[options.view || 'unspecified'],
   };
@@ -1136,7 +1136,7 @@ Table.prototype.insert = function(entries, gaxOptions, callback) {
  * });
  */
 Table.prototype.mutate = function(entries, gaxOptions, callback) {
-  var self = this;
+  const self = this;
 
   if (is.fn(gaxOptions)) {
     callback = gaxOptions;
@@ -1145,12 +1145,12 @@ Table.prototype.mutate = function(entries, gaxOptions, callback) {
 
   entries = flatten(arrify(entries));
 
-  var numRequestsMade = 0;
+  let numRequestsMade = 0;
 
-  var maxRetries = is.number(this.maxRetries) ? this.maxRetries : 3;
-  var pendingEntryIndices = new Set(entries.map((entry, index) => index));
-  var entryToIndex = new Map(entries.map((entry, index) => [entry, index]));
-  var mutationErrorsByEntryIndex = new Map();
+  const maxRetries = is.number(this.maxRetries) ? this.maxRetries : 3;
+  const pendingEntryIndices = new Set(entries.map((entry, index) => index));
+  const entryToIndex = new Map(entries.map((entry, index) => [entry, index]));
+  const mutationErrorsByEntryIndex = new Map();
 
   function onBatchResponse(err) {
     if (err) {
@@ -1164,7 +1164,7 @@ Table.prototype.mutate = function(entries, gaxOptions, callback) {
     }
 
     if (mutationErrorsByEntryIndex.size !== 0) {
-      var mutationErrors = Array.from(mutationErrorsByEntryIndex.values());
+      const mutationErrors = Array.from(mutationErrorsByEntryIndex.values());
       err = new common.util.PartialFailureError({
         errors: mutationErrors,
       });
@@ -1174,17 +1174,17 @@ Table.prototype.mutate = function(entries, gaxOptions, callback) {
   }
 
   function makeNextBatchRequest() {
-    var entryBatch = entries.filter((entry, index) => {
+    const entryBatch = entries.filter((entry, index) => {
       return pendingEntryIndices.has(index);
     });
 
-    var reqOpts = {
+    const reqOpts = {
       tableName: self.id,
       appProfileId: self.bigtable.appProfileId,
       entries: entryBatch.map(Mutation.parse),
     };
 
-    var retryOpts = {
+    const retryOpts = {
       currentRetryAttempt: numRequestsMade,
     };
 
@@ -1207,8 +1207,8 @@ Table.prototype.mutate = function(entries, gaxOptions, callback) {
       })
       .on('data', function(obj) {
         obj.entries.forEach(function(entry) {
-          var originalEntry = entryBatch[entry.index];
-          var originalEntriesIndex = entryToIndex.get(originalEntry);
+          const originalEntry = entryBatch[entry.index];
+          const originalEntriesIndex = entryToIndex.get(originalEntry);
 
           // Mutation was successful.
           if (entry.status.code === 0) {
@@ -1221,7 +1221,7 @@ Table.prototype.mutate = function(entries, gaxOptions, callback) {
             pendingEntryIndices.delete(originalEntriesIndex);
           }
 
-          var status = commonGrpc.Service.decorateStatus_(entry.status);
+          const status = commonGrpc.Service.decorateStatus_(entry.status);
           status.entry = originalEntry;
 
           mutationErrorsByEntryIndex.set(originalEntriesIndex, status);
@@ -1322,7 +1322,7 @@ Table.prototype.sampleRowKeys = function(gaxOptions, callback) {
  *   });
  */
 Table.prototype.sampleRowKeysStream = function(gaxOptions) {
-  var reqOpts = {
+  const reqOpts = {
     tableName: this.id,
     appProfileId: this.bigtable.appProfileId,
   };
@@ -1368,7 +1368,7 @@ Table.prototype.truncate = function(gaxOptions, callback) {
     gaxOptions = {};
   }
 
-  var reqOpts = {
+  const reqOpts = {
     name: this.id,
     deleteAllDataFromTable: true,
   };

--- a/src/table.js
+++ b/src/table.js
@@ -126,7 +126,7 @@ Table.createPrefixRange_ = function(start) {
   }
 
   return {
-    start: start,
+    start,
     end: {
       value: endKey,
       inclusive: !endKey,
@@ -272,7 +272,7 @@ Table.prototype.createFamily = function(name, options, callback) {
     {
       client: 'BigtableTableAdminClient',
       method: 'modifyColumnFamilies',
-      reqOpts: reqOpts,
+      reqOpts,
       gaxOpts: options.gaxOptions,
     },
     function(err, resp) {
@@ -525,9 +525,9 @@ Table.prototype.createReadStream = function(options) {
     const requestStream = this.bigtable.request({
       client: 'BigtableClient',
       method: 'readRows',
-      reqOpts: reqOpts,
+      reqOpts,
       gaxOpts: options.gaxOptions,
-      retryOpts: retryOpts,
+      retryOpts,
     });
 
     requestStream.on('request', () => numRequestsMade++);
@@ -660,7 +660,7 @@ Table.prototype.deleteRows = function(prefix, gaxOptions, callback) {
     {
       client: 'BigtableTableAdminClient',
       method: 'dropRowRange',
-      reqOpts: reqOpts,
+      reqOpts,
       gaxOpts: gaxOptions,
     },
     callback
@@ -880,7 +880,7 @@ Table.prototype.getMetadata = function(options, callback) {
     {
       client: 'BigtableTableAdminClient',
       method: 'getTable',
-      reqOpts: reqOpts,
+      reqOpts,
       gaxOpts: options.gaxOptions,
     },
     function(...args) {
@@ -1194,9 +1194,9 @@ Table.prototype.mutate = function(entries, gaxOptions, callback) {
       .request({
         client: 'BigtableClient',
         method: 'mutateRows',
-        reqOpts: reqOpts,
+        reqOpts,
         gaxOpts: gaxOptions,
-        retryOpts: retryOpts,
+        retryOpts,
       })
       .on('request', () => numRequestsMade++)
       .on('error', err => {
@@ -1333,7 +1333,7 @@ Table.prototype.sampleRowKeysStream = function(gaxOptions) {
     this.bigtable.request({
       client: 'BigtableClient',
       method: 'sampleRowKeys',
-      reqOpts: reqOpts,
+      reqOpts,
       gaxOpts: gaxOptions,
     }),
     through.obj(function(key, enc, next) {
@@ -1379,7 +1379,7 @@ Table.prototype.truncate = function(gaxOptions, callback) {
     {
       client: 'BigtableTableAdminClient',
       method: 'dropRowRange',
-      reqOpts: reqOpts,
+      reqOpts,
       gaxOpts: gaxOptions,
     },
     callback

--- a/src/table.js
+++ b/src/table.js
@@ -47,14 +47,1330 @@ const RETRYABLE_STATUS_CODES = new Set([4, 10, 14]);
  * const instance = bigtable.instance('my-instance');
  * const table = instance.table('prezzy');
  */
-function Table(instance, name) {
-  this.bigtable = instance.bigtable;
-  this.instance = instance;
+class Table {
+  constructor(instance, name) {
+    this.bigtable = instance.bigtable;
+    this.instance = instance;
 
-  const id = Table.formatName_(instance.id, name);
+    const id = Table.formatName_(instance.id, name);
 
-  this.id = id;
-  this.name = id.split('/').pop();
+    this.id = id;
+    this.name = id.split('/').pop();
+  }
+
+  /**
+   * Formats the table name to include the Bigtable cluster.
+   *
+   * @private
+   *
+   * @param {string} instanceName The formatted instance name.
+   * @param {string} name The table name.
+   *
+   * @example
+   * Table.formatName_(
+   *   'projects/my-project/zones/my-zone/instances/my-instance',
+   *   'my-table'
+   * );
+   * // 'projects/my-project/zones/my-zone/instances/my-instance/tables/my-table'
+   */
+  static formatName_(instanceName, name) {
+    if (name.indexOf('/') > -1) {
+      return name;
+    }
+
+    return instanceName + '/tables/' + name;
+  }
+
+  /**
+   * Creates a range based off of a key prefix.
+   *
+   * @private
+   *
+   * @param {string} start The key prefix/starting bound.
+   * @returns {object} range
+   *
+   * @example
+   * Table.createPrefixRange_('start');
+   * // => {
+   * //   start: 'start',
+   * //   end: {
+   * //     value: 'staru',
+   * //     inclusive: false
+   * //   }
+   * // }
+   */
+  static createPrefixRange_(start) {
+    const prefix = start.replace(new RegExp('[\xff]+$'), '');
+    let endKey = '';
+
+    if (prefix) {
+      const position = prefix.length - 1;
+      const charCode = prefix.charCodeAt(position);
+      const nextChar = String.fromCharCode(charCode + 1);
+
+      endKey = prefix.substring(0, position) + nextChar;
+    }
+
+    return {
+      start,
+      end: {
+        value: endKey,
+        inclusive: !endKey,
+      },
+    };
+  }
+
+  /**
+   * Create a table.
+   *
+   * @param {object} [options] See {@link Instance#createTable}.
+   * @param {object} [options.gaxOptions]  Request configuration options, outlined
+   *     here: https://googleapis.github.io/gax-nodejs/global.html#CallOptions.
+   * @param {function} callback The callback function.
+   * @param {?error} callback.err An error returned while making this request.
+   * @param {Table} callback.table The newly created table.
+   * @param {object} callback.apiResponse The full API response.
+   * @example
+   * table.create(function(err, table, apiResponse) {
+   *   if (!err) {
+   *     // The table was created successfully.
+   *   }
+   * });
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * table.create().then(function(data) {
+   *   var table = data[0];
+   *   var apiResponse = data[1];
+   * });
+   */
+  create(options, callback) {
+    if (is.fn(options)) {
+      callback = options;
+      options = {};
+    }
+
+    this.instance.createTable(this.name, options, callback);
+  }
+
+  /**
+   * Create a column family.
+   *
+   * Optionally you can send garbage collection rules and when creating a family.
+   * Garbage collection executes opportunistically in the background, so it's
+   * possible for reads to return a cell even if it matches the active expression
+   * for its family.
+   *
+   * @see [Garbage Collection Proto Docs]{@link https://github.com/googleapis/googleapis/blob/master/google/bigtable/admin/table/v1/bigtable_table_data.proto#L59}
+   *
+   * @throws {error} If a name is not provided.
+   *
+   * @param {string} name The name of column family.
+   * @param {object} [options] Configuration object.
+   * @param {object} [options.gaxOptions] Request configuration options, outlined
+   *     here: https://googleapis.github.io/gax-nodejs/global.html#CallOptions.
+   * @param {object} [options.rule] Garbage collection rule
+   * @param {object} [options.rule.age] Delete cells in a column older than the
+   *     given age. Values must be at least 1 millisecond.
+   * @param {number} [options.rule.versions] Maximum number of versions to delete
+   *     cells in a column, except for the most recent.
+   * @param {boolean} [options.rule.intersect] Cells to delete should match all
+   *     rules.
+   * @param {boolean} [options.rule.union] Cells to delete should match any of the
+   *     rules.
+   * @param {function} callback The callback function.
+   * @param {?error} callback.err An error returned while making this request.
+   * @param {Family} callback.family The newly created Family.
+   * @param {object} callback.apiResponse The full API response.
+   *
+   * @example
+   * const Bigtable = require('@google-cloud/bigtable');
+   * const bigtable = new Bigtable();
+   * const instance = bigtable.instance('my-instance');
+   * const table = instance.table('prezzy');
+   *
+   * const callback = function(err, family, apiResponse) {
+   *   // `family` is a Family object
+   * };
+   *
+   * const options={};
+   *
+   * options.rule = {
+   *   age: {
+   *     seconds: 0,
+   *     nanos: 5000
+   *   },
+   *   versions: 3,
+   *   union: true
+   * };
+   *
+   * table.createFamily('follows', options, callback);
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * table.createFamily('follows').then(function(data) {
+   *   const family = data[0];
+   *   const apiResponse = data[1];
+   * });
+   *
+   * // Note that rules can have nested rules. For example The following rule
+   * // will delete cells that are either older than 10 versions OR if the cell
+   * // is is a month old and has at least 2 newer version.
+   * // Essentially: (version > 10 OR (age > 30 AND version > 2))
+   * const rule = {
+   *   union: true,
+   *   versions: 10,
+   *   rule: {
+   *     versions: 2,
+   *     age: { seconds: 60 * 60 * 24 * 30 }, // one month
+   *   },
+   * };
+   */
+  createFamily(name, options, callback) {
+    const self = this;
+
+    if (is.function(options)) {
+      callback = options;
+      options = {};
+    }
+
+    if (!name) {
+      throw new Error('A name is required to create a family.');
+    }
+
+    const mod = {
+      id: name,
+      create: {},
+    };
+
+    if (options.rule) {
+      mod.create.gcRule = Family.formatRule_(options.rule);
+    }
+
+    const reqOpts = {
+      name: this.id,
+      modifications: [mod],
+    };
+
+    this.bigtable.request(
+      {
+        client: 'BigtableTableAdminClient',
+        method: 'modifyColumnFamilies',
+        reqOpts,
+        gaxOpts: options.gaxOptions,
+      },
+      function(err, resp) {
+        if (err) {
+          callback(err, null, resp);
+          return;
+        }
+
+        const family = self.family(resp.name);
+        family.metadata = resp;
+
+        callback(null, family, resp);
+      }
+    );
+  }
+
+  /**
+   * Get {@link Row} objects for the rows currently in your table as a
+   * readable object stream.
+   *
+   * @param {object} [options] Configuration object.
+   * @param {boolean} [options.decode=true] If set to `false` it will not decode
+   *     Buffer values returned from Bigtable.
+   * @param {string} [options.end] End value for key range.
+   * @param {Filter} [options.filter] Row filters allow you to
+   *     both make advanced queries and format how the data is returned.
+   * @param {object} [options.gaxOptions] Request configuration options, outlined
+   *     here: https://googleapis.github.io/gax-nodejs/CallSettings.html.
+   * @param {string[]} [options.keys] A list of row keys.
+   * @param {number} [options.limit] Maximum number of rows to be returned.
+   * @param {string} [options.prefix] Prefix that the row key must match.
+   * @param {string[]} [options.prefixes] List of prefixes that a row key must
+   *     match.
+   * @param {object[]} [options.ranges] A list of key ranges.
+   * @param {string} [options.start] Start value for key range.
+   * @returns {stream}
+   *
+   * @example
+   * const Bigtable = require('@google-cloud/bigtable');
+   * const bigtable = new Bigtable();
+   * const instance = bigtable.instance('my-instance');
+   * const table = instance.table('prezzy');
+   *
+   * table.createReadStream()
+   *   .on('error', console.error)
+   *   .on('data', function(row) {
+   *     // `row` is a Row object.
+   *   })
+   *   .on('end', function() {
+   *     // All rows retrieved.
+   *   });
+   *
+   * //-
+   * // If you anticipate many results, you can end a stream early to prevent
+   * // unnecessary processing.
+   * //-
+   * table.createReadStream()
+   *   .on('data', function(row) {
+   *     this.end();
+   *   });
+   *
+   * //-
+   * // Specify arbitrary keys for a non-contiguous set of rows.
+   * // The total size of the keys must remain under 1MB, after encoding.
+   * //-
+   * table.createReadStream({
+   *   keys: [
+   *     'alincoln',
+   *     'gwashington'
+   *   ]
+   * });
+   *
+   * //-
+   * // Scan for row keys that contain a specific prefix.
+   * //-
+   * table.createReadStream({
+   *   prefix: 'gwash'
+   * });
+   *
+   * //-
+   * // Specify a contiguous range of rows to read by supplying `start` and `end`
+   * // keys.
+   * //
+   * // If the `start` key is omitted, it is interpreted as an empty string.
+   * // If the `end` key is omitted, it is interpreted as infinity.
+   * //-
+   * table.createReadStream({
+   *   start: 'alincoln',
+   *   end: 'gwashington'
+   * });
+   *
+   * //-
+   * // Specify multiple ranges.
+   * //-
+   * table.createReadStream({
+   *   ranges: [{
+   *     start: 'alincoln',
+   *     end: 'gwashington'
+   *   }, {
+   *     start: 'tjefferson',
+   *     end: 'jadams'
+   *   }]
+   * });
+   *
+   * //-
+   * // Apply a {@link Filter} to the contents of the specified rows.
+   * //-
+   * table.createReadStream({
+   *   filter: [
+   *     {
+   *       column: 'gwashington'
+   *     }, {
+   *       value: 1
+   *     }
+   *   ]
+   * });
+   */
+  createReadStream(options) {
+    const self = this;
+
+    options = options || {};
+    let maxRetries = is.number(this.maxRetries) ? this.maxRetries : 3;
+
+    let rowKeys;
+    let ranges = options.ranges || [];
+    let filter;
+    let rowsLimit;
+    let rowsRead = 0;
+    let numRequestsMade = 0;
+
+    if (options.start || options.end) {
+      ranges.push({
+        start: options.start,
+        end: options.end,
+      });
+    }
+
+    if (options.keys) {
+      rowKeys = options.keys;
+    }
+
+    if (options.prefix) {
+      ranges.push(Table.createPrefixRange_(options.prefix));
+    }
+
+    if (options.prefixes) {
+      options.prefixes.forEach(function(prefix) {
+        ranges.push(Table.createPrefixRange_(prefix));
+      });
+    }
+
+    if (options.filter) {
+      filter = Filter.parse(options.filter);
+    }
+
+    if (options.limit) {
+      rowsLimit = options.limit;
+    }
+
+    const userStream = through.obj();
+    let chunkTransformer;
+
+    const makeNewRequest = () => {
+      let lastRowKey = chunkTransformer ? chunkTransformer.lastRowKey : '';
+      chunkTransformer = new ChunkTransformer({decode: options.decode});
+
+      const reqOpts = {
+        tableName: this.id,
+        appProfileId: this.bigtable.appProfileId,
+      };
+
+      const retryOpts = {
+        currentRetryAttempt: numRequestsMade,
+      };
+
+      if (lastRowKey) {
+        const lessThan = (lhs, rhs) => {
+          const lhsBytes = Mutation.convertToBytes(lhs);
+          const rhsBytes = Mutation.convertToBytes(rhs);
+          return lhsBytes.compare(rhsBytes) === -1;
+        };
+        const greaterThan = (lhs, rhs) => lessThan(rhs, lhs);
+        const greaterThanOrEqualTo = (lhs, rhs) => !lessThan(rhs, lhs);
+
+        if (ranges.length === 0) {
+          ranges.push({
+            start: {
+              value: lastRowKey,
+              inclusive: false,
+            },
+          });
+        } else {
+          // Readjust and/or remove ranges based on previous valid row reads.
+
+          // Iterate backward since items may need to be removed.
+          for (let index = ranges.length - 1; index >= 0; index--) {
+            const range = ranges[index];
+            const startValue = is.object(range.start)
+              ? range.start.value
+              : range.start;
+            const endValue = is.object(range.end) ? range.end.value : range.end;
+            const isWithinStart =
+              !startValue || greaterThanOrEqualTo(startValue, lastRowKey);
+            const isWithinEnd = !endValue || lessThan(lastRowKey, endValue);
+            if (isWithinStart) {
+              if (isWithinEnd) {
+                // The lastRowKey is within this range, adjust the start value.
+                range.start = {
+                  value: lastRowKey,
+                  inclusive: false,
+                };
+              } else {
+                // The lastRowKey is past this range, remove this range.
+                ranges.splice(index, 1);
+              }
+            }
+          }
+        }
+
+        // Remove rowKeys already read.
+        if (rowKeys) {
+          rowKeys = rowKeys.filter(rowKey => greaterThan(rowKey, lastRowKey));
+          if (rowKeys.length === 0) {
+            rowKeys = null;
+          }
+        }
+      }
+      if (rowKeys || ranges.length) {
+        reqOpts.rows = {};
+
+        if (rowKeys) {
+          reqOpts.rows.rowKeys = rowKeys.map(Mutation.convertToBytes);
+        }
+
+        if (ranges.length) {
+          reqOpts.rows.rowRanges = ranges.map(function(range) {
+            return Filter.createRange(range.start, range.end, 'Key');
+          });
+        }
+      }
+
+      if (filter) {
+        reqOpts.filter = filter;
+      }
+
+      if (rowsLimit) {
+        reqOpts.rowsLimit = rowsLimit - rowsRead;
+      }
+
+      const requestStream = this.bigtable.request({
+        client: 'BigtableClient',
+        method: 'readRows',
+        reqOpts,
+        gaxOpts: options.gaxOptions,
+        retryOpts,
+      });
+
+      requestStream.on('request', () => numRequestsMade++);
+
+      const rowStream = pumpify.obj([
+        requestStream,
+        chunkTransformer,
+        through.obj(function(rowData, enc, next) {
+          if (chunkTransformer._destroyed || userStream._writableState.ended) {
+            return next();
+          }
+          numRequestsMade = 0;
+          rowsRead++;
+          const row = self.row(rowData.key);
+          row.data = rowData.data;
+          next(null, row);
+        }),
+      ]);
+
+      rowStream.on('error', error => {
+        rowStream.unpipe(userStream);
+        if (
+          numRequestsMade <= maxRetries &&
+          RETRYABLE_STATUS_CODES.has(error.code)
+        ) {
+          makeNewRequest();
+        } else {
+          userStream.emit('error', error);
+        }
+      });
+      rowStream.pipe(userStream);
+    };
+
+    makeNewRequest();
+    return userStream;
+  }
+
+  /**
+   * Delete the table.
+   *
+   * @param {object} [gaxOptions] Request configuration options, outlined
+   *     here: https://googleapis.github.io/gax-nodejs/CallSettings.html.
+   * @param {function} [callback] The callback function.
+   * @param {?error} callback.err An error returned while making this
+   *     request.
+   * @param {object} callback.apiResponse The full API response.
+   *
+   * @example
+   * table.delete(function(err, apiResponse) {});
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * table.delete().then(function(data) {
+   *   var apiResponse = data[0];
+   * });
+   */
+  delete(gaxOptions, callback) {
+    if (is.fn(gaxOptions)) {
+      callback = gaxOptions;
+      gaxOptions = {};
+    }
+
+    this.bigtable.request(
+      {
+        client: 'BigtableTableAdminClient',
+        method: 'deleteTable',
+        reqOpts: {
+          name: this.id,
+        },
+        gaxOpts: gaxOptions,
+      },
+      callback
+    );
+  }
+
+  /**
+   * Delete all rows in the table, optionally corresponding to a particular
+   * prefix.
+   *
+   * @throws {error} If a prefix is not provided.
+   *
+   * @param {string} prefix Row key prefix.
+   * @param {object} [gaxOptions] Request configuration options, outlined
+   *     here: https://googleapis.github.io/gax-nodejs/CallSettings.html.
+   * @param {function} callback The callback function.
+   * @param {?error} callback.err An error returned while making this request.
+   * @param {object} callback.apiResponse The full API response.
+   *
+   * @example
+   * const Bigtable = require('@google-cloud/bigtable');
+   * const bigtable = new Bigtable();
+   * const instance = bigtable.instance('my-instance');
+   * const table = instance.table('prezzy');
+   *
+   * //-
+   * // You can supply a prefix to delete all corresponding rows.
+   * //-
+   * const callback = function(err, apiResponse) {
+   *   if (!err) {
+   *     // Rows successfully deleted.
+   *   }
+   * };
+   *
+   * table.deleteRows('alincoln', callback);
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * table.deleteRows('alincoln').then(function(data) {
+   *   const apiResponse = data[0];
+   * });
+   */
+  deleteRows(prefix, gaxOptions, callback) {
+    if (is.function(gaxOptions)) {
+      callback = gaxOptions;
+      gaxOptions = {};
+    }
+
+    if (!prefix || is.fn(prefix)) {
+      throw new Error('A prefix is required for deleteRows.');
+    }
+
+    const reqOpts = {
+      name: this.id,
+      rowKeyPrefix: Mutation.convertToBytes(prefix),
+    };
+
+    this.bigtable.request(
+      {
+        client: 'BigtableTableAdminClient',
+        method: 'dropRowRange',
+        reqOpts,
+        gaxOpts: gaxOptions,
+      },
+      callback
+    );
+  }
+
+  /**
+   * Check if a table exists.
+   *
+   * @param {object} [gaxOptions] Request configuration options, outlined
+   *     here: https://googleapis.github.io/gax-nodejs/CallSettings.html.
+   * @param {function} callback The callback function.
+   * @param {?error} callback.err An error returned while making this
+   *     request.
+   * @param {boolean} callback.exists Whether the table exists or not.
+   *
+   * @example
+   * table.exists(function(err, exists) {});
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * table.exists().then(function(data) {
+   *   var exists = data[0];
+   * });
+   */
+  exists(gaxOptions, callback) {
+    if (is.fn(gaxOptions)) {
+      callback = gaxOptions;
+      gaxOptions = {};
+    }
+
+    this.getMetadata(gaxOptions, function(err) {
+      if (err) {
+        if (err.code === 5) {
+          callback(null, false);
+          return;
+        }
+
+        callback(err);
+        return;
+      }
+
+      callback(null, true);
+    });
+  }
+
+  /**
+   * Get a reference to a Table Family.
+   *
+   * @throws {error} If a name is not provided.
+   *
+   * @param {string} name The family name.
+   * @returns {Family}
+   *
+   * @example
+   * const family = table.family('my-family');
+   */
+  family(name) {
+    if (!name) {
+      throw new Error('A family name must be provided.');
+    }
+
+    return new Family(this, name);
+  }
+
+  /**
+   * Get a table if it exists.
+   *
+   * You may optionally use this to "get or create" an object by providing an
+   * object with `autoCreate` set to `true`. Any extra configuration that is
+   * normally required for the `create` method must be contained within this
+   * object as well.
+   *
+   * @param {object} [options] Configuration object.
+   * @param {boolean} [options.autoCreate=false] Automatically create the
+   *     instance if it does not already exist.
+   * @param {object} [options.gaxOptions] Request configuration options, outlined
+   *     here: https://googleapis.github.io/gax-nodejs/CallSettings.html.
+   * @param {?error} callback.error An error returned while making this request.
+   * @param {Table} callback.table The Table object.
+   * @param {object} callback.apiResponse The resource as it exists in the API.
+   *
+   * @example
+   * table.get(function(err, table, apiResponse) {
+   *   // The `table` data has been populated.
+   * });
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * table.get().then(function(data) {
+   *   var table = data[0];
+   *   var apiResponse = data[0];
+   * });
+   */
+  get(options, callback) {
+    const self = this;
+
+    if (is.fn(options)) {
+      callback = options;
+      options = {};
+    }
+
+    const autoCreate = !!options.autoCreate;
+    const gaxOptions = options.gaxOptions;
+
+    this.getMetadata({gaxOptions}, function(err, metadata) {
+      if (err) {
+        if (err.code === 5 && autoCreate) {
+          self.create({gaxOptions}, callback);
+          return;
+        }
+
+        callback(err);
+        return;
+      }
+
+      callback(null, self, metadata);
+    });
+  }
+
+  /**
+   * Get Family objects for all the column familes in your table.
+   *
+   * @param {object} [gaxOptions] Request configuration options, outlined here:
+   *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
+   * @param {function} callback The callback function.
+   * @param {?error} callback.err An error returned while making this request.
+   * @param {Family[]} callback.families The list of families.
+   * @param {object} callback.apiResponse The full API response.
+   *
+   * @example
+   * const Bigtable = require('@google-cloud/bigtable');
+   * const bigtable = new Bigtable();
+   * const instance = bigtable.instance('my-instance');
+   * const table = instance.table('prezzy');
+   *
+   * table.getFamilies(function(err, families, apiResponse) {
+   *   // `families` is an array of Family objects.
+   * });
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * table.getFamilies().then(function(data) {
+   *   var families = data[0];
+   *   var apiResponse = data[1];
+   * });
+   */
+  getFamilies(gaxOptions, callback) {
+    const self = this;
+
+    if (is.fn(gaxOptions)) {
+      callback = gaxOptions;
+      gaxOptions = {};
+    }
+
+    this.getMetadata({gaxOptions}, function(err, metadata) {
+      if (err) {
+        callback(err);
+        return;
+      }
+
+      const families = Object.keys(metadata.columnFamilies).map(function(familyId) {
+        const family = self.family(familyId);
+        family.metadata = metadata.columnFamilies[familyId];
+        return family;
+      });
+
+      callback(null, families, metadata.columnFamilies);
+    });
+  }
+
+  /**
+   * Get the table's metadata.
+   *
+   * @param {object} [options] Table request options.
+   * @param {object} [options.gaxOptions] Request configuration options, outlined
+   *     here: https://googleapis.github.io/gax-nodejs/CallSettings.html.
+   * @param {string} [options.view] The view to be applied to the table fields.
+   * @param {function} [callback] The callback function.
+   * @param {?error} callback.err An error returned while making this
+   *     request.
+   * @param {object} callback.metadata The table's metadata.
+   *
+   * @example
+   * const Bigtable = require('@google-cloud/bigtable');
+   * const bigtable = new Bigtable();
+   * const instance = bigtable.instance('my-instance');
+   * const table = instance.table('prezzy');
+   *
+   * table.getMetadata(function(err, metadata) {});
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * table.getMetadata().then(function(data) {
+   *   var metadata = data[0];
+   *   var apiResponse = data[1];
+   * });
+   */
+  getMetadata(options, callback) {
+    const self = this;
+
+    if (is.function(options)) {
+      callback = options;
+      options = {};
+    }
+
+    const reqOpts = {
+      name: this.id,
+      view: Table.VIEWS[options.view || 'unspecified'],
+    };
+
+    this.bigtable.request(
+      {
+        client: 'BigtableTableAdminClient',
+        method: 'getTable',
+        reqOpts,
+        gaxOpts: options.gaxOptions,
+      },
+      function(...args) {
+        if (args[1]) {
+          self.metadata = args[1];
+        }
+
+        callback(...args);
+      }
+    );
+  }
+
+  /**
+   * Get {@link Row} objects for the rows currently in your table.
+   *
+   * This method is not recommended for large datasets as it will buffer all rows
+   * before returning the results. Instead we recommend using the streaming API
+   * via {@link Table#createReadStream}.
+   *
+   * @param {object} [options] Configuration object. See
+   *     {@link Table#createReadStream} for a complete list of options.
+   * @param {object} [options.gaxOptions] Request configuration options, outlined
+   *     here: https://googleapis.github.io/gax-nodejs/CallSettings.html.
+   * @param {function} callback The callback function.
+   * @param {?error} callback.err An error returned while making this request.
+   * @param {Row[]} callback.rows List of Row objects.
+   *
+   * @example
+   * const Bigtable = require('@google-cloud/bigtable');
+   * const bigtable = new Bigtable();
+   * const instance = bigtable.instance('my-instance');
+   * const table = instance.table('prezzy');
+   *
+   * table.getRows(function(err, rows) {
+   *   if (!err) {
+   *     // `rows` is an array of Row objects.
+   *   }
+   * });
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * table.getRows().then(function(data) {
+   *   var rows = data[0];
+   * });
+   */
+  getRows(options, callback) {
+    if (is.function(options)) {
+      callback = options;
+      options = {};
+    }
+
+    this.createReadStream(options)
+      .on('error', callback)
+      .pipe(
+        concat(function(rows) {
+          callback(null, rows);
+        })
+      );
+  }
+
+  /**
+   * Insert or update rows in your table. It should be noted that gRPC only allows
+   * you to send payloads that are less than or equal to 4MB. If you're inserting
+   * more than that you may need to send smaller individual requests.
+   *
+   * @param {object|object[]} entries List of entries to be inserted.
+   *     See {@link Table#mutate}.
+   * @param {object} [gaxOptions] Request configuration options, outlined here:
+   *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
+   * @param {function} callback The callback function.
+   * @param {?error} callback.err An error returned while making this request.
+   * @param {object[]} callback.err.errors If present, these represent partial
+   *     failures. It's possible for part of your request to be completed
+   *     successfully, while the other part was not.
+   *
+   * @example
+   * const Bigtable = require('@google-cloud/bigtable');
+   * const bigtable = new Bigtable();
+   * const instance = bigtable.instance('my-instance');
+   * const table = instance.table('prezzy');
+   *
+   * const callback = function(err) {
+   *   if (err) {
+   *     // An API error or partial failure occurred.
+   *
+   *     if (err.name === 'PartialFailureError') {
+   *       // err.errors[].code = 'Response code'
+   *       // err.errors[].message = 'Error message'
+   *       // err.errors[].entry = The original entry
+   *     }
+   *   }
+   * };
+   *
+   * const entries = [
+   *  {
+   *     key: 'alincoln',
+   *     data: {
+   *       follows: {
+   *         gwashington: 1
+   *       }
+   *     }
+   *   }
+   * ];
+   *
+   * table.insert(entries, callback);
+   *
+   * //-
+   * // By default whenever you insert new data, the server will capture a
+   * // timestamp of when your data was inserted. It's possible to provide a
+   * // date object to be used instead.
+   * //-
+   * const entries = [
+   *   {
+   *     key: 'gwashington',
+   *     data: {
+   *       follows: {
+   *         jadams: {
+   *           value: 1,
+   *           timestamp: new Date('March 22, 2016')
+   *         }
+   *       }
+   *     }
+   *   }
+   * ];
+   *
+   * table.insert(entries, callback);
+   *
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * table.insert(entries).then(function() {
+   *   // All requested inserts have been processed.
+   * });
+   * //-
+   */
+  insert(entries, gaxOptions, callback) {
+    if (is.fn(gaxOptions)) {
+      callback = gaxOptions;
+      gaxOptions = {};
+    }
+
+    entries = arrify(entries).map(propAssign('method', Mutation.methods.INSERT));
+
+    return this.mutate(entries, gaxOptions, callback);
+  }
+
+  /**
+   * Apply a set of changes to be atomically applied to the specified row(s).
+   * Mutations are applied in order, meaning that earlier mutations can be masked
+   * by later ones.
+   *
+   * @param {object|object[]} entries List of entities to be inserted or
+   *     deleted.
+   * @param {object} [gaxOptions] Request configuration options, outlined here:
+   *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
+   * @param {function} callback The callback function.
+   * @param {?error} callback.err An error returned while making this request.
+   * @param {object[]} callback.err.errors If present, these represent partial
+   *     failures. It's possible for part of your request to be completed
+   *     successfully, while the other part was not.
+   *
+   * @example
+   * const Bigtable = require('@google-cloud/bigtable');
+   * const bigtable = new Bigtable();
+   * const instance = bigtable.instance('my-instance');
+   * const table = instance.table('prezzy');
+   *
+   * //-
+   * // Insert entities. See {@link Table#insert}.
+   * //-
+   * const callback = function(err) {
+   *   if (err) {
+   *     // An API error or partial failure occurred.
+   *
+   *     if (err.name === 'PartialFailureError') {
+   *       // err.errors[].code = 'Response code'
+   *       // err.errors[].message = 'Error message'
+   *       // err.errors[].entry = The original entry
+   *     }
+   *   }
+   * };
+   *
+   * const entries = [
+   *   {
+   *     method: 'insert',
+   *     key: 'gwashington',
+   *     data: {
+   *       follows: {
+   *         jadams: 1
+   *       }
+   *     }
+   *   }
+   * ];
+   *
+   * table.mutate(entries, callback);
+   *
+   * //-
+   * // Delete entities. See {@link Row#deleteCells}.
+   * //-
+   * const entries = [
+   *   {
+   *     method: 'delete',
+   *     key: 'gwashington'
+   *   }
+   * ];
+   *
+   * table.mutate(entries, callback);
+   *
+   * //-
+   * // Delete specific columns within a row.
+   * //-
+   * const entries = [
+   *   {
+   *     method: 'delete',
+   *     key: 'gwashington',
+   *     data: [
+   *       'follows:jadams'
+   *     ]
+   *   }
+   * ];
+   *
+   * table.mutate(entries, callback);
+   *
+   * //-
+   * // Mix and match mutations. This must contain at least one entry and at
+   * // most 100,000.
+   * //-
+   * const entries = [
+   *   {
+   *     method: 'insert',
+   *     key: 'alincoln',
+   *     data: {
+   *       follows: {
+   *         gwashington: 1
+   *       }
+   *     }
+   *   }, {
+   *     method: 'delete',
+   *     key: 'jadams',
+   *     data: [
+   *       'follows:gwashington'
+   *     ]
+   *   }
+   * ];
+   *
+   * table.mutate(entries, callback);
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * table.mutate(entries).then(function() {
+   *   // All requested mutations have been processed.
+   * });
+   */
+  mutate(entries, gaxOptions, callback) {
+    const self = this;
+
+    if (is.fn(gaxOptions)) {
+      callback = gaxOptions;
+      gaxOptions = {};
+    }
+
+    entries = flatten(arrify(entries));
+
+    let numRequestsMade = 0;
+
+    const maxRetries = is.number(this.maxRetries) ? this.maxRetries : 3;
+    const pendingEntryIndices = new Set(entries.map((entry, index) => index));
+    const entryToIndex = new Map(entries.map((entry, index) => [entry, index]));
+    const mutationErrorsByEntryIndex = new Map();
+
+    function onBatchResponse(err) {
+      if (err) {
+        // The error happened before a request was even made, don't retry.
+        callback(err);
+        return;
+      }
+      if (pendingEntryIndices.size !== 0 && numRequestsMade <= maxRetries) {
+        makeNextBatchRequest();
+        return;
+      }
+
+      if (mutationErrorsByEntryIndex.size !== 0) {
+        const mutationErrors = Array.from(mutationErrorsByEntryIndex.values());
+        err = new common.util.PartialFailureError({
+          errors: mutationErrors,
+        });
+      }
+
+      callback(err);
+    }
+
+    function makeNextBatchRequest() {
+      const entryBatch = entries.filter((entry, index) => {
+        return pendingEntryIndices.has(index);
+      });
+
+      const reqOpts = {
+        tableName: self.id,
+        appProfileId: self.bigtable.appProfileId,
+        entries: entryBatch.map(Mutation.parse),
+      };
+
+      const retryOpts = {
+        currentRetryAttempt: numRequestsMade,
+      };
+
+      self.bigtable
+        .request({
+          client: 'BigtableClient',
+          method: 'mutateRows',
+          reqOpts,
+          gaxOpts: gaxOptions,
+          retryOpts,
+        })
+        .on('request', () => numRequestsMade++)
+        .on('error', err => {
+          if (numRequestsMade === 0) {
+            callback(err); // Likely a "projectId not detected" error.
+            return;
+          }
+
+          onBatchResponse(err);
+        })
+        .on('data', function(obj) {
+          obj.entries.forEach(function(entry) {
+            const originalEntry = entryBatch[entry.index];
+            const originalEntriesIndex = entryToIndex.get(originalEntry);
+
+            // Mutation was successful.
+            if (entry.status.code === 0) {
+              pendingEntryIndices.delete(originalEntriesIndex);
+              mutationErrorsByEntryIndex.delete(originalEntriesIndex);
+              return;
+            }
+
+            if (!RETRYABLE_STATUS_CODES.has(entry.status.code)) {
+              pendingEntryIndices.delete(originalEntriesIndex);
+            }
+
+            const status = commonGrpc.Service.decorateStatus_(entry.status);
+            status.entry = originalEntry;
+
+            mutationErrorsByEntryIndex.set(originalEntriesIndex, status);
+          });
+        })
+        .on('end', onBatchResponse);
+    }
+
+    makeNextBatchRequest();
+  }
+
+  /**
+   * Get a reference to a table row.
+   *
+   * @throws {error} If a key is not provided.
+   *
+   * @param {string} key The row key.
+   * @returns {Row}
+   *
+   * @example
+   * var row = table.row('lincoln');
+   */
+  row(key) {
+    if (!key) {
+      throw new Error('A row key must be provided.');
+    }
+
+    return new Row(this, key);
+  }
+
+  /**
+   * Returns a sample of row keys in the table. The returned row keys will delimit
+   * contigous sections of the table of approximately equal size, which can be
+   * used to break up the data for distributed tasks like mapreduces.
+   *
+   * @param {object} [gaxOptions] Request configuration options, outlined here:
+   *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
+   * @param {function} [callback] The callback function.
+   * @param {?error} callback.err An error returned while making this request.
+   * @param {object[]} callback.keys The list of keys.
+   *
+   * @example
+   * table.sampleRowKeys(function(err, keys) {
+   *   // keys = [
+   *   //   {
+   *   //     key: '',
+   *   //     offset: '805306368'
+   *   //   },
+   *   //   ...
+   *   // ]
+   * });
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * table.sampleRowKeys().then(function(data) {
+   *   var keys = data[0];
+   * });
+   */
+  sampleRowKeys(gaxOptions, callback) {
+    if (is.fn(gaxOptions)) {
+      callback = gaxOptions;
+      gaxOptions = {};
+    }
+
+    this.sampleRowKeysStream(gaxOptions)
+      .on('error', callback)
+      .pipe(
+        concat(function(keys) {
+          callback(null, keys);
+        })
+      );
+  }
+
+  /**
+   * Returns a sample of row keys in the table as a readable object stream.
+   *
+   * See {@link Table#sampleRowKeys} for more details.
+   *
+   * @param {object} [gaxOptions] Request configuration options, outlined here:
+   *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
+   * @returns {stream}
+   *
+   * @example
+   * table.sampleRowKeysStream()
+   *   .on('error', console.error)
+   *   .on('data', function(key) {
+   *     // Do something with the `key` object.
+   *   });
+   *
+   * //-
+   * // If you anticipate many results, you can end a stream early to prevent
+   * // unnecessary processing.
+   * //-
+   * table.sampleRowKeysStream()
+   *   .on('data', function(key) {
+   *     this.end();
+   *   });
+   */
+  sampleRowKeysStream(gaxOptions) {
+    const reqOpts = {
+      tableName: this.id,
+      appProfileId: this.bigtable.appProfileId,
+    };
+
+    return pumpify.obj([
+      this.bigtable.request({
+        client: 'BigtableClient',
+        method: 'sampleRowKeys',
+        reqOpts,
+        gaxOpts: gaxOptions,
+      }),
+      through.obj(function(key, enc, next) {
+        next(null, {
+          key: key.rowKey,
+          offset: key.offsetBytes,
+        });
+      }),
+    ]);
+  }
+
+  /**
+   * Truncate the table.
+   *
+   * @param {object} [gaxOptions] Request configuration options, outlined
+   *     here: https://googleapis.github.io/gax-nodejs/CallSettings.html.
+   * @param {function} callback The callback function.
+   * @param {?error} callback.err An error returned while making this request.
+   * @param {object} callback.apiResponse The full API response.
+   *
+   * @example
+   * table.truncate(function(err, apiResponse) {});
+   *
+   * //-
+   * // If the callback is omitted, we'll return a Promise.
+   * //-
+   * table.truncate().then(function(data) {
+   *   var apiResponse = data[0];
+   * });
+   */
+  truncate(gaxOptions, callback) {
+    if (is.fn(gaxOptions)) {
+      callback = gaxOptions;
+      gaxOptions = {};
+    }
+
+    const reqOpts = {
+      name: this.id,
+      deleteAllDataFromTable: true,
+    };
+
+    this.bigtable.request(
+      {
+        client: 'BigtableTableAdminClient',
+        method: 'dropRowRange',
+        reqOpts,
+        gaxOpts: gaxOptions,
+      },
+      callback
+    );
+  }
 }
 
 /**
@@ -68,1320 +1384,6 @@ Table.VIEWS = {
   name: 1,
   schema: 2,
   full: 4,
-};
-
-/**
- * Formats the table name to include the Bigtable cluster.
- *
- * @private
- *
- * @param {string} instanceName The formatted instance name.
- * @param {string} name The table name.
- *
- * @example
- * Table.formatName_(
- *   'projects/my-project/zones/my-zone/instances/my-instance',
- *   'my-table'
- * );
- * // 'projects/my-project/zones/my-zone/instances/my-instance/tables/my-table'
- */
-Table.formatName_ = function(instanceName, name) {
-  if (name.indexOf('/') > -1) {
-    return name;
-  }
-
-  return instanceName + '/tables/' + name;
-};
-
-/**
- * Creates a range based off of a key prefix.
- *
- * @private
- *
- * @param {string} start The key prefix/starting bound.
- * @returns {object} range
- *
- * @example
- * Table.createPrefixRange_('start');
- * // => {
- * //   start: 'start',
- * //   end: {
- * //     value: 'staru',
- * //     inclusive: false
- * //   }
- * // }
- */
-Table.createPrefixRange_ = function(start) {
-  const prefix = start.replace(new RegExp('[\xff]+$'), '');
-  let endKey = '';
-
-  if (prefix) {
-    const position = prefix.length - 1;
-    const charCode = prefix.charCodeAt(position);
-    const nextChar = String.fromCharCode(charCode + 1);
-
-    endKey = prefix.substring(0, position) + nextChar;
-  }
-
-  return {
-    start,
-    end: {
-      value: endKey,
-      inclusive: !endKey,
-    },
-  };
-};
-
-/**
- * Create a table.
- *
- * @param {object} [options] See {@link Instance#createTable}.
- * @param {object} [options.gaxOptions]  Request configuration options, outlined
- *     here: https://googleapis.github.io/gax-nodejs/global.html#CallOptions.
- * @param {function} callback The callback function.
- * @param {?error} callback.err An error returned while making this request.
- * @param {Table} callback.table The newly created table.
- * @param {object} callback.apiResponse The full API response.
- * @example
- * table.create(function(err, table, apiResponse) {
- *   if (!err) {
- *     // The table was created successfully.
- *   }
- * });
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * table.create().then(function(data) {
- *   var table = data[0];
- *   var apiResponse = data[1];
- * });
- */
-Table.prototype.create = function(options, callback) {
-  if (is.fn(options)) {
-    callback = options;
-    options = {};
-  }
-
-  this.instance.createTable(this.name, options, callback);
-};
-
-/**
- * Create a column family.
- *
- * Optionally you can send garbage collection rules and when creating a family.
- * Garbage collection executes opportunistically in the background, so it's
- * possible for reads to return a cell even if it matches the active expression
- * for its family.
- *
- * @see [Garbage Collection Proto Docs]{@link https://github.com/googleapis/googleapis/blob/master/google/bigtable/admin/table/v1/bigtable_table_data.proto#L59}
- *
- * @throws {error} If a name is not provided.
- *
- * @param {string} name The name of column family.
- * @param {object} [options] Configuration object.
- * @param {object} [options.gaxOptions] Request configuration options, outlined
- *     here: https://googleapis.github.io/gax-nodejs/global.html#CallOptions.
- * @param {object} [options.rule] Garbage collection rule
- * @param {object} [options.rule.age] Delete cells in a column older than the
- *     given age. Values must be at least 1 millisecond.
- * @param {number} [options.rule.versions] Maximum number of versions to delete
- *     cells in a column, except for the most recent.
- * @param {boolean} [options.rule.intersect] Cells to delete should match all
- *     rules.
- * @param {boolean} [options.rule.union] Cells to delete should match any of the
- *     rules.
- * @param {function} callback The callback function.
- * @param {?error} callback.err An error returned while making this request.
- * @param {Family} callback.family The newly created Family.
- * @param {object} callback.apiResponse The full API response.
- *
- * @example
- * const Bigtable = require('@google-cloud/bigtable');
- * const bigtable = new Bigtable();
- * const instance = bigtable.instance('my-instance');
- * const table = instance.table('prezzy');
- *
- * const callback = function(err, family, apiResponse) {
- *   // `family` is a Family object
- * };
- *
- * const options={};
- *
- * options.rule = {
- *   age: {
- *     seconds: 0,
- *     nanos: 5000
- *   },
- *   versions: 3,
- *   union: true
- * };
- *
- * table.createFamily('follows', options, callback);
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * table.createFamily('follows').then(function(data) {
- *   const family = data[0];
- *   const apiResponse = data[1];
- * });
- *
- * // Note that rules can have nested rules. For example The following rule
- * // will delete cells that are either older than 10 versions OR if the cell
- * // is is a month old and has at least 2 newer version.
- * // Essentially: (version > 10 OR (age > 30 AND version > 2))
- * const rule = {
- *   union: true,
- *   versions: 10,
- *   rule: {
- *     versions: 2,
- *     age: { seconds: 60 * 60 * 24 * 30 }, // one month
- *   },
- * };
- */
-Table.prototype.createFamily = function(name, options, callback) {
-  const self = this;
-
-  if (is.function(options)) {
-    callback = options;
-    options = {};
-  }
-
-  if (!name) {
-    throw new Error('A name is required to create a family.');
-  }
-
-  const mod = {
-    id: name,
-    create: {},
-  };
-
-  if (options.rule) {
-    mod.create.gcRule = Family.formatRule_(options.rule);
-  }
-
-  const reqOpts = {
-    name: this.id,
-    modifications: [mod],
-  };
-
-  this.bigtable.request(
-    {
-      client: 'BigtableTableAdminClient',
-      method: 'modifyColumnFamilies',
-      reqOpts,
-      gaxOpts: options.gaxOptions,
-    },
-    function(err, resp) {
-      if (err) {
-        callback(err, null, resp);
-        return;
-      }
-
-      const family = self.family(resp.name);
-      family.metadata = resp;
-
-      callback(null, family, resp);
-    }
-  );
-};
-
-/**
- * Get {@link Row} objects for the rows currently in your table as a
- * readable object stream.
- *
- * @param {object} [options] Configuration object.
- * @param {boolean} [options.decode=true] If set to `false` it will not decode
- *     Buffer values returned from Bigtable.
- * @param {string} [options.end] End value for key range.
- * @param {Filter} [options.filter] Row filters allow you to
- *     both make advanced queries and format how the data is returned.
- * @param {object} [options.gaxOptions] Request configuration options, outlined
- *     here: https://googleapis.github.io/gax-nodejs/CallSettings.html.
- * @param {string[]} [options.keys] A list of row keys.
- * @param {number} [options.limit] Maximum number of rows to be returned.
- * @param {string} [options.prefix] Prefix that the row key must match.
- * @param {string[]} [options.prefixes] List of prefixes that a row key must
- *     match.
- * @param {object[]} [options.ranges] A list of key ranges.
- * @param {string} [options.start] Start value for key range.
- * @returns {stream}
- *
- * @example
- * const Bigtable = require('@google-cloud/bigtable');
- * const bigtable = new Bigtable();
- * const instance = bigtable.instance('my-instance');
- * const table = instance.table('prezzy');
- *
- * table.createReadStream()
- *   .on('error', console.error)
- *   .on('data', function(row) {
- *     // `row` is a Row object.
- *   })
- *   .on('end', function() {
- *     // All rows retrieved.
- *   });
- *
- * //-
- * // If you anticipate many results, you can end a stream early to prevent
- * // unnecessary processing.
- * //-
- * table.createReadStream()
- *   .on('data', function(row) {
- *     this.end();
- *   });
- *
- * //-
- * // Specify arbitrary keys for a non-contiguous set of rows.
- * // The total size of the keys must remain under 1MB, after encoding.
- * //-
- * table.createReadStream({
- *   keys: [
- *     'alincoln',
- *     'gwashington'
- *   ]
- * });
- *
- * //-
- * // Scan for row keys that contain a specific prefix.
- * //-
- * table.createReadStream({
- *   prefix: 'gwash'
- * });
- *
- * //-
- * // Specify a contiguous range of rows to read by supplying `start` and `end`
- * // keys.
- * //
- * // If the `start` key is omitted, it is interpreted as an empty string.
- * // If the `end` key is omitted, it is interpreted as infinity.
- * //-
- * table.createReadStream({
- *   start: 'alincoln',
- *   end: 'gwashington'
- * });
- *
- * //-
- * // Specify multiple ranges.
- * //-
- * table.createReadStream({
- *   ranges: [{
- *     start: 'alincoln',
- *     end: 'gwashington'
- *   }, {
- *     start: 'tjefferson',
- *     end: 'jadams'
- *   }]
- * });
- *
- * //-
- * // Apply a {@link Filter} to the contents of the specified rows.
- * //-
- * table.createReadStream({
- *   filter: [
- *     {
- *       column: 'gwashington'
- *     }, {
- *       value: 1
- *     }
- *   ]
- * });
- */
-Table.prototype.createReadStream = function(options) {
-  const self = this;
-
-  options = options || {};
-  let maxRetries = is.number(this.maxRetries) ? this.maxRetries : 3;
-
-  let rowKeys;
-  let ranges = options.ranges || [];
-  let filter;
-  let rowsLimit;
-  let rowsRead = 0;
-  let numRequestsMade = 0;
-
-  if (options.start || options.end) {
-    ranges.push({
-      start: options.start,
-      end: options.end,
-    });
-  }
-
-  if (options.keys) {
-    rowKeys = options.keys;
-  }
-
-  if (options.prefix) {
-    ranges.push(Table.createPrefixRange_(options.prefix));
-  }
-
-  if (options.prefixes) {
-    options.prefixes.forEach(function(prefix) {
-      ranges.push(Table.createPrefixRange_(prefix));
-    });
-  }
-
-  if (options.filter) {
-    filter = Filter.parse(options.filter);
-  }
-
-  if (options.limit) {
-    rowsLimit = options.limit;
-  }
-
-  const userStream = through.obj();
-  let chunkTransformer;
-
-  const makeNewRequest = () => {
-    let lastRowKey = chunkTransformer ? chunkTransformer.lastRowKey : '';
-    chunkTransformer = new ChunkTransformer({decode: options.decode});
-
-    const reqOpts = {
-      tableName: this.id,
-      appProfileId: this.bigtable.appProfileId,
-    };
-
-    const retryOpts = {
-      currentRetryAttempt: numRequestsMade,
-    };
-
-    if (lastRowKey) {
-      const lessThan = (lhs, rhs) => {
-        const lhsBytes = Mutation.convertToBytes(lhs);
-        const rhsBytes = Mutation.convertToBytes(rhs);
-        return lhsBytes.compare(rhsBytes) === -1;
-      };
-      const greaterThan = (lhs, rhs) => lessThan(rhs, lhs);
-      const greaterThanOrEqualTo = (lhs, rhs) => !lessThan(rhs, lhs);
-
-      if (ranges.length === 0) {
-        ranges.push({
-          start: {
-            value: lastRowKey,
-            inclusive: false,
-          },
-        });
-      } else {
-        // Readjust and/or remove ranges based on previous valid row reads.
-
-        // Iterate backward since items may need to be removed.
-        for (let index = ranges.length - 1; index >= 0; index--) {
-          const range = ranges[index];
-          const startValue = is.object(range.start)
-            ? range.start.value
-            : range.start;
-          const endValue = is.object(range.end) ? range.end.value : range.end;
-          const isWithinStart =
-            !startValue || greaterThanOrEqualTo(startValue, lastRowKey);
-          const isWithinEnd = !endValue || lessThan(lastRowKey, endValue);
-          if (isWithinStart) {
-            if (isWithinEnd) {
-              // The lastRowKey is within this range, adjust the start value.
-              range.start = {
-                value: lastRowKey,
-                inclusive: false,
-              };
-            } else {
-              // The lastRowKey is past this range, remove this range.
-              ranges.splice(index, 1);
-            }
-          }
-        }
-      }
-
-      // Remove rowKeys already read.
-      if (rowKeys) {
-        rowKeys = rowKeys.filter(rowKey => greaterThan(rowKey, lastRowKey));
-        if (rowKeys.length === 0) {
-          rowKeys = null;
-        }
-      }
-    }
-    if (rowKeys || ranges.length) {
-      reqOpts.rows = {};
-
-      if (rowKeys) {
-        reqOpts.rows.rowKeys = rowKeys.map(Mutation.convertToBytes);
-      }
-
-      if (ranges.length) {
-        reqOpts.rows.rowRanges = ranges.map(function(range) {
-          return Filter.createRange(range.start, range.end, 'Key');
-        });
-      }
-    }
-
-    if (filter) {
-      reqOpts.filter = filter;
-    }
-
-    if (rowsLimit) {
-      reqOpts.rowsLimit = rowsLimit - rowsRead;
-    }
-
-    const requestStream = this.bigtable.request({
-      client: 'BigtableClient',
-      method: 'readRows',
-      reqOpts,
-      gaxOpts: options.gaxOptions,
-      retryOpts,
-    });
-
-    requestStream.on('request', () => numRequestsMade++);
-
-    const rowStream = pumpify.obj([
-      requestStream,
-      chunkTransformer,
-      through.obj(function(rowData, enc, next) {
-        if (chunkTransformer._destroyed || userStream._writableState.ended) {
-          return next();
-        }
-        numRequestsMade = 0;
-        rowsRead++;
-        const row = self.row(rowData.key);
-        row.data = rowData.data;
-        next(null, row);
-      }),
-    ]);
-
-    rowStream.on('error', error => {
-      rowStream.unpipe(userStream);
-      if (
-        numRequestsMade <= maxRetries &&
-        RETRYABLE_STATUS_CODES.has(error.code)
-      ) {
-        makeNewRequest();
-      } else {
-        userStream.emit('error', error);
-      }
-    });
-    rowStream.pipe(userStream);
-  };
-
-  makeNewRequest();
-  return userStream;
-};
-
-/**
- * Delete the table.
- *
- * @param {object} [gaxOptions] Request configuration options, outlined
- *     here: https://googleapis.github.io/gax-nodejs/CallSettings.html.
- * @param {function} [callback] The callback function.
- * @param {?error} callback.err An error returned while making this
- *     request.
- * @param {object} callback.apiResponse The full API response.
- *
- * @example
- * table.delete(function(err, apiResponse) {});
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * table.delete().then(function(data) {
- *   var apiResponse = data[0];
- * });
- */
-Table.prototype.delete = function(gaxOptions, callback) {
-  if (is.fn(gaxOptions)) {
-    callback = gaxOptions;
-    gaxOptions = {};
-  }
-
-  this.bigtable.request(
-    {
-      client: 'BigtableTableAdminClient',
-      method: 'deleteTable',
-      reqOpts: {
-        name: this.id,
-      },
-      gaxOpts: gaxOptions,
-    },
-    callback
-  );
-};
-
-/**
- * Delete all rows in the table, optionally corresponding to a particular
- * prefix.
- *
- * @throws {error} If a prefix is not provided.
- *
- * @param {string} prefix Row key prefix.
- * @param {object} [gaxOptions] Request configuration options, outlined
- *     here: https://googleapis.github.io/gax-nodejs/CallSettings.html.
- * @param {function} callback The callback function.
- * @param {?error} callback.err An error returned while making this request.
- * @param {object} callback.apiResponse The full API response.
- *
- * @example
- * const Bigtable = require('@google-cloud/bigtable');
- * const bigtable = new Bigtable();
- * const instance = bigtable.instance('my-instance');
- * const table = instance.table('prezzy');
- *
- * //-
- * // You can supply a prefix to delete all corresponding rows.
- * //-
- * const callback = function(err, apiResponse) {
- *   if (!err) {
- *     // Rows successfully deleted.
- *   }
- * };
- *
- * table.deleteRows('alincoln', callback);
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * table.deleteRows('alincoln').then(function(data) {
- *   const apiResponse = data[0];
- * });
- */
-Table.prototype.deleteRows = function(prefix, gaxOptions, callback) {
-  if (is.function(gaxOptions)) {
-    callback = gaxOptions;
-    gaxOptions = {};
-  }
-
-  if (!prefix || is.fn(prefix)) {
-    throw new Error('A prefix is required for deleteRows.');
-  }
-
-  const reqOpts = {
-    name: this.id,
-    rowKeyPrefix: Mutation.convertToBytes(prefix),
-  };
-
-  this.bigtable.request(
-    {
-      client: 'BigtableTableAdminClient',
-      method: 'dropRowRange',
-      reqOpts,
-      gaxOpts: gaxOptions,
-    },
-    callback
-  );
-};
-
-/**
- * Check if a table exists.
- *
- * @param {object} [gaxOptions] Request configuration options, outlined
- *     here: https://googleapis.github.io/gax-nodejs/CallSettings.html.
- * @param {function} callback The callback function.
- * @param {?error} callback.err An error returned while making this
- *     request.
- * @param {boolean} callback.exists Whether the table exists or not.
- *
- * @example
- * table.exists(function(err, exists) {});
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * table.exists().then(function(data) {
- *   var exists = data[0];
- * });
- */
-Table.prototype.exists = function(gaxOptions, callback) {
-  if (is.fn(gaxOptions)) {
-    callback = gaxOptions;
-    gaxOptions = {};
-  }
-
-  this.getMetadata(gaxOptions, function(err) {
-    if (err) {
-      if (err.code === 5) {
-        callback(null, false);
-        return;
-      }
-
-      callback(err);
-      return;
-    }
-
-    callback(null, true);
-  });
-};
-
-/**
- * Get a reference to a Table Family.
- *
- * @throws {error} If a name is not provided.
- *
- * @param {string} name The family name.
- * @returns {Family}
- *
- * @example
- * const family = table.family('my-family');
- */
-Table.prototype.family = function(name) {
-  if (!name) {
-    throw new Error('A family name must be provided.');
-  }
-
-  return new Family(this, name);
-};
-
-/**
- * Get a table if it exists.
- *
- * You may optionally use this to "get or create" an object by providing an
- * object with `autoCreate` set to `true`. Any extra configuration that is
- * normally required for the `create` method must be contained within this
- * object as well.
- *
- * @param {object} [options] Configuration object.
- * @param {boolean} [options.autoCreate=false] Automatically create the
- *     instance if it does not already exist.
- * @param {object} [options.gaxOptions] Request configuration options, outlined
- *     here: https://googleapis.github.io/gax-nodejs/CallSettings.html.
- * @param {?error} callback.error An error returned while making this request.
- * @param {Table} callback.table The Table object.
- * @param {object} callback.apiResponse The resource as it exists in the API.
- *
- * @example
- * table.get(function(err, table, apiResponse) {
- *   // The `table` data has been populated.
- * });
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * table.get().then(function(data) {
- *   var table = data[0];
- *   var apiResponse = data[0];
- * });
- */
-Table.prototype.get = function(options, callback) {
-  const self = this;
-
-  if (is.fn(options)) {
-    callback = options;
-    options = {};
-  }
-
-  const autoCreate = !!options.autoCreate;
-  const gaxOptions = options.gaxOptions;
-
-  this.getMetadata({gaxOptions}, function(err, metadata) {
-    if (err) {
-      if (err.code === 5 && autoCreate) {
-        self.create({gaxOptions}, callback);
-        return;
-      }
-
-      callback(err);
-      return;
-    }
-
-    callback(null, self, metadata);
-  });
-};
-
-/**
- * Get Family objects for all the column familes in your table.
- *
- * @param {object} [gaxOptions] Request configuration options, outlined here:
- *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
- * @param {function} callback The callback function.
- * @param {?error} callback.err An error returned while making this request.
- * @param {Family[]} callback.families The list of families.
- * @param {object} callback.apiResponse The full API response.
- *
- * @example
- * const Bigtable = require('@google-cloud/bigtable');
- * const bigtable = new Bigtable();
- * const instance = bigtable.instance('my-instance');
- * const table = instance.table('prezzy');
- *
- * table.getFamilies(function(err, families, apiResponse) {
- *   // `families` is an array of Family objects.
- * });
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * table.getFamilies().then(function(data) {
- *   var families = data[0];
- *   var apiResponse = data[1];
- * });
- */
-Table.prototype.getFamilies = function(gaxOptions, callback) {
-  const self = this;
-
-  if (is.fn(gaxOptions)) {
-    callback = gaxOptions;
-    gaxOptions = {};
-  }
-
-  this.getMetadata({gaxOptions}, function(err, metadata) {
-    if (err) {
-      callback(err);
-      return;
-    }
-
-    const families = Object.keys(metadata.columnFamilies).map(function(familyId) {
-      const family = self.family(familyId);
-      family.metadata = metadata.columnFamilies[familyId];
-      return family;
-    });
-
-    callback(null, families, metadata.columnFamilies);
-  });
-};
-
-/**
- * Get the table's metadata.
- *
- * @param {object} [options] Table request options.
- * @param {object} [options.gaxOptions] Request configuration options, outlined
- *     here: https://googleapis.github.io/gax-nodejs/CallSettings.html.
- * @param {string} [options.view] The view to be applied to the table fields.
- * @param {function} [callback] The callback function.
- * @param {?error} callback.err An error returned while making this
- *     request.
- * @param {object} callback.metadata The table's metadata.
- *
- * @example
- * const Bigtable = require('@google-cloud/bigtable');
- * const bigtable = new Bigtable();
- * const instance = bigtable.instance('my-instance');
- * const table = instance.table('prezzy');
- *
- * table.getMetadata(function(err, metadata) {});
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * table.getMetadata().then(function(data) {
- *   var metadata = data[0];
- *   var apiResponse = data[1];
- * });
- */
-Table.prototype.getMetadata = function(options, callback) {
-  const self = this;
-
-  if (is.function(options)) {
-    callback = options;
-    options = {};
-  }
-
-  const reqOpts = {
-    name: this.id,
-    view: Table.VIEWS[options.view || 'unspecified'],
-  };
-
-  this.bigtable.request(
-    {
-      client: 'BigtableTableAdminClient',
-      method: 'getTable',
-      reqOpts,
-      gaxOpts: options.gaxOptions,
-    },
-    function(...args) {
-      if (args[1]) {
-        self.metadata = args[1];
-      }
-
-      callback(...args);
-    }
-  );
-};
-
-/**
- * Get {@link Row} objects for the rows currently in your table.
- *
- * This method is not recommended for large datasets as it will buffer all rows
- * before returning the results. Instead we recommend using the streaming API
- * via {@link Table#createReadStream}.
- *
- * @param {object} [options] Configuration object. See
- *     {@link Table#createReadStream} for a complete list of options.
- * @param {object} [options.gaxOptions] Request configuration options, outlined
- *     here: https://googleapis.github.io/gax-nodejs/CallSettings.html.
- * @param {function} callback The callback function.
- * @param {?error} callback.err An error returned while making this request.
- * @param {Row[]} callback.rows List of Row objects.
- *
- * @example
- * const Bigtable = require('@google-cloud/bigtable');
- * const bigtable = new Bigtable();
- * const instance = bigtable.instance('my-instance');
- * const table = instance.table('prezzy');
- *
- * table.getRows(function(err, rows) {
- *   if (!err) {
- *     // `rows` is an array of Row objects.
- *   }
- * });
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * table.getRows().then(function(data) {
- *   var rows = data[0];
- * });
- */
-Table.prototype.getRows = function(options, callback) {
-  if (is.function(options)) {
-    callback = options;
-    options = {};
-  }
-
-  this.createReadStream(options)
-    .on('error', callback)
-    .pipe(
-      concat(function(rows) {
-        callback(null, rows);
-      })
-    );
-};
-
-/**
- * Insert or update rows in your table. It should be noted that gRPC only allows
- * you to send payloads that are less than or equal to 4MB. If you're inserting
- * more than that you may need to send smaller individual requests.
- *
- * @param {object|object[]} entries List of entries to be inserted.
- *     See {@link Table#mutate}.
- * @param {object} [gaxOptions] Request configuration options, outlined here:
- *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
- * @param {function} callback The callback function.
- * @param {?error} callback.err An error returned while making this request.
- * @param {object[]} callback.err.errors If present, these represent partial
- *     failures. It's possible for part of your request to be completed
- *     successfully, while the other part was not.
- *
- * @example
- * const Bigtable = require('@google-cloud/bigtable');
- * const bigtable = new Bigtable();
- * const instance = bigtable.instance('my-instance');
- * const table = instance.table('prezzy');
- *
- * const callback = function(err) {
- *   if (err) {
- *     // An API error or partial failure occurred.
- *
- *     if (err.name === 'PartialFailureError') {
- *       // err.errors[].code = 'Response code'
- *       // err.errors[].message = 'Error message'
- *       // err.errors[].entry = The original entry
- *     }
- *   }
- * };
- *
- * const entries = [
- *  {
- *     key: 'alincoln',
- *     data: {
- *       follows: {
- *         gwashington: 1
- *       }
- *     }
- *   }
- * ];
- *
- * table.insert(entries, callback);
- *
- * //-
- * // By default whenever you insert new data, the server will capture a
- * // timestamp of when your data was inserted. It's possible to provide a
- * // date object to be used instead.
- * //-
- * const entries = [
- *   {
- *     key: 'gwashington',
- *     data: {
- *       follows: {
- *         jadams: {
- *           value: 1,
- *           timestamp: new Date('March 22, 2016')
- *         }
- *       }
- *     }
- *   }
- * ];
- *
- * table.insert(entries, callback);
- *
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * table.insert(entries).then(function() {
- *   // All requested inserts have been processed.
- * });
- * //-
- */
-Table.prototype.insert = function(entries, gaxOptions, callback) {
-  if (is.fn(gaxOptions)) {
-    callback = gaxOptions;
-    gaxOptions = {};
-  }
-
-  entries = arrify(entries).map(propAssign('method', Mutation.methods.INSERT));
-
-  return this.mutate(entries, gaxOptions, callback);
-};
-
-/**
- * Apply a set of changes to be atomically applied to the specified row(s).
- * Mutations are applied in order, meaning that earlier mutations can be masked
- * by later ones.
- *
- * @param {object|object[]} entries List of entities to be inserted or
- *     deleted.
- * @param {object} [gaxOptions] Request configuration options, outlined here:
- *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
- * @param {function} callback The callback function.
- * @param {?error} callback.err An error returned while making this request.
- * @param {object[]} callback.err.errors If present, these represent partial
- *     failures. It's possible for part of your request to be completed
- *     successfully, while the other part was not.
- *
- * @example
- * const Bigtable = require('@google-cloud/bigtable');
- * const bigtable = new Bigtable();
- * const instance = bigtable.instance('my-instance');
- * const table = instance.table('prezzy');
- *
- * //-
- * // Insert entities. See {@link Table#insert}.
- * //-
- * const callback = function(err) {
- *   if (err) {
- *     // An API error or partial failure occurred.
- *
- *     if (err.name === 'PartialFailureError') {
- *       // err.errors[].code = 'Response code'
- *       // err.errors[].message = 'Error message'
- *       // err.errors[].entry = The original entry
- *     }
- *   }
- * };
- *
- * const entries = [
- *   {
- *     method: 'insert',
- *     key: 'gwashington',
- *     data: {
- *       follows: {
- *         jadams: 1
- *       }
- *     }
- *   }
- * ];
- *
- * table.mutate(entries, callback);
- *
- * //-
- * // Delete entities. See {@link Row#deleteCells}.
- * //-
- * const entries = [
- *   {
- *     method: 'delete',
- *     key: 'gwashington'
- *   }
- * ];
- *
- * table.mutate(entries, callback);
- *
- * //-
- * // Delete specific columns within a row.
- * //-
- * const entries = [
- *   {
- *     method: 'delete',
- *     key: 'gwashington',
- *     data: [
- *       'follows:jadams'
- *     ]
- *   }
- * ];
- *
- * table.mutate(entries, callback);
- *
- * //-
- * // Mix and match mutations. This must contain at least one entry and at
- * // most 100,000.
- * //-
- * const entries = [
- *   {
- *     method: 'insert',
- *     key: 'alincoln',
- *     data: {
- *       follows: {
- *         gwashington: 1
- *       }
- *     }
- *   }, {
- *     method: 'delete',
- *     key: 'jadams',
- *     data: [
- *       'follows:gwashington'
- *     ]
- *   }
- * ];
- *
- * table.mutate(entries, callback);
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * table.mutate(entries).then(function() {
- *   // All requested mutations have been processed.
- * });
- */
-Table.prototype.mutate = function(entries, gaxOptions, callback) {
-  const self = this;
-
-  if (is.fn(gaxOptions)) {
-    callback = gaxOptions;
-    gaxOptions = {};
-  }
-
-  entries = flatten(arrify(entries));
-
-  let numRequestsMade = 0;
-
-  const maxRetries = is.number(this.maxRetries) ? this.maxRetries : 3;
-  const pendingEntryIndices = new Set(entries.map((entry, index) => index));
-  const entryToIndex = new Map(entries.map((entry, index) => [entry, index]));
-  const mutationErrorsByEntryIndex = new Map();
-
-  function onBatchResponse(err) {
-    if (err) {
-      // The error happened before a request was even made, don't retry.
-      callback(err);
-      return;
-    }
-    if (pendingEntryIndices.size !== 0 && numRequestsMade <= maxRetries) {
-      makeNextBatchRequest();
-      return;
-    }
-
-    if (mutationErrorsByEntryIndex.size !== 0) {
-      const mutationErrors = Array.from(mutationErrorsByEntryIndex.values());
-      err = new common.util.PartialFailureError({
-        errors: mutationErrors,
-      });
-    }
-
-    callback(err);
-  }
-
-  function makeNextBatchRequest() {
-    const entryBatch = entries.filter((entry, index) => {
-      return pendingEntryIndices.has(index);
-    });
-
-    const reqOpts = {
-      tableName: self.id,
-      appProfileId: self.bigtable.appProfileId,
-      entries: entryBatch.map(Mutation.parse),
-    };
-
-    const retryOpts = {
-      currentRetryAttempt: numRequestsMade,
-    };
-
-    self.bigtable
-      .request({
-        client: 'BigtableClient',
-        method: 'mutateRows',
-        reqOpts,
-        gaxOpts: gaxOptions,
-        retryOpts,
-      })
-      .on('request', () => numRequestsMade++)
-      .on('error', err => {
-        if (numRequestsMade === 0) {
-          callback(err); // Likely a "projectId not detected" error.
-          return;
-        }
-
-        onBatchResponse(err);
-      })
-      .on('data', function(obj) {
-        obj.entries.forEach(function(entry) {
-          const originalEntry = entryBatch[entry.index];
-          const originalEntriesIndex = entryToIndex.get(originalEntry);
-
-          // Mutation was successful.
-          if (entry.status.code === 0) {
-            pendingEntryIndices.delete(originalEntriesIndex);
-            mutationErrorsByEntryIndex.delete(originalEntriesIndex);
-            return;
-          }
-
-          if (!RETRYABLE_STATUS_CODES.has(entry.status.code)) {
-            pendingEntryIndices.delete(originalEntriesIndex);
-          }
-
-          const status = commonGrpc.Service.decorateStatus_(entry.status);
-          status.entry = originalEntry;
-
-          mutationErrorsByEntryIndex.set(originalEntriesIndex, status);
-        });
-      })
-      .on('end', onBatchResponse);
-  }
-
-  makeNextBatchRequest();
-};
-
-/**
- * Get a reference to a table row.
- *
- * @throws {error} If a key is not provided.
- *
- * @param {string} key The row key.
- * @returns {Row}
- *
- * @example
- * var row = table.row('lincoln');
- */
-Table.prototype.row = function(key) {
-  if (!key) {
-    throw new Error('A row key must be provided.');
-  }
-
-  return new Row(this, key);
-};
-
-/**
- * Returns a sample of row keys in the table. The returned row keys will delimit
- * contigous sections of the table of approximately equal size, which can be
- * used to break up the data for distributed tasks like mapreduces.
- *
- * @param {object} [gaxOptions] Request configuration options, outlined here:
- *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
- * @param {function} [callback] The callback function.
- * @param {?error} callback.err An error returned while making this request.
- * @param {object[]} callback.keys The list of keys.
- *
- * @example
- * table.sampleRowKeys(function(err, keys) {
- *   // keys = [
- *   //   {
- *   //     key: '',
- *   //     offset: '805306368'
- *   //   },
- *   //   ...
- *   // ]
- * });
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * table.sampleRowKeys().then(function(data) {
- *   var keys = data[0];
- * });
- */
-Table.prototype.sampleRowKeys = function(gaxOptions, callback) {
-  if (is.fn(gaxOptions)) {
-    callback = gaxOptions;
-    gaxOptions = {};
-  }
-
-  this.sampleRowKeysStream(gaxOptions)
-    .on('error', callback)
-    .pipe(
-      concat(function(keys) {
-        callback(null, keys);
-      })
-    );
-};
-
-/**
- * Returns a sample of row keys in the table as a readable object stream.
- *
- * See {@link Table#sampleRowKeys} for more details.
- *
- * @param {object} [gaxOptions] Request configuration options, outlined here:
- *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
- * @returns {stream}
- *
- * @example
- * table.sampleRowKeysStream()
- *   .on('error', console.error)
- *   .on('data', function(key) {
- *     // Do something with the `key` object.
- *   });
- *
- * //-
- * // If you anticipate many results, you can end a stream early to prevent
- * // unnecessary processing.
- * //-
- * table.sampleRowKeysStream()
- *   .on('data', function(key) {
- *     this.end();
- *   });
- */
-Table.prototype.sampleRowKeysStream = function(gaxOptions) {
-  const reqOpts = {
-    tableName: this.id,
-    appProfileId: this.bigtable.appProfileId,
-  };
-
-  return pumpify.obj([
-    this.bigtable.request({
-      client: 'BigtableClient',
-      method: 'sampleRowKeys',
-      reqOpts,
-      gaxOpts: gaxOptions,
-    }),
-    through.obj(function(key, enc, next) {
-      next(null, {
-        key: key.rowKey,
-        offset: key.offsetBytes,
-      });
-    }),
-  ]);
-};
-
-/**
- * Truncate the table.
- *
- * @param {object} [gaxOptions] Request configuration options, outlined
- *     here: https://googleapis.github.io/gax-nodejs/CallSettings.html.
- * @param {function} callback The callback function.
- * @param {?error} callback.err An error returned while making this request.
- * @param {object} callback.apiResponse The full API response.
- *
- * @example
- * table.truncate(function(err, apiResponse) {});
- *
- * //-
- * // If the callback is omitted, we'll return a Promise.
- * //-
- * table.truncate().then(function(data) {
- *   var apiResponse = data[0];
- * });
- */
-Table.prototype.truncate = function(gaxOptions, callback) {
-  if (is.fn(gaxOptions)) {
-    callback = gaxOptions;
-    gaxOptions = {};
-  }
-
-  const reqOpts = {
-    name: this.id,
-    deleteAllDataFromTable: true,
-  };
-
-  this.bigtable.request(
-    {
-      client: 'BigtableTableAdminClient',
-      method: 'dropRowRange',
-      reqOpts,
-      gaxOpts: gaxOptions,
-    },
-    callback
-  );
 };
 
 /*! Developer Documentation

--- a/test/index.js
+++ b/test/index.js
@@ -135,12 +135,6 @@ describe('Bigtable', function() {
       assert(promisified);
     });
 
-    it('should work without new', function() {
-      assert.doesNotThrow(function() {
-        Bigtable({projectId: PROJECT_ID});
-      });
-    });
-
     it('should normalize the arguments', function() {
       var normalizeArgumentsCalled = false;
       var options = {};


### PR DESCRIPTION
Fixes #85 

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

---

This PR should be ready to go. I believe this requires a major semver bump. I figured the test files shouldn't be updated in the same PR. The only thing that really needs to be pointed out is that classes shouldn't be instantiatable without the new keyword:

```js
const client1 = new Bigtable()
const client2 = Bigtable() // Error: Class constructor Foo cannot be invoked without 'new'
```

I was on the fence about requiring people to use the `new` keyword or not, and chose to make it optional. I did this by using a proxy:

```js
Bigtable = new Proxy(Bigtable, {
  apply(target, thisArg, argumentsList) {
    return new target(...argumentsList);
  },
});
```

Let me know if this should be removed. I didn't add that to the semi-private classes since the common case of creating one is something like `instance.table(...)` and not `new Table(...)`

As before, most of this was done via lebab so there may be some issues so please do go through it again to make sure nothing terrible is being done.

