### PR TITLE
Fixing docs that refered to "Compute Instances"

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -66,7 +66,7 @@ const v2 = require('./v2');
  */
 
 /**
- * @see [Creating a Cloud Bigtable Cluster]{@link https://cloud.google.com/bigtable/docs/creating-compute-instance}
+ * @see [Creating a Cloud Bigtable Cluster]{@link https://cloud.google.com/bigtable/docs/creating-instance}
  * @see [Cloud Bigtable Concepts Overview]{@link https://cloud.google.com/bigtable/docs/concepts}
  *
  * @class
@@ -431,9 +431,9 @@ function Bigtable(options) {
 }
 
 /**
- * Create a Compute instance.
+ * Create a Cloud Bigtable instance.
  *
- * @see [Creating a Compute Instance]{@link https://cloud.google.com/bigtable/docs/creating-compute-instance}
+ * @see [Creating a Cloud Bigtable Instance]{@link https://cloud.google.com/bigtable/docs/creating-instance}
  *
  * @param {string} name The unique name of the instance.
  * @param {object} [options] Instance creation options.
@@ -559,7 +559,7 @@ Bigtable.prototype.createInstance = function(name, options, callback) {
 };
 
 /**
- * Get Instance objects for all of your Compute instances.
+ * Get Instance objects for all of your Cloud Bigtable instances.
  *
  * @param {object} [gaxOptions] Request configuration options, outlined here:
  *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
@@ -623,7 +623,7 @@ Bigtable.prototype.getInstances = function(gaxOptions, callback) {
 };
 
 /**
- * Get a reference to a Compute instance.
+ * Get a reference to a Cloud Bigtable instance.
  *
  * @param {string} name The name of the instance.
  * @returns {Instance}

--- a/src/instance.js
+++ b/src/instance.js
@@ -26,7 +26,7 @@ var Family = require('./family.js');
 var Table = require('./table.js');
 
 /**
- * Create an Instance object to interact with a Compute instance.
+ * Create an Instance object to interact with a Cloud Bigtable instance.
  *
  * @class
  * @param {Bigtable} bigtable The parent {@link Bigtable} object of this
@@ -810,7 +810,7 @@ Instance.prototype.getMetadata = function(gaxOptions, callback) {
 };
 
 /**
- * Get Table objects for all the tables in your Compute instance.
+ * Get Table objects for all the tables in your Cloud Bigtable instance.
  *
  * @param {object} [options] Query object.
  * @param {boolean} [options.autoPaginate=true] Have pagination handled
@@ -899,7 +899,7 @@ Instance.prototype.getTables = function(options, callback) {
 };
 
 /**
- * Get {@link Table} objects for all the tables in your Compute
+ * Get {@link Table} objects for all the tables in your Cloud Bigtable
  * instance as a readable object stream.
  *
  * @param {object} [query] Configuration object. See


### PR DESCRIPTION
The references should have been for Cloud Bigtable Instances.

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
