### PR TITLE
Fix rowKey being force stringified to utf8

### DIFF
--- a/src/chunktransformer.js
+++ b/src/chunktransformer.js
@@ -132,7 +132,7 @@ class ChunkTransformer extends Transform {
    * @private
    */
   reset() {
-    this.prevRowKey = '';
+    this.prevRowKey = null;
     this.family = {};
     this.qualifiers = [];
     this.qualifier = {};
@@ -173,10 +173,10 @@ class ChunkTransformer extends Transform {
    */
   validateResetRow(chunk) {
     const containsData =
-      (chunk.rowKey && chunk.rowKey.toString() !== '') ||
+      (chunk.rowKey && chunk.rowKey.length !== 0) ||
       chunk.familyName ||
       chunk.qualifier ||
-      (chunk.value && chunk.value.toString() !== '') ||
+      (chunk.value && chunk.value.length !== 0) ||
       chunk.timestampMicros > 0;
     if (chunk.resetRow && containsData) {
       this.destroy(
@@ -203,8 +203,8 @@ class ChunkTransformer extends Transform {
       errorMessage = 'A new row cannot have existing state';
     } else if (
       typeof chunk.rowKey === 'undefined' ||
-      chunk.rowKey === '' ||
-      newRowKey === ''
+      chunk.rowKey.length === 0 ||
+      newRowKey.length === 0
     ) {
       errorMessage = 'A row key must be set';
     } else if (chunk.resetRow) {

--- a/src/chunktransformer.js
+++ b/src/chunktransformer.js
@@ -88,7 +88,9 @@ class ChunkTransformer extends Transform {
       }
     }
     if (data.lastScannedRowKey && data.lastScannedRowKey.length > 0) {
-      this.lastRowKey = Mutation.convertFromBytes(data.lastScannedRowKey);
+      this.lastRowKey = Mutation.convertFromBytes(data.lastScannedRowKey, {
+        userOptions: this.options,
+      });
     }
     next();
   }
@@ -229,11 +231,13 @@ class ChunkTransformer extends Transform {
   validateRowInProgress(chunk) {
     const row = this.row;
     if (chunk.rowKey && chunk.rowKey.length) {
-      const newRowKey = Mutation.convertFromBytes(chunk.rowKey);
+      const newRowKey = Mutation.convertFromBytes(chunk.rowKey, {
+        userOptions: this.options,
+      });
       if (
         newRowKey &&
         chunk.rowKey &&
-        newRowKey !== '' &&
+        newRowKey.length !== 0 &&
         newRowKey !== row.key
       ) {
         this.destroy(
@@ -294,14 +298,18 @@ class ChunkTransformer extends Transform {
    * @param {chunks} chunk chunk to process
    */
   processNewRow(chunk) {
-    const newRowKey = Mutation.convertFromBytes(chunk.rowKey);
+    const newRowKey = Mutation.convertFromBytes(chunk.rowKey, {
+      userOptions: this.options,
+    });
     this.validateNewRow(chunk, newRowKey);
     if (chunk.familyName && chunk.qualifier) {
       const row = this.row;
       row.key = newRowKey;
       row.data = {};
       this.family = row.data[chunk.familyName.value] = {};
-      const qualifierName = Mutation.convertFromBytes(chunk.qualifier.value);
+      const qualifierName = Mutation.convertFromBytes(chunk.qualifier.value, {
+        userOptions: this.options,
+      });
       this.qualifiers = this.family[qualifierName] = [];
       this.qualifier = {
         value: Mutation.convertFromBytes(chunk.value, {
@@ -332,7 +340,9 @@ class ChunkTransformer extends Transform {
         row.data[chunk.familyName.value] || {};
     }
     if (chunk.qualifier) {
-      const qualifierName = Mutation.convertFromBytes(chunk.qualifier.value);
+      const qualifierName = Mutation.convertFromBytes(chunk.qualifier.value, {
+        userOptions: this.options,
+      });
       this.qualifiers = this.family[qualifierName] =
         this.family[qualifierName] || [];
     }

--- a/src/mutation.js
+++ b/src/mutation.js
@@ -51,6 +51,8 @@ class Mutation {
    * @param {boolean} [options.isPossibleNumber] Check if byte is number
    * @param {object} [options.userOptions]
    * @param {boolean} [options.userOptions.decode] Check if decode is required
+   * @param {boolean} [options.userOptions.encoding] The encoding to use when
+   *     converting the buffer to a string.
    * @returns {string|number|buffer}
    */
   static convertFromBytes(bytes, options) {
@@ -63,15 +65,13 @@ class Mutation {
       }
     }
 
-    if (
-      options &&
-      options.userOptions &&
-      options.userOptions.decode === false
-    ) {
+    const userOptions = (options && options.userOptions) || {};
+
+    if (userOptions.decode === false) {
       return buf;
     }
 
-    return buf.toString();
+    return buf.toString(userOptions.encoding);
   }
 
   /**

--- a/src/table.js
+++ b/src/table.js
@@ -293,6 +293,8 @@ Please use the format 'prezzy' or '${instance.name}/tables/prezzy'.`
    * @param {object} [options] Configuration object.
    * @param {boolean} [options.decode=true] If set to `false` it will not decode
    *     Buffer values returned from Bigtable.
+   * @param {boolean} [options.encoding] The encoding to use when converting
+   *     Buffer values to a string.
    * @param {string} [options.end] End value for key range.
    * @param {Filter} [options.filter] Row filters allow you to
    *     both make advanced queries and format how the data is returned.

--- a/test/chunktransformer.js
+++ b/test/chunktransformer.js
@@ -69,7 +69,7 @@ describe('Bigtable/ChunkTransformer', function() {
       assert.deepEqual(chunkTransformer.row, {}, 'invalid initial state');
       assert.deepEqual(
         chunkTransformer.prevRowKey,
-        '',
+        null,
         'invalid initial state'
       );
       assert.deepEqual(chunkTransformer.family, {}, 'invalid initial state');
@@ -965,7 +965,7 @@ describe('Bigtable/ChunkTransformer', function() {
       assert.deepEqual(chunkTransformer.row, {}, 'invalid initial state');
       assert.deepEqual(
         chunkTransformer.prevRowKey,
-        '',
+        null,
         'invalid initial state'
       );
       assert.deepEqual(chunkTransformer.family, {}, 'invalid initial state');

--- a/test/mutation.js
+++ b/test/mutation.js
@@ -75,6 +75,16 @@ describe('Bigtable/Mutation', function() {
       assert.strictEqual(message, decoded);
     });
 
+    it('should allow using a custom encoding scheme', function() {
+      var message = 'æ';
+      var encoded = Buffer.from(message, 'binary').toString('base64');
+      var decoded = Mutation.convertFromBytes(encoded, {
+        userOptions: {encoding: 'binary'},
+      });
+
+      assert.strictEqual(message, decoded);
+    });
+
     it('should return a buffer if decode is set to false', function() {
       var message = 'Hello!';
       var encoded = Buffer.from(message).toString('base64');


### PR DESCRIPTION
Fixes #185 

The key should be treated as a black box of bytes and not as a utf8 encoded string. 
 
`Buffer.from('ø', 'binary').toString() === Buffer.from('æ', 'binary').toString()`  
evaluates to true so two consecutive keys like this will cause the chunkTransformer to throw an error. This PR also allows choosing a custom encoding since the `row.data.family` is a hashmap and needs to stringify the value so we can't just leave it as a buffer with `decode = false`

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
