### PR TITLE
nodejs-bigtable is now GA.

### DIFF
--- a/.cloud-repo-tools.json
+++ b/.cloud-repo-tools.json
@@ -4,14 +4,28 @@
   "product": "bigtable",
   "client_reference_url":
     "https://cloud.google.com/nodejs/docs/reference/bigtable/latest/",
-  "release_quality": "beta",
+  "release_quality": "ga",
   "samples": [
+    {
+      "id": "quickstart",
+      "name": "Quickstart",
+      "file": "quickstart.js",
+      "docs_link": "https://cloud.google.com/nodejs/docs/reference/bigtable/latest/",
+      "usage": "node quickstart.js --help"
+    },
     {
       "id": "instances",
       "name": "Instances",
       "file": "instances.js",
-      "docs_link": "https://cloud.google.com/bigtable/docs/",
+      "docs_link": "https://cloud.google.com/nodejs/docs/reference/bigtable/latest/",
       "usage": "node instances.js --help"
+    },
+    {
+      "id": "tables",
+      "name": "Tables",
+      "file": "tableadmin.js",
+      "docs_link": "https://cloud.google.com/bigtable/docs/",
+      "usage": "node tableadmin.js --help"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 # [Cloud Bigtable: Node.js Client](https://github.com/googleapis/nodejs-bigtable)
 
-[![release level](https://img.shields.io/badge/release%20level-beta-yellow.svg?style&#x3D;flat)](https://cloud.google.com/terms/launch-stages)
+
+[![release level](https://img.shields.io/badge/release%20level-general%20availability%20%28GA%29-brightgreen.svg?style&#x3D;flat)](https://cloud.google.com/terms/launch-stages)
 [![CircleCI](https://img.shields.io/circleci/project/github/googleapis/nodejs-bigtable.svg?style=flat)](https://circleci.com/gh/googleapis/nodejs-bigtable)
 [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/googleapis/nodejs-bigtable?branch=master&svg=true)](https://ci.appveyor.com/project/googleapis/nodejs-bigtable)
 [![codecov](https://img.shields.io/codecov/c/github/googleapis/nodejs-bigtable/master.svg?style=flat)](https://codecov.io/gh/googleapis/nodejs-bigtable)
@@ -119,10 +120,11 @@ also contains samples.
 
 This library follows [Semantic Versioning](http://semver.org/).
 
-This library is considered to be in **beta**. This means it is expected to be
-mostly stable while we work toward a general availability release; however,
-complete stability is not guaranteed. We will address issues and requests
-against beta libraries with a high priority.
+This library is considered to be **General Availability (GA)**. This means it
+is stable; the code surface will not change in backwards-incompatible ways
+unless absolutely necessary (e.g. because of critical security issues) or with
+an extensive deprecation period. Issues and requests against **GA** libraries
+are addressed with the highest priority.
 
 More Information: [Google Cloud Platform Launch Stages][launch_stages]
 


### PR DESCRIPTION
This may have to wait for another PR, which releases the 1.0.0 binary.  That's PR #367 
