### PR TITLE
Use assert.deepStrictEqual instead of deepEqual.

### DIFF
--- a/samples/hello-world/package.json
+++ b/samples/hello-world/package.json
@@ -5,5 +5,8 @@
   "dependencies": {
     "@google-cloud/bigtable": "^0.15.0",
     "co": "^4.6.0"
+  },
+  "engines": {
+    "node": ">=8.0.0"
   }
 }

--- a/system-test/bigtable.js
+++ b/system-test/bigtable.js
@@ -423,7 +423,7 @@ describe('Bigtable', function() {
         assert.ifError(err);
         assert.strictEqual(families.length, 3);
         assert(families[0] instanceof Family);
-        assert.notEqual(
+        assert.notStrictEqual(
           -1,
           families
             .map(f => {
@@ -1204,7 +1204,11 @@ describe('Bigtable', function() {
 
             var columns = Object.keys(rows[0].data.follows).sort();
 
-            assert.deepStrictEqual(columns, ['gwashington', 'jadams', 'tjefferson']);
+            assert.deepStrictEqual(columns, [
+              'gwashington',
+              'jadams',
+              'tjefferson',
+            ]);
 
             done();
           });

--- a/system-test/bigtable.js
+++ b/system-test/bigtable.js
@@ -554,7 +554,7 @@ describe('Bigtable', function() {
         assert.ifError(err);
         var maxAge = metadata.gcRule.maxAge;
 
-        assert.strictEqual(maxAge.seconds, rule.age.seconds);
+        assert.strictEqual(maxAge.seconds, rule.age.seconds.toString());
         assert.strictEqual(maxAge.nanas, rule.age.nanas);
         done();
       });
@@ -942,7 +942,7 @@ describe('Bigtable', function() {
               })
               .sort();
 
-            assert.deepEqual(keys, ['alincoln', 'jadams', 'tjefferson']);
+            assert.deepStrictEqual(keys, ['alincoln', 'jadams', 'tjefferson']);
 
             done();
           });
@@ -1002,7 +1002,7 @@ describe('Bigtable', function() {
             rows.forEach(function(row) {
               var keys = Object.keys(row.data.follows).sort();
 
-              assert.deepEqual(keys, ['gwashington', 'jadams']);
+              assert.deepStrictEqual(keys, ['gwashington', 'jadams']);
             });
 
             done();
@@ -1087,7 +1087,7 @@ describe('Bigtable', function() {
               assert(rows.length > 0);
 
               var families = Object.keys(rows[0].data);
-              assert.deepEqual(families, ['traits']);
+              assert.deepStrictEqual(families, ['traits']);
               done();
             });
           });
@@ -1121,7 +1121,7 @@ describe('Bigtable', function() {
               })
               .sort();
 
-            assert.deepEqual(ids, ['gwashington', 'tjefferson']);
+            assert.deepStrictEqual(ids, ['gwashington', 'tjefferson']);
 
             done();
           });
@@ -1140,7 +1140,7 @@ describe('Bigtable', function() {
 
               Object.keys(follows).forEach(function(column) {
                 follows[column].forEach(function(cell) {
-                  assert.deepEqual(cell.labels, [filter.label]);
+                  assert.deepStrictEqual(cell.labels, [filter.label]);
                 });
               });
             });
@@ -1163,7 +1163,7 @@ describe('Bigtable', function() {
               })
               .sort();
 
-            assert.deepEqual(keys, ['gwashington', 'tjefferson']);
+            assert.deepStrictEqual(keys, ['gwashington', 'tjefferson']);
 
             done();
           });
@@ -1204,7 +1204,7 @@ describe('Bigtable', function() {
 
             var columns = Object.keys(rows[0].data.follows).sort();
 
-            assert.deepEqual(columns, ['gwashington', 'jadams', 'tjefferson']);
+            assert.deepStrictEqual(columns, ['gwashington', 'jadams', 'tjefferson']);
 
             done();
           });

