### PR TITLE
Allow creating a Bigtable instance without the new keyword.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -793,6 +793,14 @@ Bigtable.Cluster = Cluster;
  */
 Bigtable.Instance = Instance;
 
+// Allow creating a `Bigtable` instance without using the `new` keyword.
+// eslint-disable-next-line no-class-assign
+Bigtable = new Proxy(Bigtable, {
+  apply(target, thisArg, argumentsList) {
+    return new target(...argumentsList);
+  },
+});
+
 /**
  * The default export of the `@google-cloud/bigtable` package is the
  * {@link Bigtable} class.

--- a/test/index.js
+++ b/test/index.js
@@ -137,6 +137,11 @@ describe('Bigtable', function() {
       assert(promisified);
     });
 
+    it('should work without new', function() {
+      const bigtable = Bigtable();
+      assert(bigtable instanceof Bigtable);
+    });
+
     it('should normalize the arguments', function() {
       let normalizeArgumentsCalled = false;
       let options = {};


### PR DESCRIPTION
Fixes #215

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

I prefer the docs the way they are (with the `new` keyword) since that way is more idiomatic.