### PR TITLE
Updating the Readme: Node is now beta

### DIFF
--- a/.cloud-repo-tools.json
+++ b/.cloud-repo-tools.json
@@ -4,7 +4,7 @@
   "product": "bigtable",
   "client_reference_url":
     "https://cloud.google.com/nodejs/docs/reference/bigtable/latest/",
-  "release_quality": "alpha",
+  "release_quality": "beta",
   "samples": [
     {
       "id": "instances",

--- a/README.md
+++ b/README.md
@@ -119,9 +119,10 @@ also contains samples.
 
 This library follows [Semantic Versioning](http://semver.org/).
 
-This library is considered to be in **alpha**. This means it is still a
-work-in-progress and under active development. Any release is subject to
-backwards-incompatible changes at any time.
+This library is considered to be in **beta**. This means it is expected to be
+mostly stable while we work toward a general availability release; however,
+complete stability is not guaranteed. We will address issues and requests
+against beta libraries with a high priority.
 
 More Information: [Google Cloud Platform Launch Stages][launch_stages]
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # [Cloud Bigtable: Node.js Client](https://github.com/googleapis/nodejs-bigtable)
 
-[![release level](https://img.shields.io/badge/release%20level-alpha-orange.svg?style&#x3D;flat)](https://cloud.google.com/terms/launch-stages)
+[![release level](https://img.shields.io/badge/release%20level-beta-yellow.svg?style&#x3D;flat)](https://cloud.google.com/terms/launch-stages)
 [![CircleCI](https://img.shields.io/circleci/project/github/googleapis/nodejs-bigtable.svg?style=flat)](https://circleci.com/gh/googleapis/nodejs-bigtable)
 [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/googleapis/nodejs-bigtable?branch=master&svg=true)](https://ci.appveyor.com/project/googleapis/nodejs-bigtable)
 [![codecov](https://img.shields.io/codecov/c/github/googleapis/nodejs-bigtable/master.svg?style=flat)](https://codecov.io/gh/googleapis/nodejs-bigtable)


### PR DESCRIPTION
This works towards issue #224.

The client is ready for Beta.  This PR updates the readme.