### PR TITLE
build: only delete stale test resources

### DIFF
--- a/system-test/bigtable.ts
+++ b/system-test/bigtable.ts
@@ -60,7 +60,6 @@ describe('Bigtable', () => {
 
   after(async () => {
     const [instances] = await (bigtable as any).getInstances();
-    const [instances] = await bigtable.getInstances();
     const testInstances = instances
       .filter(i => i.id.match(PREFIX))
       .filter(i => {

--- a/system-test/bigtable.ts
+++ b/system-test/bigtable.ts
@@ -44,6 +44,9 @@ describe('Bigtable', () => {
           nodes: 3,
         },
       ],
+      labels: {
+        time_created: Date.now(),
+      },
     });
     await operation.promise();
     await TABLE.create({
@@ -57,7 +60,15 @@ describe('Bigtable', () => {
 
   after(async () => {
     const [instances] = await (bigtable as any).getInstances();
-    const testInstances = instances.filter(i => i.id.match(PREFIX));
+    const [instances] = await bigtable.getInstances();
+    const testInstances = instances
+      .filter(i => i.id.match(PREFIX))
+      .filter(i => {
+        const timeCreated = i.metadata.labels.time_created;
+        // Only delete stale resources.
+        const oneHourAgo = new Date(Date.now() - 3600000);
+        return !timeCreated || timeCreated <= oneHourAgo;
+      });
     const q = new Q({concurrency: 5});
     await Promise.all(
       testInstances.map(instance => {


### PR DESCRIPTION
Fixes #425 

This changes the system test clean up process to only remove stale (1 hour old or greater) instances. This should prevent collisions from parallel system test and sample test runs.