### PR TITLE
fix: use GCLOUD_PROJECT instead of PROJECT_ID

### DIFF
--- a/samples/hello-world/index.js
+++ b/samples/hello-world/index.js
@@ -16,18 +16,18 @@ const TABLE_ID = 'Hello-Bigtable';
 const COLUMN_FAMILY_ID = 'cf1';
 const COLUMN_QUALIFIER = 'greeting';
 const INSTANCE_ID = process.env.INSTANCE_ID;
-const PROJECT_ID = process.env.PROJECT_ID;
+const GCLOUD_PROJECT = process.env.GCLOUD_PROJECT;
 
 if (!INSTANCE_ID) {
   throw new Error('Environment variables for INSTANCE_ID must be set!');
 }
 
-if (!PROJECT_ID) {
-  throw new Error('Environment variables PROJECT_ID must be set!');
+if (!GCLOUD_PROJECT) {
+  throw new Error('Environment variables GCLOUD_PROJECT must be set!');
 }
 
 var bigtableOptions = {
-  projectId: PROJECT_ID,
+  projectId: GCLOUD_PROJECT,
 };
 
 const getRowGreeting = row => {

--- a/samples/hello-world/index.v6.js
+++ b/samples/hello-world/index.v6.js
@@ -18,18 +18,18 @@ const TABLE_ID = 'Hello-Bigtable';
 const COLUMN_FAMILY_ID = 'cf1';
 const COLUMN_QUALIFIER = 'greeting';
 const INSTANCE_ID = process.env.INSTANCE_ID;
-const PROJECT_ID = process.env.PROJECT_ID;
+const GCLOUD_PROJECT = process.env.GCLOUD_PROJECT;
 
 if (!INSTANCE_ID) {
   throw new Error('Environment variables for INSTANCE_ID must be set!');
 }
 
-if (!PROJECT_ID) {
-  throw new Error('Environment variables PROJECT_ID must be set!');
+if (!GCLOUD_PROJECT) {
+  throw new Error('Environment variables GCLOUD_PROJECT must be set!');
 }
 
 var bigtableOptions = {
-  projectId: PROJECT_ID,
+  projectId: GCLOUD_PROJECT,
 };
 
 const getRowGreeting = row => {

--- a/samples/instances.js
+++ b/samples/instances.js
@@ -17,14 +17,14 @@
 
 // Imports the Google Cloud client library
 const Bigtable = require('@google-cloud/bigtable');
-const PROJECT_ID = process.env.PROJECT_ID;
+const GCLOUD_PROJECT = process.env.GCLOUD_PROJECT;
 
-if (!PROJECT_ID) {
-  throw new Error('Environment variables PROJECT_ID must be set!');
+if (!GCLOUD_PROJECT) {
+  throw new Error('Environment variables GCLOUD_PROJECT must be set!');
 }
 
 var bigtableOptions = {
-  projectId: PROJECT_ID,
+  projectId: GCLOUD_PROJECT,
 };
 
 async function runInstanceOperations(instanceID, clusterID) {

--- a/samples/quickstart.js
+++ b/samples/quickstart.js
@@ -23,16 +23,16 @@ const Bigtable = require('@google-cloud/bigtable');
 const INSTANCE_ID = 'my-bigtable-instance';
 // The ID of the Cloud Bigtable table
 const TABLE_ID = 'my-table';
-const PROJECT_ID = process.env.PROJECT_ID;
+const GCLOUD_PROJECT = process.env.GCLOUD_PROJECT;
 
-if (!PROJECT_ID) {
-  throw new Error('Environment variables PROJECT_ID must be set!');
+if (!GCLOUD_PROJECT) {
+  throw new Error('Environment variables GCLOUD_PROJECT must be set!');
 }
 
 (async () => {
   try {
     var bigtableOptions = {
-      projectId: PROJECT_ID,
+      projectId: GCLOUD_PROJECT,
     };
 
     const bigtable = Bigtable(bigtableOptions);

--- a/samples/tableadmin.js
+++ b/samples/tableadmin.js
@@ -17,14 +17,14 @@
 
 // Imports the Google Cloud client library
 const Bigtable = require('@google-cloud/bigtable');
-const PROJECT_ID = process.env.PROJECT_ID;
+const GCLOUD_PROJECT = process.env.GCLOUD_PROJECT;
 
-if (!PROJECT_ID) {
-  throw new Error('Environment variables PROJECT_ID must be set!');
+if (!GCLOUD_PROJECT) {
+  throw new Error('Environment variables GCLOUD_PROJECT must be set!');
 }
 
 var bigtableOptions = {
-  projectId: PROJECT_ID,
+  projectId: GCLOUD_PROJECT,
 };
 
 async function runTableOperations(instanceID, tableID) {


### PR DESCRIPTION
We use `GCLOUD_PROJECT` across all our libraries so let's keep using it here.

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
