### PR TITLE
chore: run prettier for auto-generated code

### DIFF
--- a/src/v2/bigtable_client.js
+++ b/src/v2/bigtable_client.js
@@ -251,10 +251,11 @@ class BigtableClient {
     options = options || {};
     options.otherArgs = options.otherArgs || {};
     options.otherArgs.headers = options.otherArgs.headers || {};
-    options.otherArgs.headers['x-goog-request-params'] =
-      gax.routingHeader.fromParams({
-        'table_name': request.tableName
-      });
+    options.otherArgs.headers[
+      'x-goog-request-params'
+    ] = gax.routingHeader.fromParams({
+      table_name: request.tableName,
+    });
 
     return this._innerApiCalls.readRows(request, options);
   }
@@ -297,10 +298,11 @@ class BigtableClient {
     options = options || {};
     options.otherArgs = options.otherArgs || {};
     options.otherArgs.headers = options.otherArgs.headers || {};
-    options.otherArgs.headers['x-goog-request-params'] =
-      gax.routingHeader.fromParams({
-        'table_name': request.tableName
-      });
+    options.otherArgs.headers[
+      'x-goog-request-params'
+    ] = gax.routingHeader.fromParams({
+      table_name: request.tableName,
+    });
 
     return this._innerApiCalls.sampleRowKeys(request, options);
   }
@@ -370,10 +372,11 @@ class BigtableClient {
     options = options || {};
     options.otherArgs = options.otherArgs || {};
     options.otherArgs.headers = options.otherArgs.headers || {};
-    options.otherArgs.headers['x-goog-request-params'] =
-      gax.routingHeader.fromParams({
-        'table_name': request.tableName
-      });
+    options.otherArgs.headers[
+      'x-goog-request-params'
+    ] = gax.routingHeader.fromParams({
+      table_name: request.tableName,
+    });
 
     return this._innerApiCalls.mutateRow(request, options, callback);
   }
@@ -426,10 +429,11 @@ class BigtableClient {
     options = options || {};
     options.otherArgs = options.otherArgs || {};
     options.otherArgs.headers = options.otherArgs.headers || {};
-    options.otherArgs.headers['x-goog-request-params'] =
-      gax.routingHeader.fromParams({
-        'table_name': request.tableName
-      });
+    options.otherArgs.headers[
+      'x-goog-request-params'
+    ] = gax.routingHeader.fromParams({
+      table_name: request.tableName,
+    });
 
     return this._innerApiCalls.mutateRows(request, options);
   }
@@ -514,10 +518,11 @@ class BigtableClient {
     options = options || {};
     options.otherArgs = options.otherArgs || {};
     options.otherArgs.headers = options.otherArgs.headers || {};
-    options.otherArgs.headers['x-goog-request-params'] =
-      gax.routingHeader.fromParams({
-        'table_name': request.tableName
-      });
+    options.otherArgs.headers[
+      'x-goog-request-params'
+    ] = gax.routingHeader.fromParams({
+      table_name: request.tableName,
+    });
 
     return this._innerApiCalls.checkAndMutateRow(request, options, callback);
   }
@@ -591,10 +596,11 @@ class BigtableClient {
     options = options || {};
     options.otherArgs = options.otherArgs || {};
     options.otherArgs.headers = options.otherArgs.headers || {};
-    options.otherArgs.headers['x-goog-request-params'] =
-      gax.routingHeader.fromParams({
-        'table_name': request.tableName
-      });
+    options.otherArgs.headers[
+      'x-goog-request-params'
+    ] = gax.routingHeader.fromParams({
+      table_name: request.tableName,
+    });
 
     return this._innerApiCalls.readModifyWriteRow(request, options, callback);
   }
@@ -627,9 +633,7 @@ class BigtableClient {
    * @returns {String} - A string representing the project.
    */
   matchProjectFromTableName(tableName) {
-    return this._pathTemplates.tablePathTemplate
-      .match(tableName)
-      .project;
+    return this._pathTemplates.tablePathTemplate.match(tableName).project;
   }
 
   /**
@@ -640,9 +644,7 @@ class BigtableClient {
    * @returns {String} - A string representing the instance.
    */
   matchInstanceFromTableName(tableName) {
-    return this._pathTemplates.tablePathTemplate
-      .match(tableName)
-      .instance;
+    return this._pathTemplates.tablePathTemplate.match(tableName).instance;
   }
 
   /**
@@ -653,11 +655,8 @@ class BigtableClient {
    * @returns {String} - A string representing the table.
    */
   matchTableFromTableName(tableName) {
-    return this._pathTemplates.tablePathTemplate
-      .match(tableName)
-      .table;
+    return this._pathTemplates.tablePathTemplate.match(tableName).table;
   }
 }
