### PR TITLE
refactor(samples): convert sample tests from ava to mocha

### DIFF
--- a/samples/package.json
+++ b/samples/package.json
@@ -15,9 +15,8 @@
   },
   "devDependencies": {
     "@google-cloud/nodejs-repo-tools": "^3.0.0",
-    "ava": "^0.25.0",
+    "mocha": "^5.2.0",
     "doctoc": "^1.3.1",
-    "nyc": "^13.0.0",
     "proxyquire": "^2.0.0",
     "sinon": "^7.0.0"
   },
@@ -27,9 +26,7 @@
     ]
   },
   "scripts": {
-    "ava": "ava -T 20s --verbose system-test/*.test.js",
-    "cover": "nyc --reporter=lcov --cache ava -T 300s --verbose system-test/*.test.js && nyc report",
     "doctoc": "doctoc README.md */README.md",
-    "test": "npm run cover"
+    "test": "mocha system-test/*.test.js --timeout=600000"
   }
 }

--- a/samples/system-test/.eslintrc.yml
+++ b/samples/system-test/.eslintrc.yml
@@ -1,3 +1,5 @@
 ---
+env:
+  mocha: true
 rules:
   node/no-unpublished-require: off

--- a/samples/system-test/instances.test.js
+++ b/samples/system-test/instances.test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017, Google, Inc.
+ * Copyright 2018, Google, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/samples/system-test/instances.test.js
+++ b/samples/system-test/instances.test.js
@@ -15,22 +15,22 @@
 
 'use strict';
 
-const path = require(`path`);
-const test = require(`ava`);
-const tools = require(`@google-cloud/nodejs-repo-tools`);
-const uuid = require(`uuid`);
+const path = require('path');
+const assert = require('assert');
+const tools = require('@google-cloud/nodejs-repo-tools');
+const uuid = require('uuid');
 
-const Bigtable = require(`@google-cloud/bigtable`);
+const Bigtable = require('@google-cloud/bigtable');
 const bigtable = new Bigtable();
 const clusterId = `nodejs-bigtable-samples-${uuid.v4()}`.substr(0, 30); // Bigtable naming rules
 const instanceId = `nodejs-bigtable-samples-${uuid.v4()}`.substr(0, 30); // Bigtable naming rules
 const instance = bigtable.instance(instanceId);
 
-const cwd = path.join(__dirname, `..`);
-const cmd = `node instances.js`;
+const cwd = path.join(__dirname, '..');
+const cmd = 'node instances.js';
 
-test.before(tools.checkCredentials);
-test.before(async () => {
+before(async () => {
+  tools.checkCredentials();
   await instance.create({
     clusters: [
       {
@@ -42,24 +42,16 @@ test.before(async () => {
   });
 });
 
-test.after.always(async () => {
-  try {
-    await instance.delete();
-  } catch (err) {
-    // ignore error
-  }
-});
+after(async () => await instance.delete());
 
-test(`should list zones`, async t => {
-  t.plan(0);
+it('should list zones', async () =>
   await tools
-    .tryTest(async assert => {
+    .tryTest(async () => {
       const output = await tools.runAsync(
         `${cmd} run --instance ${instanceId}`,
         cwd
       );
-      assert(output.includes(`Instances:`));
+      assert(output.includes('Instances:'));
       assert(output.includes(instanceId));
     })
-    .start();
-});
+    .start());


### PR DESCRIPTION
Fixes convert all sample tests from ava to mocha [#2865](https://github.com/googleapis/google-cloud-node/issues/2865) (it's a good idea to open an issue first for discussion)

- [ ] Tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)
