### PR TITLE
Fix bad encoded filter

### DIFF
--- a/src/filter.js
+++ b/src/filter.js
@@ -116,8 +116,10 @@ class Filter {
     }
 
     if (Buffer.isBuffer(regex)) {
-      const regexToEscape = regex.toString(isUtf8(regex) ? 'utf8' : 'binary');
-      return escapeStringRegexp(regexToEscape);
+      const encodingToUse = isUtf8(regex) ? 'utf8' : 'binary';
+      const regexToEscape = regex.toString(encodingToUse);
+      const escapedString = escapeStringRegexp(regexToEscape);
+      return Buffer.from(escapedString, encodingToUse);
     }
 
     throw new TypeError("Can't convert to RegExp String from unknown type.");

--- a/test/filter.js
+++ b/test/filter.js
@@ -264,6 +264,21 @@ describe('Bigtable/Filter', function() {
       filter.column(column);
     });
 
+    it('should handle a binary encoded buffer regex filter', function(done) {
+      var column = {
+        name: Buffer.from('æ', 'binary'),
+      };
+
+      filter.set = function(filterName, value) {
+        assert.strictEqual(filterName, 'columnQualifierRegexFilter');
+        assert.deepStrictEqual(value, column.name);
+        assert(FakeMutation.convertToBytes.calledWithExactly(column.name));
+        done();
+      };
+
+      filter.column(column);
+    });
+
     it('should accept the short-hand version of column', function(done) {
       var column = 'fake-column';
 

--- a/test/filter.js
+++ b/test/filter.js
@@ -93,7 +93,7 @@ describe('Bigtable/Filter', function() {
       assert.deepStrictEqual(buffer, str2);
     });
 
-    it('should not incorrectly convert a non-utf8 buffer to a utf8 buffer', function() {
+    it('should use a binary encoding on a non utf8 buffer', function() {
       var str1 = 'æ';
       var buffer = Buffer.from('æ', 'binary');
       var str2 = Filter.convertToRegExpString(buffer).toString('binary');

--- a/test/filter.js
+++ b/test/filter.js
@@ -85,18 +85,18 @@ describe('Bigtable/Filter', function() {
       assert.strictEqual(str, '1');
     });
 
-    it('should convert a buffer to a string', function() {
+    it('should not do anything to a buffer', function() {
       var str1 = 'hello';
       var buffer = Buffer.from(str1);
       var str2 = Filter.convertToRegExpString(buffer);
 
-      assert.strictEqual(str1, str2);
+      assert.deepStrictEqual(buffer, str2);
     });
 
-    it('should convert a non-utf8 buffer to a string', function() {
+    it('should not incorrectly convert a non-utf8 buffer to a utf8 buffer', function() {
       var str1 = 'æ';
       var buffer = Buffer.from('æ', 'binary');
-      var str2 = Filter.convertToRegExpString(buffer);
+      var str2 = Filter.convertToRegExpString(buffer).toString('binary');
 
       assert.strictEqual(str1, str2);
     });


### PR DESCRIPTION
Fixes #171 

We were correctly escaping a binary string but after `Filter.convertToRegExpString` was called and returned a string and we then called `Mutation.convertToBytes` with that string, which then assumed utf8 encoding. This PR keeps the filter as a buffer so that `Mutation.convertToBytes` will see it's input as a buffer and just return that buffer

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