-
 
 module.exports = BigtableClient;

--- a/test/gapic-v2.js
+++ b/test/gapic-v2.js
@@ -32,7 +32,11 @@ describe('BigtableClient', () => {
       });
 
       // Mock request
-      var formattedTableName = client.tablePath('[PROJECT]', '[INSTANCE]', '[TABLE]');
+      var formattedTableName = client.tablePath(
+        '[PROJECT]',
+        '[INSTANCE]',
+        '[TABLE]'
+      );
       var request = {
         tableName: formattedTableName,
       };
@@ -44,7 +48,10 @@ describe('BigtableClient', () => {
       };
 
       // Mock Grpc layer
-      client._innerApiCalls.readRows = mockServerStreamingGrpcMethod(request, expectedResponse);
+      client._innerApiCalls.readRows = mockServerStreamingGrpcMethod(
+        request,
+        expectedResponse
+      );
 
       var stream = client.readRows(request);
       stream.on('data', response => {
@@ -65,13 +72,21 @@ describe('BigtableClient', () => {
       });
 
       // Mock request
-      var formattedTableName = client.tablePath('[PROJECT]', '[INSTANCE]', '[TABLE]');
+      var formattedTableName = client.tablePath(
+        '[PROJECT]',
+        '[INSTANCE]',
+        '[TABLE]'
+      );
       var request = {
         tableName: formattedTableName,
       };
 
       // Mock Grpc layer
-      client._innerApiCalls.readRows = mockServerStreamingGrpcMethod(request, null, error);
+      client._innerApiCalls.readRows = mockServerStreamingGrpcMethod(
+        request,
+        null,
+        error
+      );
 
       var stream = client.readRows(request);
       stream.on('data', () => {
@@ -95,7 +110,11 @@ describe('BigtableClient', () => {
       });
 
       // Mock request
-      var formattedTableName = client.tablePath('[PROJECT]', '[INSTANCE]', '[TABLE]');
+      var formattedTableName = client.tablePath(
+        '[PROJECT]',
+        '[INSTANCE]',
+        '[TABLE]'
+      );
       var request = {
         tableName: formattedTableName,
       };
@@ -109,7 +128,10 @@ describe('BigtableClient', () => {
       };
 
       // Mock Grpc layer
-      client._innerApiCalls.sampleRowKeys = mockServerStreamingGrpcMethod(request, expectedResponse);
+      client._innerApiCalls.sampleRowKeys = mockServerStreamingGrpcMethod(
+        request,
+        expectedResponse
+      );
 
       var stream = client.sampleRowKeys(request);
       stream.on('data', response => {
@@ -130,13 +152,21 @@ describe('BigtableClient', () => {
       });
 
       // Mock request
-      var formattedTableName = client.tablePath('[PROJECT]', '[INSTANCE]', '[TABLE]');
+      var formattedTableName = client.tablePath(
+        '[PROJECT]',
+        '[INSTANCE]',
+        '[TABLE]'
+      );
       var request = {
         tableName: formattedTableName,
       };
 
       // Mock Grpc layer
-      client._innerApiCalls.sampleRowKeys = mockServerStreamingGrpcMethod(request, null, error);
+      client._innerApiCalls.sampleRowKeys = mockServerStreamingGrpcMethod(
+        request,
+        null,
+        error
+      );
 
       var stream = client.sampleRowKeys(request);
       stream.on('data', () => {
@@ -160,7 +190,11 @@ describe('BigtableClient', () => {
       });
 
       // Mock request
-      var formattedTableName = client.tablePath('[PROJECT]', '[INSTANCE]', '[TABLE]');
+      var formattedTableName = client.tablePath(
+        '[PROJECT]',
+        '[INSTANCE]',
+        '[TABLE]'
+      );
       var rowKey = '122';
       var mutations = [];
       var request = {
@@ -192,7 +226,11 @@ describe('BigtableClient', () => {
       });
 
       // Mock request
-      var formattedTableName = client.tablePath('[PROJECT]', '[INSTANCE]', '[TABLE]');
+      var formattedTableName = client.tablePath(
+        '[PROJECT]',
+        '[INSTANCE]',
+        '[TABLE]'
+      );
       var rowKey = '122';
       var mutations = [];
       var request = {
@@ -225,7 +263,11 @@ describe('BigtableClient', () => {
       });
 
       // Mock request
-      var formattedTableName = client.tablePath('[PROJECT]', '[INSTANCE]', '[TABLE]');
+      var formattedTableName = client.tablePath(
+        '[PROJECT]',
+        '[INSTANCE]',
+        '[TABLE]'
+      );
       var entries = [];
       var request = {
         tableName: formattedTableName,
@@ -236,7 +278,10 @@ describe('BigtableClient', () => {
       var expectedResponse = {};
 
       // Mock Grpc layer
-      client._innerApiCalls.mutateRows = mockServerStreamingGrpcMethod(request, expectedResponse);
+      client._innerApiCalls.mutateRows = mockServerStreamingGrpcMethod(
+        request,
+        expectedResponse
+      );
 
       var stream = client.mutateRows(request);
       stream.on('data', response => {
@@ -257,7 +302,11 @@ describe('BigtableClient', () => {
       });
 
       // Mock request
-      var formattedTableName = client.tablePath('[PROJECT]', '[INSTANCE]', '[TABLE]');
+      var formattedTableName = client.tablePath(
+        '[PROJECT]',
+        '[INSTANCE]',
+        '[TABLE]'
+      );
       var entries = [];
       var request = {
         tableName: formattedTableName,
@@ -265,7 +314,11 @@ describe('BigtableClient', () => {
       };
 
       // Mock Grpc layer
-      client._innerApiCalls.mutateRows = mockServerStreamingGrpcMethod(request, null, error);
+      client._innerApiCalls.mutateRows = mockServerStreamingGrpcMethod(
+        request,
+        null,
+        error
+      );
 
       var stream = client.mutateRows(request);
       stream.on('data', () => {
@@ -289,7 +342,11 @@ describe('BigtableClient', () => {
       });
 
       // Mock request
-      var formattedTableName = client.tablePath('[PROJECT]', '[INSTANCE]', '[TABLE]');
+      var formattedTableName = client.tablePath(
+        '[PROJECT]',
+        '[INSTANCE]',
+        '[TABLE]'
+      );
       var rowKey = '122';
       var request = {
         tableName: formattedTableName,
@@ -322,7 +379,11 @@ describe('BigtableClient', () => {
       });
 
       // Mock request
-      var formattedTableName = client.tablePath('[PROJECT]', '[INSTANCE]', '[TABLE]');
+      var formattedTableName = client.tablePath(
+        '[PROJECT]',
+        '[INSTANCE]',
+        '[TABLE]'
+      );
       var rowKey = '122';
       var request = {
         tableName: formattedTableName,
@@ -353,7 +414,11 @@ describe('BigtableClient', () => {
       });
 
       // Mock request
-      var formattedTableName = client.tablePath('[PROJECT]', '[INSTANCE]', '[TABLE]');
+      var formattedTableName = client.tablePath(
+        '[PROJECT]',
+        '[INSTANCE]',
+        '[TABLE]'
+      );
       var rowKey = '122';
       var rules = [];
       var request = {
@@ -385,7 +450,11 @@ describe('BigtableClient', () => {
       });
 
       // Mock request
-      var formattedTableName = client.tablePath('[PROJECT]', '[INSTANCE]', '[TABLE]');
+      var formattedTableName = client.tablePath(
+        '[PROJECT]',
+        '[INSTANCE]',
+        '[TABLE]'
+      );
       var rowKey = '122';
       var rules = [];
       var request = {
@@ -409,7 +478,6 @@ describe('BigtableClient', () => {
       });
     });
   });
-
 });
 
 function mockSimpleGrpcMethod(expectedRequest, response, error) {
@@ -431,8 +499,7 @@ function mockServerStreamingGrpcMethod(expectedRequest, response, error) {
     var mockStream = through2.obj((chunk, enc, callback) => {
       if (error) {
         callback(error);
-      }
-      else {
+      } else {
         callback(null, response);
       }
     });


### PR DESCRIPTION
Three issues here:

(1) Lint failures caused by auto-generated code formatting.
(2) #270 - @dpebot did not run prettier on the generated files which caused lint failures;
(3) For some reason, `lint` is not listed as required for this project, so the PR got merged even with failing CI.

Fixing (1) here, leaving (2) and (3) to @JustinBeckwith / @crwilcox :)