--- a/system-test/mutate-rows.js
+++ b/system-test/mutate-rows.js
@@ -92,7 +92,7 @@ describe('Bigtable/Table', () => {
         responses = test.responses;
         TABLE.maxRetries = test.max_retries;
         TABLE.mutate(test.mutations_request, error => {
-          assert.deepEqual(
+          assert.deepStrictEqual(
             mutationBatchesInvoked,
             test.mutation_batches_invoked
           );
@@ -116,11 +116,11 @@ describe('Bigtable/Table', () => {
             const expectedIndices = test.errors.map(error => {
               return error.index_in_mutations_request;
             });
-            assert.deepEqual(error.name, 'PartialFailureError');
+            assert.deepStrictEqual(error.name, 'PartialFailureError');
             const actualIndices = error.errors.map(error => {
               return test.mutations_request.indexOf(error.entry);
             });
-            assert.deepEqual(expectedIndices, actualIndices);
+            assert.deepStrictEqual(expectedIndices, actualIndices);
           } else {
             assert.ifError(error);
           }

--- a/system-test/read-rows-acceptance-tests.js
+++ b/system-test/read-rows-acceptance-tests.js
@@ -128,7 +128,7 @@ describe('Read Row Acceptance tests', function() {
       function verify() {
         assert.strictEqual(errors.length, errorCount, ' error count mismatch');
         assert.strictEqual(rows.length, results.length, 'row count mismatch');
-        assert.deepEqual(rows, tableRows, 'row mismatch');
+        assert.deepStrictEqual(rows, tableRows, 'row mismatch');
         done();
       }
     });

--- a/test/app-profile.js
+++ b/test/app-profile.js
@@ -182,7 +182,7 @@ describe('Bigtable/AppProfile', function() {
         assert.strictEqual(config.client, 'BigtableInstanceAdminClient');
         assert.strictEqual(config.method, 'deleteAppProfile');
 
-        assert.deepEqual(config.reqOpts, {
+        assert.deepStrictEqual(config.reqOpts, {
           name: appProfile.name,
         });
 
@@ -290,7 +290,7 @@ describe('Bigtable/AppProfile', function() {
 
     it('should not require gaxOptions', function(done) {
       appProfile.getMetadata = function(gaxOptions) {
-        assert.deepEqual(gaxOptions, {});
+        assert.deepStrictEqual(gaxOptions, {});
         done();
       };
 
@@ -332,11 +332,11 @@ describe('Bigtable/AppProfile', function() {
         assert.strictEqual(config.client, 'BigtableInstanceAdminClient');
         assert.strictEqual(config.method, 'getAppProfile');
 
-        assert.deepEqual(config.reqOpts, {
+        assert.deepStrictEqual(config.reqOpts, {
           name: appProfile.name,
         });
 
-        assert.deepEqual(config.gaxOpts, {});
+        assert.deepStrictEqual(config.gaxOpts, {});
 
         done();
       };

--- a/test/chunktransformer.js
+++ b/test/chunktransformer.js
@@ -72,13 +72,21 @@ describe('Bigtable/ChunkTransformer', function() {
         null,
         'invalid initial state'
       );
-      assert.deepStrictEqual(chunkTransformer.family, {}, 'invalid initial state');
+      assert.deepStrictEqual(
+        chunkTransformer.family,
+        {},
+        'invalid initial state'
+      );
       assert.deepStrictEqual(
         chunkTransformer.qualifiers,
         [],
         'invalid initial state'
       );
-      assert.deepStrictEqual(chunkTransformer.qualifier, {}, 'invalid initial state');
+      assert.deepStrictEqual(
+        chunkTransformer.qualifier,
+        {},
+        'invalid initial state'
+      );
       assert.deepStrictEqual(
         chunkTransformer.state,
         RowStateEnum.NEW_ROW,
@@ -596,7 +604,11 @@ describe('Bigtable/ChunkTransformer', function() {
           },
         },
       };
-      assert.deepStrictEqual(chunkTransformer.row, expectedState, 'row mismatch');
+      assert.deepStrictEqual(
+        chunkTransformer.row,
+        expectedState,
+        'row mismatch'
+      );
       assert.strictEqual(
         chunkTransformer.state,
         RowStateEnum.ROW_IN_PROGRESS,
@@ -775,7 +787,11 @@ describe('Bigtable/ChunkTransformer', function() {
           },
         },
       };
-      assert.deepStrictEqual(chunkTransformer.row, expectedState, 'row mismatch');
+      assert.deepStrictEqual(
+        chunkTransformer.row,
+        expectedState,
+        'row mismatch'
+      );
       assert.strictEqual(
         chunkTransformer.state,
         RowStateEnum.ROW_IN_PROGRESS,
@@ -834,7 +850,11 @@ describe('Bigtable/ChunkTransformer', function() {
           },
         },
       };
-      assert.deepStrictEqual(chunkTransformer.row, expectedState, 'row mismatch');
+      assert.deepStrictEqual(
+        chunkTransformer.row,
+        expectedState,
+        'row mismatch'
+      );
       assert.strictEqual(
         chunkTransformer.state,
         RowStateEnum.ROW_IN_PROGRESS,
@@ -968,13 +988,21 @@ describe('Bigtable/ChunkTransformer', function() {
         null,
         'invalid initial state'
       );
-      assert.deepStrictEqual(chunkTransformer.family, {}, 'invalid initial state');
+      assert.deepStrictEqual(
+        chunkTransformer.family,
+        {},
+        'invalid initial state'
+      );
       assert.deepStrictEqual(
         chunkTransformer.qualifiers,
         [],
         'invalid initial state'
       );
-      assert.deepStrictEqual(chunkTransformer.qualifier, {}, 'invalid initial state');
+      assert.deepStrictEqual(
+        chunkTransformer.qualifier,
+        {},
+        'invalid initial state'
+      );
       assert.deepStrictEqual(
         chunkTransformer.state,
         RowStateEnum.NEW_ROW,
@@ -1014,13 +1042,21 @@ describe('Bigtable/ChunkTransformer', function() {
         'key',
         'invalid initial state'
       );
-      assert.deepStrictEqual(chunkTransformer.family, {}, 'invalid initial state');
+      assert.deepStrictEqual(
+        chunkTransformer.family,
+        {},
+        'invalid initial state'
+      );
       assert.deepStrictEqual(
         chunkTransformer.qualifiers,
         [],
         'invalid initial state'
       );
-      assert.deepStrictEqual(chunkTransformer.qualifier, {}, 'invalid initial state');
+      assert.deepStrictEqual(
+        chunkTransformer.qualifier,
+        {},
+        'invalid initial state'
+      );
       assert.deepStrictEqual(
         chunkTransformer.state,
         RowStateEnum.NEW_ROW,

--- a/test/chunktransformer.js
+++ b/test/chunktransformer.js
@@ -66,20 +66,20 @@ describe('Bigtable/ChunkTransformer', function() {
       this.qualifier = {};
       this.row = {};
       this.state = RowStateEnum.NEW_ROW;
-      assert.deepEqual(chunkTransformer.row, {}, 'invalid initial state');
-      assert.deepEqual(
+      assert.deepStrictEqual(chunkTransformer.row, {}, 'invalid initial state');
+      assert.deepStrictEqual(
         chunkTransformer.prevRowKey,
         null,
         'invalid initial state'
       );
-      assert.deepEqual(chunkTransformer.family, {}, 'invalid initial state');
-      assert.deepEqual(
+      assert.deepStrictEqual(chunkTransformer.family, {}, 'invalid initial state');
+      assert.deepStrictEqual(
         chunkTransformer.qualifiers,
         [],
         'invalid initial state'
       );
-      assert.deepEqual(chunkTransformer.qualifier, {}, 'invalid initial state');
-      assert.deepEqual(
+      assert.deepStrictEqual(chunkTransformer.qualifier, {}, 'invalid initial state');
+      assert.deepStrictEqual(
         chunkTransformer.state,
         RowStateEnum.NEW_ROW,
         'invalid initial state'
@@ -204,7 +204,7 @@ describe('Bigtable/ChunkTransformer', function() {
           },
         },
       };
-      assert.deepEqual(rows[0], expectedRow);
+      assert.deepStrictEqual(rows[0], expectedRow);
     });
     it('partial row  ', function() {
       const chunk = {
@@ -235,7 +235,7 @@ describe('Bigtable/ChunkTransformer', function() {
           },
         },
       };
-      assert.deepEqual(chunkTransformer.row, partialRow);
+      assert.deepStrictEqual(chunkTransformer.row, partialRow);
       assert.strictEqual(
         chunkTransformer.state,
         RowStateEnum.ROW_IN_PROGRESS,
@@ -271,7 +271,7 @@ describe('Bigtable/ChunkTransformer', function() {
           },
         },
       };
-      assert.deepEqual(chunkTransformer.row, partialRow);
+      assert.deepStrictEqual(chunkTransformer.row, partialRow);
       assert.strictEqual(
         chunkTransformer.state,
         RowStateEnum.CELL_IN_PROGRESS,
@@ -407,7 +407,7 @@ describe('Bigtable/ChunkTransformer', function() {
         },
       };
       const row = rows[0];
-      assert.deepEqual(row, expectedRow, 'row mismatch');
+      assert.deepStrictEqual(row, expectedRow, 'row mismatch');
       assert.strictEqual(
         chunkTransformer.state,
         RowStateEnum.NEW_ROW,
@@ -453,7 +453,7 @@ describe('Bigtable/ChunkTransformer', function() {
         },
       };
       const row = rows[0];
-      assert.deepEqual(row, expectedRow, 'row mismatch');
+      assert.deepStrictEqual(row, expectedRow, 'row mismatch');
       assert.strictEqual(
         chunkTransformer.state,
         RowStateEnum.NEW_ROW,
@@ -502,7 +502,7 @@ describe('Bigtable/ChunkTransformer', function() {
         },
       };
       const row = rows[0];
-      assert.deepEqual(row, expectedRow, 'row mismatch');
+      assert.deepStrictEqual(row, expectedRow, 'row mismatch');
       assert.strictEqual(
         chunkTransformer.state,
         RowStateEnum.NEW_ROW,
@@ -544,7 +544,7 @@ describe('Bigtable/ChunkTransformer', function() {
           },
         },
       };
-      assert.deepEqual(
+      assert.deepStrictEqual(
         chunkTransformer.row,
         expectedState,
         'row state mismatch'
@@ -596,7 +596,7 @@ describe('Bigtable/ChunkTransformer', function() {
           },
         },
       };
-      assert.deepEqual(chunkTransformer.row, expectedState, 'row mismatch');
+      assert.deepStrictEqual(chunkTransformer.row, expectedState, 'row mismatch');
       assert.strictEqual(
         chunkTransformer.state,
         RowStateEnum.ROW_IN_PROGRESS,
@@ -727,7 +727,7 @@ describe('Bigtable/ChunkTransformer', function() {
         },
       };
       const row = rows[0];
-      assert.deepEqual(row, expectedRow, 'row mismatch');
+      assert.deepStrictEqual(row, expectedRow, 'row mismatch');
       assert.strictEqual(
         chunkTransformer.state,
         RowStateEnum.NEW_ROW,
@@ -775,7 +775,7 @@ describe('Bigtable/ChunkTransformer', function() {
           },
         },
       };
-      assert.deepEqual(chunkTransformer.row, expectedState, 'row mismatch');
+      assert.deepStrictEqual(chunkTransformer.row, expectedState, 'row mismatch');
       assert.strictEqual(
         chunkTransformer.state,
         RowStateEnum.ROW_IN_PROGRESS,
@@ -834,7 +834,7 @@ describe('Bigtable/ChunkTransformer', function() {
           },
         },
       };
-      assert.deepEqual(chunkTransformer.row, expectedState, 'row mismatch');
+      assert.deepStrictEqual(chunkTransformer.row, expectedState, 'row mismatch');
       assert.strictEqual(
         chunkTransformer.state,
         RowStateEnum.ROW_IN_PROGRESS,
@@ -938,7 +938,7 @@ describe('Bigtable/ChunkTransformer', function() {
         {},
         callback
       );
-      assert.deepEqual(chunkTransformer.lastRowKey, 'foo');
+      assert.deepStrictEqual(chunkTransformer.lastRowKey, 'foo');
     });
   });
   describe('reset', function() {
@@ -962,20 +962,20 @@ describe('Bigtable/ChunkTransformer', function() {
       };
       this.state = RowStateEnum.CELL_IN_PROGRESS;
       chunkTransformer.reset();
-      assert.deepEqual(chunkTransformer.row, {}, 'invalid initial state');
-      assert.deepEqual(
+      assert.deepStrictEqual(chunkTransformer.row, {}, 'invalid initial state');
+      assert.deepStrictEqual(
         chunkTransformer.prevRowKey,
         null,
         'invalid initial state'
       );
-      assert.deepEqual(chunkTransformer.family, {}, 'invalid initial state');
-      assert.deepEqual(
+      assert.deepStrictEqual(chunkTransformer.family, {}, 'invalid initial state');
+      assert.deepStrictEqual(
         chunkTransformer.qualifiers,
         [],
         'invalid initial state'
       );
-      assert.deepEqual(chunkTransformer.qualifier, {}, 'invalid initial state');
-      assert.deepEqual(
+      assert.deepStrictEqual(chunkTransformer.qualifier, {}, 'invalid initial state');
+      assert.deepStrictEqual(
         chunkTransformer.state,
         RowStateEnum.NEW_ROW,
         'invalid initial state'
@@ -1008,20 +1008,20 @@ describe('Bigtable/ChunkTransformer', function() {
       this.state = RowStateEnum.CELL_IN_PROGRESS;
       chunkTransformer.commit();
       assert(resetSpy.called, 'did not call reset');
-      assert.deepEqual(chunkTransformer.row, {}, 'invalid initial state');
-      assert.deepEqual(
+      assert.deepStrictEqual(chunkTransformer.row, {}, 'invalid initial state');
+      assert.deepStrictEqual(
         chunkTransformer.prevRowKey,
         'key',
         'invalid initial state'
       );
-      assert.deepEqual(chunkTransformer.family, {}, 'invalid initial state');
-      assert.deepEqual(
+      assert.deepStrictEqual(chunkTransformer.family, {}, 'invalid initial state');
+      assert.deepStrictEqual(
         chunkTransformer.qualifiers,
         [],
         'invalid initial state'
       );
-      assert.deepEqual(chunkTransformer.qualifier, {}, 'invalid initial state');
-      assert.deepEqual(
+      assert.deepStrictEqual(chunkTransformer.qualifier, {}, 'invalid initial state');
+      assert.deepStrictEqual(
         chunkTransformer.state,
         RowStateEnum.NEW_ROW,
         'invalid initial state'
@@ -1072,7 +1072,7 @@ describe('Bigtable/ChunkTransformer', function() {
         },
       };
       const row = rows[0];
-      assert.deepEqual(row, expectedRow, 'row mismatch');
+      assert.deepStrictEqual(row, expectedRow, 'row mismatch');
       assert.strictEqual(
         chunkTransformer.state,
         RowStateEnum.NEW_ROW,

--- a/test/cluster.js
+++ b/test/cluster.js
@@ -172,11 +172,11 @@ describe('Bigtable/Cluster', function() {
         assert.strictEqual(config.client, 'BigtableInstanceAdminClient');
         assert.strictEqual(config.method, 'deleteCluster');
 
-        assert.deepEqual(config.reqOpts, {
+        assert.deepStrictEqual(config.reqOpts, {
           name: cluster.name,
         });
 
-        assert.deepEqual(config.gaxOpts, {});
+        assert.deepStrictEqual(config.gaxOpts, {});
 
         callback(); // done()
       };
@@ -273,7 +273,7 @@ describe('Bigtable/Cluster', function() {
 
     it('should not require gaxOptions', function(done) {
       cluster.getMetadata = function(gaxOptions) {
-        assert.deepEqual(gaxOptions, {});
+        assert.deepStrictEqual(gaxOptions, {});
         done();
       };
 
@@ -315,11 +315,11 @@ describe('Bigtable/Cluster', function() {
         assert.strictEqual(config.client, 'BigtableInstanceAdminClient');
         assert.strictEqual(config.method, 'getCluster');
 
-        assert.deepEqual(config.reqOpts, {
+        assert.deepStrictEqual(config.reqOpts, {
           name: cluster.name,
         });
 
-        assert.deepEqual(config.gaxOpts, {});
+        assert.deepStrictEqual(config.gaxOpts, {});
 
         done();
       };

--- a/test/family.js
+++ b/test/family.js
@@ -103,7 +103,7 @@ describe('Bigtable/Family', function() {
 
       let rule = Family.formatRule_(originalRule);
 
-      assert.deepEqual(rule, {
+      assert.deepStrictEqual(rule, {
         maxAge: originalRule.age,
       });
     });
@@ -115,7 +115,7 @@ describe('Bigtable/Family', function() {
 
       let rule = Family.formatRule_(originalRule);
 
-      assert.deepEqual(rule, {
+      assert.deepStrictEqual(rule, {
         maxNumVersions: originalRule.versions,
       });
     });
@@ -129,7 +129,7 @@ describe('Bigtable/Family', function() {
 
       let rule = Family.formatRule_(originalRule);
 
-      assert.deepEqual(rule, {
+      assert.deepStrictEqual(rule, {
         union: {
           rules: [
             {
@@ -151,7 +151,7 @@ describe('Bigtable/Family', function() {
 
       let rule = Family.formatRule_(originalRule);
 
-      assert.deepEqual(rule, {
+      assert.deepStrictEqual(rule, {
         intersection: {
           rules: [
             {
@@ -174,7 +174,7 @@ describe('Bigtable/Family', function() {
 
       let rule = Family.formatRule_(originalRule);
 
-      assert.deepEqual(rule, {
+      assert.deepStrictEqual(rule, {
         union: {
           rules: [
             {maxAge: originalRule.age},
@@ -520,7 +520,7 @@ describe('Bigtable/Family', function() {
         assert.strictEqual(config.method, 'modifyColumnFamilies');
 
         assert.strictEqual(config.reqOpts.name, TABLE.name);
-        assert.deepEqual(config.reqOpts.modifications, [
+        assert.deepStrictEqual(config.reqOpts.modifications, [
           {
             id: FAMILY_ID,
             update: {},
@@ -554,7 +554,7 @@ describe('Bigtable/Family', function() {
       };
 
       family.bigtable.request = function(config) {
-        assert.deepEqual(config.reqOpts, {
+        assert.deepStrictEqual(config.reqOpts, {
           name: TABLE.name,
           modifications: [
             {

--- a/test/filter.js
+++ b/test/filter.js
@@ -47,7 +47,7 @@ describe('Bigtable/Filter', function() {
 
   describe('instantiation', function() {
     it('should create an empty array of filters', function() {
-      assert.deepEqual(filter.filters_, []);
+      assert.deepStrictEqual(filter.filters_, []);
     });
   });
 
@@ -118,7 +118,7 @@ describe('Bigtable/Filter', function() {
 
       let range = Filter.createRange(start, end, key);
 
-      assert.deepEqual(range, {
+      assert.deepStrictEqual(range, {
         startKeyClosed: start,
         endKeyClosed: end,
       });
@@ -131,7 +131,7 @@ describe('Bigtable/Filter', function() {
       let range = Filter.createRange(start, null, key);
 
       assert(FakeMutation.convertToBytes.calledWithExactly(start));
-      assert.deepEqual(range, {
+      assert.deepStrictEqual(range, {
         startKeyClosed: start,
       });
     });
@@ -143,7 +143,7 @@ describe('Bigtable/Filter', function() {
       let range = Filter.createRange(null, end, key);
 
       assert(FakeMutation.convertToBytes.calledWithExactly(end));
-      assert.deepEqual(range, {
+      assert.deepStrictEqual(range, {
         endKeyClosed: end,
       });
     });
@@ -163,7 +163,7 @@ describe('Bigtable/Filter', function() {
 
       let range = Filter.createRange(start, end, key);
 
-      assert.deepEqual(range, {
+      assert.deepStrictEqual(range, {
         startKeyOpen: start.value,
         endKeyOpen: end.value,
       });
@@ -341,7 +341,7 @@ describe('Bigtable/Filter', function() {
 
       filter.set = function(filterName, value) {
         assert.strictEqual(filterName, 'condition');
-        assert.deepEqual(value, {
+        assert.deepStrictEqual(value, {
           predicateFilter: condition.test,
           trueFilter: condition.pass,
           falseFilter: condition.fail,

--- a/test/index.js
+++ b/test/index.js
@@ -42,7 +42,11 @@ const fakeUtil = extend({}, common.util, {
     }
 
     promisified = true;
-    assert.deepStrictEqual(options.exclude, ['instance', 'operation', 'request']);
+    assert.deepStrictEqual(options.exclude, [
+      'instance',
+      'operation',
+      'request',
+    ]);
   },
   replaceProjectIdToken: function(reqOpts) {
     if (replaceProjectIdTokenOverride) {

--- a/test/index.js
+++ b/test/index.js
@@ -42,7 +42,7 @@ const fakeUtil = extend({}, common.util, {
     }
 
     promisified = true;
-    assert.deepEqual(options.exclude, ['instance', 'operation', 'request']);
+    assert.deepStrictEqual(options.exclude, ['instance', 'operation', 'request']);
   },
   replaceProjectIdToken: function(reqOpts) {
     if (replaceProjectIdTokenOverride) {
@@ -157,7 +157,7 @@ describe('Bigtable', function() {
     });
 
     it('should initialize the API object', function() {
-      assert.deepEqual(bigtable.api, {});
+      assert.deepStrictEqual(bigtable.api, {});
     });
 
     it('should cache a local google-auth-library instance', function() {
@@ -168,7 +168,7 @@ describe('Bigtable', function() {
       };
 
       googleAuthOverride = function(options_) {
-        assert.deepEqual(
+        assert.deepStrictEqual(
           options_,
           extend(
             {
@@ -209,7 +209,7 @@ describe('Bigtable', function() {
         'grpc.max_receive_message_length': -1,
       };
 
-      assert.deepEqual(bigtable.options, {
+      assert.deepStrictEqual(bigtable.options, {
         BigtableClient: extend(
           {
             servicePath: 'bigtable.googleapis.com',
@@ -257,7 +257,7 @@ describe('Bigtable', function() {
         process.env.BIGTABLE_EMULATOR_HOST
       );
 
-      assert.deepEqual(bigtable.options, {
+      assert.deepStrictEqual(bigtable.options, {
         BigtableClient: extend(
           {
             servicePath: 'override',
@@ -301,7 +301,7 @@ describe('Bigtable', function() {
 
       assert.strictEqual(bigtable.customEndpoint, options.apiEndpoint);
 
-      assert.deepEqual(bigtable.options, {
+      assert.deepStrictEqual(bigtable.options, {
         BigtableClient: extend(
           {
             servicePath: 'customEndpoint',
@@ -406,7 +406,7 @@ describe('Bigtable', function() {
       };
 
       bigtable.request = function(config) {
-        assert.deepEqual(config.reqOpts.instance.type, fakeTypeType);
+        assert.deepStrictEqual(config.reqOpts.instance.type, fakeTypeType);
         done();
       };
 
@@ -421,7 +421,7 @@ describe('Bigtable', function() {
       };
 
       bigtable.request = function(config) {
-        assert.deepEqual(config.reqOpts.instance.labels, options.labels);
+        assert.deepStrictEqual(config.reqOpts.instance.labels, options.labels);
         done();
       };
 
@@ -454,7 +454,7 @@ describe('Bigtable', function() {
       };
 
       bigtable.request = function(config) {
-        assert.deepEqual(config.reqOpts.clusters, {
+        assert.deepStrictEqual(config.reqOpts.clusters, {
           'my-cluster': {
             location: fakeLocation,
             serveNodes: cluster.nodes,
@@ -520,7 +520,7 @@ describe('Bigtable', function() {
         assert.deepStrictEqual(config.reqOpts, {
           parent: bigtable.projectName,
         });
-        assert.deepEqual(config.gaxOpts, {});
+        assert.deepStrictEqual(config.gaxOpts, {});
         done();
       };
 
@@ -703,7 +703,7 @@ describe('Bigtable', function() {
 
         replaceProjectIdTokenOverride = function(reqOpts, projectId) {
           assert.notStrictEqual(reqOpts, CONFIG.reqOpts);
-          assert.deepEqual(reqOpts, CONFIG.reqOpts);
+          assert.deepStrictEqual(reqOpts, CONFIG.reqOpts);
           assert.strictEqual(projectId, PROJECT_ID);
 
           return replacedReqOpts;
@@ -750,7 +750,7 @@ describe('Bigtable', function() {
         bigtable.api[CONFIG.client][CONFIG.method] = {
           bind: function(gaxClient, reqOpts, gaxOpts) {
             assert.strictEqual(gaxClient, bigtable.api[CONFIG.client]);
-            assert.deepEqual(reqOpts, CONFIG.reqOpts);
+            assert.deepStrictEqual(reqOpts, CONFIG.reqOpts);
             assert.strictEqual(gaxOpts, CONFIG.gaxOpts);
 
             setImmediate(done);
@@ -828,7 +828,7 @@ describe('Bigtable', function() {
         bigtable.api[CONFIG.client][CONFIG.method] = {
           bind: function(gaxClient, reqOpts, gaxOpts) {
             assert.strictEqual(gaxClient, bigtable.api[CONFIG.client]);
-            assert.deepEqual(reqOpts, CONFIG.reqOpts);
+            assert.deepStrictEqual(reqOpts, CONFIG.reqOpts);
             assert.strictEqual(gaxOpts, CONFIG.gaxOpts);
 
             setImmediate(done);

--- a/test/instance.js
+++ b/test/instance.js
@@ -34,7 +34,7 @@ const fakeUtil = extend({}, common.util, {
     }
 
     promisified = true;
-    assert.deepEqual(options.exclude, ['appProfile', 'cluster', 'table']);
+    assert.deepStrictEqual(options.exclude, ['appProfile', 'cluster', 'table']);
   },
 });
 
@@ -94,7 +94,7 @@ describe('Bigtable/Instance', function() {
       let args = fakePaginator.calledWith_;
 
       assert.strictEqual(args[0], Instance);
-      assert.deepEqual(args[1], ['getTables']);
+      assert.deepStrictEqual(args[1], ['getTables']);
     });
 
     it('should streamify the correct methods', function() {
@@ -492,7 +492,7 @@ describe('Bigtable/Instance', function() {
       let expectedSplits = [{key: 'a'}, {key: 'b'}];
 
       instance.bigtable.request = function(config) {
-        assert.deepEqual(config.reqOpts.initialSplits, expectedSplits);
+        assert.deepStrictEqual(config.reqOpts.initialSplits, expectedSplits);
         done();
       };
 
@@ -506,7 +506,7 @@ describe('Bigtable/Instance', function() {
         };
 
         instance.bigtable.request = function(config) {
-          assert.deepEqual(config.reqOpts.table.columnFamilies, {
+          assert.deepStrictEqual(config.reqOpts.table.columnFamilies, {
             a: {},
             b: {},
           });
@@ -535,7 +535,7 @@ describe('Bigtable/Instance', function() {
         };
 
         instance.bigtable.request = function(config) {
-          assert.deepEqual(config.reqOpts.table.columnFamilies, {
+          assert.deepStrictEqual(config.reqOpts.table.columnFamilies, {
             e: {
               gcRule: fakeRule,
             },
@@ -592,11 +592,11 @@ describe('Bigtable/Instance', function() {
         assert.strictEqual(config.client, 'BigtableInstanceAdminClient');
         assert.strictEqual(config.method, 'deleteInstance');
 
-        assert.deepEqual(config.reqOpts, {
+        assert.deepStrictEqual(config.reqOpts, {
           name: instance.name,
         });
 
-        assert.deepEqual(config.gaxOpts, {});
+        assert.deepStrictEqual(config.gaxOpts, {});
 
         callback(); // done()
       };
@@ -693,7 +693,7 @@ describe('Bigtable/Instance', function() {
 
     it('should not require gaxOptions', function(done) {
       instance.getMetadata = function(gaxOptions) {
-        assert.deepEqual(gaxOptions, {});
+        assert.deepStrictEqual(gaxOptions, {});
         done();
       };
 
@@ -737,7 +737,7 @@ describe('Bigtable/Instance', function() {
         assert.deepStrictEqual(config.reqOpts, {
           parent: INSTANCE_NAME,
         });
-        assert.deepEqual(config.gaxOpts, {});
+        assert.deepStrictEqual(config.gaxOpts, {});
         done();
       };
 
@@ -795,7 +795,7 @@ describe('Bigtable/Instance', function() {
         assert.deepStrictEqual(config.reqOpts, {
           parent: INSTANCE_NAME,
         });
-        assert.deepEqual(config.gaxOpts, {});
+        assert.deepStrictEqual(config.gaxOpts, {});
         done();
       };
 
@@ -869,11 +869,11 @@ describe('Bigtable/Instance', function() {
         assert.strictEqual(config.client, 'BigtableInstanceAdminClient');
         assert.strictEqual(config.method, 'getInstance');
 
-        assert.deepEqual(config.reqOpts, {
+        assert.deepStrictEqual(config.reqOpts, {
           name: instance.name,
         });
 
-        assert.deepEqual(config.gaxOpts, {});
+        assert.deepStrictEqual(config.gaxOpts, {});
 
         done();
       };

--- a/test/mutation.js
+++ b/test/mutation.js
@@ -62,7 +62,7 @@ describe('Bigtable/Mutation', function() {
         );
         let decoded = Mutation.convertFromBytes(encoded);
 
-        assert.notEqual(num, decoded);
+        assert.notStrictEqual(num, decoded);
       });
     });
 

--- a/test/mutation.js
+++ b/test/mutation.js
@@ -176,7 +176,7 @@ describe('Bigtable/Mutation', function() {
 
       assert.strictEqual(cells.length, 2);
 
-      assert.deepEqual(cells, [
+      assert.deepStrictEqual(cells, [
         {
           setCell: {
             familyName: 'follows',
@@ -196,7 +196,7 @@ describe('Bigtable/Mutation', function() {
       ]);
 
       assert.strictEqual(convertCalls.length, 4);
-      assert.deepEqual(convertCalls, ['gwashington', 1, 'alincoln', 1]);
+      assert.deepStrictEqual(convertCalls, ['gwashington', 1, 'alincoln', 1]);
     });
 
     it('should optionally accept a timestamp', function() {
@@ -211,7 +211,7 @@ describe('Bigtable/Mutation', function() {
 
       let cells = Mutation.encodeSetCell(fakeMutation);
 
-      assert.deepEqual(cells, [
+      assert.deepStrictEqual(cells, [
         {
           setCell: {
             familyName: 'follows',
@@ -223,7 +223,7 @@ describe('Bigtable/Mutation', function() {
       ]);
 
       assert.strictEqual(convertCalls.length, 2);
-      assert.deepEqual(convertCalls, ['gwashington', 1]);
+      assert.deepStrictEqual(convertCalls, ['gwashington', 1]);
     });
 
     it('should accept buffers', function() {
@@ -236,7 +236,7 @@ describe('Bigtable/Mutation', function() {
 
       let cells = Mutation.encodeSetCell(fakeMutation);
 
-      assert.deepEqual(cells, [
+      assert.deepStrictEqual(cells, [
         {
           setCell: {
             familyName: 'follows',
@@ -248,7 +248,7 @@ describe('Bigtable/Mutation', function() {
       ]);
 
       assert.strictEqual(convertCalls.length, 2);
-      assert.deepEqual(convertCalls, ['gwashington', val]);
+      assert.deepStrictEqual(convertCalls, ['gwashington', val]);
     });
   });
 
@@ -275,7 +275,7 @@ describe('Bigtable/Mutation', function() {
     it('should create a delete row mutation', function() {
       let mutation = Mutation.encodeDelete();
 
-      assert.deepEqual(mutation, [
+      assert.deepStrictEqual(mutation, [
         {
           deleteFromRow: {},
         },
@@ -286,7 +286,7 @@ describe('Bigtable/Mutation', function() {
       let fakeKey = 'follows';
       let mutation = Mutation.encodeDelete(fakeKey);
 
-      assert.deepEqual(mutation, [
+      assert.deepStrictEqual(mutation, [
         {
           deleteFromFamily: {
             familyName: fakeKey,
@@ -305,7 +305,7 @@ describe('Bigtable/Mutation', function() {
 
       let mutation = Mutation.encodeDelete(['follows']);
 
-      assert.deepEqual(mutation, [
+      assert.deepStrictEqual(mutation, [
         {
           deleteFromFamily: {
             familyName: fakeColumnName.family,
@@ -317,7 +317,7 @@ describe('Bigtable/Mutation', function() {
     it('should create a delete column mutation', function() {
       let mutation = Mutation.encodeDelete(['follows:gwashington']);
 
-      assert.deepEqual(mutation, [
+      assert.deepStrictEqual(mutation, [
         {
           deleteFromColumn: {
             familyName: 'follows',
@@ -354,7 +354,7 @@ describe('Bigtable/Mutation', function() {
 
       let mutation = Mutation.encodeDelete(fakeMutationData);
 
-      assert.deepEqual(mutation, [
+      assert.deepStrictEqual(mutation, [
         {
           deleteFromColumn: {
             familyName: 'follows',
@@ -365,7 +365,7 @@ describe('Bigtable/Mutation', function() {
       ]);
 
       assert.strictEqual(timeCalls.length, 1);
-      assert.deepEqual(timeCalls[0], fakeMutationData.time);
+      assert.deepStrictEqual(timeCalls[0], fakeMutationData.time);
 
       Mutation.createTimeRange = createTimeRange;
     });

--- a/test/row.js
+++ b/test/row.js
@@ -874,8 +874,14 @@ describe('Bigtable/Row', function() {
         assert.strictEqual(config.method, 'checkAndMutateRow');
         assert.strictEqual(config.reqOpts.tableName, TABLE.name);
         assert.strictEqual(config.reqOpts.rowKey, CONVERTED_ROW_ID);
-        assert.deepStrictEqual(config.reqOpts.predicateFilter, fakeParsedFilter);
-        assert.deepStrictEqual(config.reqOpts.trueMutations, fakeMutations.mutations);
+        assert.deepStrictEqual(
+          config.reqOpts.predicateFilter,
+          fakeParsedFilter
+        );
+        assert.deepStrictEqual(
+          config.reqOpts.trueMutations,
+          fakeMutations.mutations
+        );
         assert.deepStrictEqual(
           config.reqOpts.falseMutations,
           fakeMutations.mutations

--- a/test/row.js
+++ b/test/row.js
@@ -111,7 +111,7 @@ describe('Bigtable/Row', function() {
     });
 
     it('should create an empty data object', function() {
-      assert.deepEqual(row.data, {});
+      assert.deepStrictEqual(row.data, {});
     });
   });
 
@@ -154,7 +154,7 @@ describe('Bigtable/Row', function() {
 
       let rows = Row.formatChunks_(chunks);
 
-      assert.deepEqual(rows, [
+      assert.deepStrictEqual(rows, [
         {
           key: 'convertedKey',
           data: {
@@ -199,7 +199,7 @@ describe('Bigtable/Row', function() {
 
       let rows = Row.formatChunks_(chunks);
 
-      assert.deepEqual(rows, [
+      assert.deepStrictEqual(rows, [
         {
           key: 'convertedKey',
           data: {
@@ -240,7 +240,7 @@ describe('Bigtable/Row', function() {
 
       let rows = Row.formatChunks_(chunks);
 
-      assert.deepEqual(rows, [
+      assert.deepStrictEqual(rows, [
         {
           key: 'convertedKey',
           data: {
@@ -286,7 +286,7 @@ describe('Bigtable/Row', function() {
 
       let rows = Row.formatChunks_(chunks);
 
-      assert.deepEqual(rows, [
+      assert.deepStrictEqual(rows, [
         {
           key: 'convertedKey',
           data: {
@@ -353,7 +353,7 @@ describe('Bigtable/Row', function() {
 
       let rows = Row.formatChunks_(chunks, formatOptions);
 
-      assert.deepEqual(rows, [
+      assert.deepStrictEqual(rows, [
         {
           key: 'convertedKey',
           data: {
@@ -413,7 +413,7 @@ describe('Bigtable/Row', function() {
 
       let rows = Row.formatChunks_(chunks, formatOptions);
 
-      assert.deepEqual(rows, [
+      assert.deepStrictEqual(rows, [
         {
           key: 'ø',
           data: {
@@ -476,7 +476,7 @@ describe('Bigtable/Row', function() {
 
       let rows = Row.formatChunks_(chunks);
 
-      assert.deepEqual(rows, [
+      assert.deepStrictEqual(rows, [
         {
           key: 'convertedKey2',
           data: {
@@ -531,7 +531,7 @@ describe('Bigtable/Row', function() {
 
     it('should format the families into a user-friendly format', function() {
       let formatted = Row.formatFamilies_(families);
-      assert.deepEqual(formatted, formattedRowData);
+      assert.deepStrictEqual(formatted, formattedRowData);
 
       let convertStpy = FakeMutation.convertFromBytes;
       assert.strictEqual(convertStpy.callCount, 2);
@@ -544,7 +544,7 @@ describe('Bigtable/Row', function() {
         decode: false,
       });
 
-      assert.deepEqual(formatted, formattedRowData);
+      assert.deepStrictEqual(formatted, formattedRowData);
 
       let convertStpy = FakeMutation.convertFromBytes;
       assert.strictEqual(convertStpy.callCount, 1);
@@ -649,7 +649,7 @@ describe('Bigtable/Row', function() {
         assert.strictEqual(config.reqOpts.tableName, TABLE.name);
         assert.strictEqual(config.reqOpts.rowKey, CONVERTED_ROW_ID);
 
-        assert.deepEqual(config.reqOpts.rules, [
+        assert.deepStrictEqual(config.reqOpts.rules, [
           {
             familyName: 'a',
             columnQualifier: 'b',
@@ -874,9 +874,9 @@ describe('Bigtable/Row', function() {
         assert.strictEqual(config.method, 'checkAndMutateRow');
         assert.strictEqual(config.reqOpts.tableName, TABLE.name);
         assert.strictEqual(config.reqOpts.rowKey, CONVERTED_ROW_ID);
-        assert.deepEqual(config.reqOpts.predicateFilter, fakeParsedFilter);
-        assert.deepEqual(config.reqOpts.trueMutations, fakeMutations.mutations);
-        assert.deepEqual(
+        assert.deepStrictEqual(config.reqOpts.predicateFilter, fakeParsedFilter);
+        assert.deepStrictEqual(config.reqOpts.trueMutations, fakeMutations.mutations);
+        assert.deepStrictEqual(
           config.reqOpts.falseMutations,
           fakeMutations.mutations
         );
@@ -995,7 +995,7 @@ describe('Bigtable/Row', function() {
       ];
 
       row.table.getRows = function(reqOpts) {
-        assert.deepEqual(reqOpts.filter, expectedFilter);
+        assert.deepStrictEqual(reqOpts.filter, expectedFilter);
         assert.strictEqual(FakeMutation.parseColumnName.callCount, 1);
         assert(FakeMutation.parseColumnName.calledWith(keys[0]));
         done();
@@ -1031,7 +1031,7 @@ describe('Bigtable/Row', function() {
       ];
 
       row.table.getRows = function(reqOpts) {
-        assert.deepEqual(reqOpts.filter, expectedFilter);
+        assert.deepStrictEqual(reqOpts.filter, expectedFilter);
 
         let spy = FakeMutation.parseColumnName;
 
@@ -1054,7 +1054,7 @@ describe('Bigtable/Row', function() {
       ];
 
       row.table.getRows = function(reqOpts) {
-        assert.deepEqual(reqOpts.filter, expectedFilter);
+        assert.deepStrictEqual(reqOpts.filter, expectedFilter);
         assert.strictEqual(FakeMutation.parseColumnName.callCount, 1);
         assert(FakeMutation.parseColumnName.calledWith(keys[0]));
         done();
@@ -1092,7 +1092,7 @@ describe('Bigtable/Row', function() {
       ];
 
       row.table.getRows = function(reqOpts) {
-        assert.deepEqual(reqOpts.filter, expectedFilter);
+        assert.deepStrictEqual(reqOpts.filter, expectedFilter);
         assert.strictEqual(FakeMutation.parseColumnName.callCount, 1);
         assert(FakeMutation.parseColumnName.calledWith(keys[0]));
         assert.strictEqual(reqOpts.decode, options.decode);
@@ -1144,7 +1144,7 @@ describe('Bigtable/Row', function() {
       ];
 
       row.table.getRows = function(reqOpts) {
-        assert.deepEqual(reqOpts.filter, expectedFilter);
+        assert.deepStrictEqual(reqOpts.filter, expectedFilter);
         assert.strictEqual(FakeMutation.parseColumnName.callCount, 2);
         assert(FakeMutation.parseColumnName.calledWith(keys[0]));
         assert.strictEqual(reqOpts.decode, options.decode);
@@ -1164,7 +1164,7 @@ describe('Bigtable/Row', function() {
       let expectedFilter = options.filter;
 
       row.table.getRows = function(reqOpts) {
-        assert.deepEqual(reqOpts.filter, expectedFilter);
+        assert.deepStrictEqual(reqOpts.filter, expectedFilter);
         done();
       };
 
@@ -1207,7 +1207,7 @@ describe('Bigtable/Row', function() {
       row.get(function(err, row_) {
         assert(err instanceof Row.RowError);
         assert.strictEqual(err.message, 'Unknown row: ' + row.id + '.');
-        assert.deepEqual(row_, undefined);
+        assert.deepStrictEqual(row_, undefined);
         done();
       });
     });
@@ -1227,7 +1227,7 @@ describe('Bigtable/Row', function() {
       row.get(function(err, row_) {
         assert.ifError(err);
         assert.strictEqual(row_, row);
-        assert.deepEqual(row.data, fakeRow.data);
+        assert.deepStrictEqual(row.data, fakeRow.data);
         done();
       });
     });
@@ -1252,7 +1252,7 @@ describe('Bigtable/Row', function() {
 
       row.get(keys, function(err, data) {
         assert.ifError(err);
-        assert.deepEqual(Object.keys(data), keys);
+        assert.deepStrictEqual(Object.keys(data), keys);
         done();
       });
     });

--- a/test/table.js
+++ b/test/table.js
@@ -39,7 +39,7 @@ const fakeUtil = extend({}, common.util, {
     }
 
     promisified = true;
-    assert.deepEqual(options.exclude, ['family', 'row']);
+    assert.deepStrictEqual(options.exclude, ['family', 'row']);
   },
 });
 
@@ -175,7 +175,7 @@ describe('Bigtable/Table', function() {
     };
 
     it('should export the table views', function() {
-      assert.deepEqual(views, Table.VIEWS);
+      assert.deepStrictEqual(views, Table.VIEWS);
     });
   });
 
@@ -216,7 +216,7 @@ describe('Bigtable/Table', function() {
 
   describe('createPrefixRange_', function() {
     it('should create a range from the prefix', function() {
-      assert.deepEqual(Table.createPrefixRange_('start'), {
+      assert.deepStrictEqual(Table.createPrefixRange_('start'), {
         start: 'start',
         end: {
           value: 'staru',
@@ -224,7 +224,7 @@ describe('Bigtable/Table', function() {
         },
       });
 
-      assert.deepEqual(Table.createPrefixRange_('X\xff'), {
+      assert.deepStrictEqual(Table.createPrefixRange_('X\xff'), {
         start: 'X\xff',
         end: {
           value: 'Y',
@@ -232,7 +232,7 @@ describe('Bigtable/Table', function() {
         },
       });
 
-      assert.deepEqual(Table.createPrefixRange_('xoo\xff'), {
+      assert.deepStrictEqual(Table.createPrefixRange_('xoo\xff'), {
         start: 'xoo\xff',
         end: {
           value: 'xop',
@@ -240,7 +240,7 @@ describe('Bigtable/Table', function() {
         },
       });
 
-      assert.deepEqual(Table.createPrefixRange_('a\xffb'), {
+      assert.deepStrictEqual(Table.createPrefixRange_('a\xffb'), {
         start: 'a\xffb',
         end: {
           value: 'a\xffc',
@@ -248,7 +248,7 @@ describe('Bigtable/Table', function() {
         },
       });
 
-      assert.deepEqual(Table.createPrefixRange_('com.google.'), {
+      assert.deepStrictEqual(Table.createPrefixRange_('com.google.'), {
         start: 'com.google.',
         end: {
           value: 'com.google/',
@@ -258,7 +258,7 @@ describe('Bigtable/Table', function() {
     });
 
     it('should create an inclusive bound when the prefix is empty', function() {
-      assert.deepEqual(Table.createPrefixRange_('\xff'), {
+      assert.deepStrictEqual(Table.createPrefixRange_('\xff'), {
         start: '\xff',
         end: {
           value: '',
@@ -266,7 +266,7 @@ describe('Bigtable/Table', function() {
         },
       });
 
-      assert.deepEqual(Table.createPrefixRange_(''), {
+      assert.deepStrictEqual(Table.createPrefixRange_(''), {
         start: '',
         end: {
           value: '',
@@ -292,7 +292,7 @@ describe('Bigtable/Table', function() {
         assert.strictEqual(config.method, 'modifyColumnFamilies');
 
         assert.strictEqual(config.reqOpts.name, TABLE_NAME);
-        assert.deepEqual(config.reqOpts.modifications, [
+        assert.deepStrictEqual(config.reqOpts.modifications, [
           {
             id: COLUMN_ID,
             create: {},
@@ -442,9 +442,9 @@ describe('Bigtable/Table', function() {
         }));
 
         table.bigtable.request = function(config) {
-          assert.deepEqual(config.reqOpts.rows.rowRanges[0], fakeRange);
+          assert.deepStrictEqual(config.reqOpts.rows.rowRanges[0], fakeRange);
           assert.strictEqual(formatSpy.callCount, 1);
-          assert.deepEqual(formatSpy.getCall(0).args, [
+          assert.deepStrictEqual(formatSpy.getCall(0).args, [
             options.start,
             options.end,
             'Key',
@@ -469,7 +469,7 @@ describe('Bigtable/Table', function() {
         }));
 
         table.bigtable.request = function(config) {
-          assert.deepEqual(config.reqOpts.rows.rowKeys, convertedKeys);
+          assert.deepStrictEqual(config.reqOpts.rows.rowKeys, convertedKeys);
           assert.strictEqual(convertSpy.callCount, 2);
           assert.strictEqual(convertSpy.getCall(0).args[0], options.keys[0]);
           assert.strictEqual(convertSpy.getCall(1).args[0], options.keys[1]);
@@ -509,14 +509,14 @@ describe('Bigtable/Table', function() {
         }));
 
         table.bigtable.request = function(config) {
-          assert.deepEqual(config.reqOpts.rows.rowRanges, fakeRanges);
+          assert.deepStrictEqual(config.reqOpts.rows.rowRanges, fakeRanges);
           assert.strictEqual(formatSpy.callCount, 2);
-          assert.deepEqual(formatSpy.getCall(0).args, [
+          assert.deepStrictEqual(formatSpy.getCall(0).args, [
             options.ranges[0].start,
             options.ranges[0].end,
             'Key',
           ]);
-          assert.deepEqual(formatSpy.getCall(1).args, [
+          assert.deepStrictEqual(formatSpy.getCall(1).args, [
             options.ranges[1].start,
             options.ranges[1].end,
             'Key',
@@ -593,9 +593,9 @@ describe('Bigtable/Table', function() {
 
           table.bigtable.request = function(config) {
             assert.strictEqual(prefixSpy.getCall(0).args[0], fakePrefix);
-            assert.deepEqual(config.reqOpts.rows.rowRanges, [fakeRange]);
+            assert.deepStrictEqual(config.reqOpts.rows.rowRanges, [fakeRange]);
 
-            assert.deepEqual(rangeSpy.getCall(0).args, [
+            assert.deepStrictEqual(rangeSpy.getCall(0).args, [
               fakePrefixRange.start,
               fakePrefixRange.end,
               'Key',
@@ -634,8 +634,8 @@ describe('Bigtable/Table', function() {
             prefixes.forEach(function(prefix, i) {
               let prefixRange = prefixRanges[i];
 
-              assert.deepEqual(prefixSpy.getCall(i).args, [prefix]);
-              assert.deepEqual(rangeSpy.getCall(i).args, [
+              assert.deepStrictEqual(prefixSpy.getCall(i).args, [prefix]);
+              assert.deepStrictEqual(rangeSpy.getCall(i).args, [
                 prefixRange.start,
                 prefixRange.end,
                 'Key',
@@ -1058,11 +1058,11 @@ describe('Bigtable/Table', function() {
         assert.strictEqual(config.client, 'BigtableTableAdminClient');
         assert.strictEqual(config.method, 'deleteTable');
 
-        assert.deepEqual(config.reqOpts, {
+        assert.deepStrictEqual(config.reqOpts, {
           name: table.name,
         });
 
-        assert.deepEqual(config.gaxOpts, {});
+        assert.deepStrictEqual(config.gaxOpts, {});
 
         callback(); // done()
       };
@@ -1745,7 +1745,7 @@ describe('Bigtable/Table', function() {
 
         table.getRows(options, function(err, rows) {
           assert.ifError(err);
-          assert.deepEqual(rows, fakeRows);
+          assert.deepStrictEqual(rows, fakeRows);
 
           let spy = table.createReadStream.getCall(0);
           assert.strictEqual(spy.args[0], options);
@@ -1756,7 +1756,7 @@ describe('Bigtable/Table', function() {
       it('should optionally accept options', function(done) {
         table.getRows(function(err, rows) {
           assert.ifError(err);
-          assert.deepEqual(rows, fakeRows);
+          assert.deepStrictEqual(rows, fakeRows);
           done();
         });
       });
@@ -1802,13 +1802,13 @@ describe('Bigtable/Table', function() {
       ];
 
       table.mutate = function(entries, options, callback) {
-        assert.deepEqual(entries[0], {
+        assert.deepStrictEqual(entries[0], {
           key: fakeEntries[0].key,
           data: fakeEntries[0].data,
           method: FakeMutation.methods.INSERT,
         });
 
-        assert.deepEqual(entries[1], {
+        assert.deepStrictEqual(entries[1], {
           key: fakeEntries[1].key,
           data: fakeEntries[1].data,
           method: FakeMutation.methods.INSERT,
@@ -1853,7 +1853,7 @@ describe('Bigtable/Table', function() {
 
         assert.strictEqual(config.reqOpts.tableName, TABLE_NAME);
         assert.strictEqual(config.reqOpts.appProfileId, undefined);
-        assert.deepEqual(config.reqOpts.entries, fakeEntries);
+        assert.deepStrictEqual(config.reqOpts.entries, fakeEntries);
 
         assert.strictEqual(parseSpy.callCount, 2);
         assert.strictEqual(parseSpy.getCall(0).args[0], entries[0]);
@@ -2005,7 +2005,7 @@ describe('Bigtable/Table', function() {
           table.mutate(entries, function(err) {
             assert.strictEqual(err.name, 'PartialFailureError');
 
-            assert.deepEqual(err.errors, [
+            assert.deepStrictEqual(err.errors, [
               extend(
                 {
                   entry: entries[0],
@@ -2190,7 +2190,7 @@ describe('Bigtable/Table', function() {
       it('should return the keys to the callback', function(done) {
         table.sampleRowKeys(function(err, keys) {
           assert.ifError(err);
-          assert.deepEqual(keys, fakeKeys);
+          assert.deepStrictEqual(keys, fakeKeys);
           done();
         });
       });


### PR DESCRIPTION
`deepEqual` is causing some issues in PR #247, where the linter seems to prefers `deepStrinctEqual`.  Also, this fixes a strange System test problem from PR #251.