### PR TITLE
fix #196 should not call replaceProjectID token when projectid is passed in option

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -423,6 +423,7 @@ class Bigtable {
     this.projectId = options.projectId || '{{projectId}}';
     this.appProfileId = options.appProfileId;
     this.projectName = `projects/${this.projectId}`;
+    this.shouldReplaceProjectIdToken = this.projectId === '{{projectId}}';
   }
 
   /**
@@ -651,7 +652,7 @@ class Bigtable {
 
         let reqOpts = extend(true, {}, config.reqOpts);
 
-        if (projectId !== '{{projectId}}') {
+        if (this.shouldReplaceProjectIdToken && projectId !== '{{projectId}}') {
           reqOpts = common.util.replaceProjectIdToken(reqOpts, projectId);
         }
 

--- a/test/index.js
+++ b/test/index.js
@@ -690,6 +690,7 @@ describe('Bigtable', function() {
           [CONFIG.method]: common.util.noop,
         };
       });
+
       it('should replace the project ID token', function(done) {
         var replacedReqOpts = {};
 
@@ -700,6 +701,7 @@ describe('Bigtable', function() {
 
           return replacedReqOpts;
         };
+
         bigtable.api[CONFIG.client][CONFIG.method] = {
           bind: function(gaxClient, reqOpts) {
             assert.strictEqual(reqOpts, replacedReqOpts);
@@ -712,10 +714,12 @@ describe('Bigtable', function() {
 
         bigtable.request(CONFIG, assert.ifError);
       });
+
       it('should not replace token when project ID not detected', function(done) {
         replaceProjectIdTokenOverride = function() {
           throw new Error('Should not have tried to replace token.');
         };
+
         bigtable.getProjectId_ = function(callback) {
           callback(null, PROJECT_ID_TOKEN);
         };

--- a/test/index.js
+++ b/test/index.js
@@ -663,6 +663,35 @@ describe('Bigtable', function() {
         done();
       });
 
+      it('should not call replace project ID token', function(done) {
+        var replacedReqOpts = {};
+
+        replaceProjectIdTokenOverride = sinon.spy();
+
+        bigtable.api[CONFIG.client][CONFIG.method] = {
+          bind: function(gaxClient, reqOpts) {
+            assert(!replaceProjectIdTokenOverride.called);
+            setImmediate(done);
+
+            return common.util.noop;
+          },
+        };
+
+        bigtable.request(CONFIG, assert.ifError);
+      });
+    });
+
+    describe('replace projectID token', function() {
+      beforeEach(function() {
+        bigtable = new Bigtable();
+        bigtable.getProjectId_ = function(callback) {
+          callback(null, PROJECT_ID);
+        };
+
+        bigtable.api[CONFIG.client] = {
+          [CONFIG.method]: common.util.noop,
+        };
+      });
       it('should replace the project ID token', function(done) {
         var replacedReqOpts = {};
 
@@ -673,7 +702,6 @@ describe('Bigtable', function() {
 
           return replacedReqOpts;
         };
-
         bigtable.api[CONFIG.client][CONFIG.method] = {
           bind: function(gaxClient, reqOpts) {
             assert.strictEqual(reqOpts, replacedReqOpts);
@@ -686,12 +714,10 @@ describe('Bigtable', function() {
 
         bigtable.request(CONFIG, assert.ifError);
       });
-
       it('should not replace token when project ID not detected', function(done) {
         replaceProjectIdTokenOverride = function() {
           throw new Error('Should not have tried to replace token.');
         };
-
         bigtable.getProjectId_ = function(callback) {
           callback(null, PROJECT_ID_TOKEN);
         };

--- a/test/index.js
+++ b/test/index.js
@@ -664,12 +664,10 @@ describe('Bigtable', function() {
       });
 
       it('should not call replace project ID token', function(done) {
-        var replacedReqOpts = {};
-
         replaceProjectIdTokenOverride = sinon.spy();
 
         bigtable.api[CONFIG.client][CONFIG.method] = {
-          bind: function(gaxClient, reqOpts) {
+          bind: function() {
             assert(!replaceProjectIdTokenOverride.called);
             setImmediate(done);
 


### PR DESCRIPTION

Fixes #196  (it's a good idea to open an issue first for discussion)

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
