### PR TITLE
docs: add .repo-metadata.json and regenerate docs

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -1,0 +1,13 @@
+{
+  "name": "bigtable",
+  "name_pretty": "Cloud Bigtable",
+  "product_documentation": "https://cloud.google.com/bigtable",
+  "client_documentation": "https://cloud.google.com/nodejs/docs/reference/bigtable/latest/",
+  "issue_tracker":"https://issuetracker.google.com/savedsearches/559777",
+  "release_level": "ga",
+  "language": "nodejs",
+  "repo": "googleapis/nodejs-bigtable",
+  "distribution_name": "@google-cloud/bigtable",
+  "api_id": "bigtable.googleapis.com",
+  "requires_billing ": true
+}

--- a/README.md
+++ b/README.md
@@ -1,20 +1,22 @@
+[//]: # "This README.md file is auto-generated, all changes to this file will be lost."
+[//]: # "To regenerate it, use `python -m synthtool`."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
 # [Cloud Bigtable: Node.js Client](https://github.com/googleapis/nodejs-bigtable)
 
-
-[![release level](https://img.shields.io/badge/release%20level-general%20availability%20%28GA%29-brightgreen.svg?style&#x3D;flat)](https://cloud.google.com/terms/launch-stages)
+[![release level](https://img.shields.io/badge/release%20level-general%20availability%20%28GA%29-brightgreen.svg?style=flat)](https://cloud.google.com/terms/launch-stages)
 [![npm version](https://img.shields.io/npm/v/@google-cloud/bigtable.svg)](https://www.npmjs.org/package/@google-cloud/bigtable)
 [![codecov](https://img.shields.io/codecov/c/github/googleapis/nodejs-bigtable/master.svg?style=flat)](https://codecov.io/gh/googleapis/nodejs-bigtable)
 
-> Node.js idiomatic client for [Cloud Bigtable][product-docs].
 
-[Cloud Bigtable](https://cloud.google.com/bigtable/docs/) is Google&#x27;s NoSQL Big Data database service. It&#x27;s the same database that powers many core Google services, including Search, Analytics, Maps, and Gmail.
+
+
+Cloud Bigtable Client Library for Node.js
 
 
 * [Cloud Bigtable Node.js Client API Reference][client-docs]
-* [github.com/googleapis/nodejs-bigtable](https://github.com/googleapis/nodejs-bigtable)
 * [Cloud Bigtable Documentation][product-docs]
+* [github.com/googleapis/nodejs-bigtable](https://github.com/googleapis/nodejs-bigtable)
 
 Read more about the client libraries for Cloud APIs, including the older
 Google APIs Client Libraries, in [Client Libraries Explained][explained].
@@ -22,6 +24,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 [explained]: https://cloud.google.com/apis/docs/client-libraries-explained
 
 **Table of contents:**
+
 
 * [Quickstart](#quickstart)
   * [Before you begin](#before-you-begin)
@@ -36,70 +39,47 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 ### Before you begin
 
-1.  Select or create a Cloud Platform project.
-
-    [Go to the projects page][projects]
-
-1.  Enable billing for your project.
-
-    [Enable billing][billing]
-
-1.  Enable the Cloud Bigtable and Cloud Bigtable Admin APIs.
-
-    [Enable the APIs][enable_api]
-
+1.  [Select or create a Cloud Platform project][projects].
+1.  [Enable the Cloud Bigtable API][enable_api].
 1.  [Set up authentication with a service account][auth] so you can access the
     API from your local workstation.
 
-[projects]: https://console.cloud.google.com/project
-[billing]: https://support.google.com/cloud/answer/6293499#enable-billing
-[enable_api]: https://console.cloud.google.com/flows/enableapi?apiid=bigtable.googleapis.com,bigtableadmin.googleapis.com
-[auth]: https://cloud.google.com/docs/authentication/getting-started
-
 ### Installing the client library
 
-    npm install --save @google-cloud/bigtable
+```bash
+npm install @google-cloud/bigtable
+```
+
 
 ### Using the client library
 
-[embedmd]:# (samples/quickstart.js javascript /.*Imports/ /}\)\(\);/)
 ```javascript
 // Imports the Google Cloud client library
 const Bigtable = require('@google-cloud/bigtable');
 
-// The name of the Cloud Bigtable instance
-const INSTANCE_NAME = 'my-bigtable-instance';
-// The name of the Cloud Bigtable table
-const TABLE_NAME = 'my-table';
+async function quickstart(
+  INSTANCE_ID = 'my-instance', // ID of the Cloud Bigtable instance
+  TABLE_ID = 'my-table' // ID of the Cloud Bigtable table
+) {
+  const bigtable = Bigtable();
 
-(async () => {
-  try {
-    // Creates a Bigtable client
-    const bigtable = new Bigtable();
+  // Connect to an existing instance:my-bigtable-instance
+  const instance = bigtable.instance(INSTANCE_ID);
 
-    // Connect to an existing instance:my-bigtable-instance
-    const instance = bigtable.instance(INSTANCE_NAME);
+  // Connect to an existing table:my-table
+  const table = instance.table(TABLE_ID);
 
-    // Connect to an existing table:my-table
-    const table = instance.table(TABLE_NAME);
+  // Read a row from my-table using a row key
+  const [singleRow] = await table.row('r1').get();
 
-    // Read a row from my-table using a row key
-    let [singleRow] = await table.row('r1').get();
+  // Print the row key and data (column value, labels, timestamp)
+  const rowData = JSON.stringify(singleRow.data, null, 4);
+  console.log(`Row key: ${singleRow.id}\nData: ${rowData}`);
+}
 
-    // Print the row key and data (column value, labels, timestamp)
-    console.log(
-      `Row key: ${singleRow.id}\nData: ${JSON.stringify(
-        singleRow.data,
-        null,
-        4
-      )}`
-    );
-  } catch (err) {
-    // Handle error performing the read operation
-    console.error(`Error reading row r1:`, err);
-  }
-})();
 ```
+
+
 
 ## Samples
 
@@ -108,9 +88,11 @@ has instructions for running the samples.
 
 | Sample                      | Source Code                       | Try it |
 | --------------------------- | --------------------------------- | ------ |
-| Hello World | [source code](https://github.com/googleapis/nodejs-bigtable/blob/master/samples/hello-world/index.js) | [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-bigtable&page=editor&open_in_editor=samples/hello-world/index.js,samples/hello-world/README.md) |
-| Instance operations | [source code](https://github.com/googleapis/nodejs-bigtable/blob/master/samples/instances.js) | [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-bigtable&page=editor&open_in_editor=samples/instances.js,samples/README.md) |
-| Table operations | [source code](https://github.com/googleapis/nodejs-bigtable/blob/master/samples/tableadmin.js) | [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-bigtable&page=editor&open_in_editor=samples/tableadmin.js,samples/README.md) |
+| Instances | [source code](https://github.com/googleapis/nodejs-bigtable/blob/master/samples/instances.js) | [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-bigtable&page=editor&open_in_editor=samples/instances.js,samples/README.md) |
+| Quickstart | [source code](https://github.com/googleapis/nodejs-bigtable/blob/master/samples/quickstart.js) | [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-bigtable&page=editor&open_in_editor=samples/quickstart.js,samples/README.md) |
+| Tableadmin | [source code](https://github.com/googleapis/nodejs-bigtable/blob/master/samples/tableadmin.js) | [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-bigtable&page=editor&open_in_editor=samples/tableadmin.js,samples/README.md) |
+
+
 
 The [Cloud Bigtable Node.js Client API Reference][client-docs] documentation
 also contains samples.
@@ -119,11 +101,16 @@ also contains samples.
 
 This library follows [Semantic Versioning](http://semver.org/).
 
+
 This library is considered to be **General Availability (GA)**. This means it
 is stable; the code surface will not change in backwards-incompatible ways
 unless absolutely necessary (e.g. because of critical security issues) or with
 an extensive deprecation period. Issues and requests against **GA** libraries
 are addressed with the highest priority.
+
+
+
+
 
 More Information: [Google Cloud Platform Launch Stages][launch_stages]
 
@@ -140,6 +127,9 @@ Apache Version 2.0
 See [LICENSE](https://github.com/googleapis/nodejs-bigtable/blob/master/LICENSE)
 
 [client-docs]: https://cloud.google.com/nodejs/docs/reference/bigtable/latest/
-[product-docs]: https://cloud.google.com/bigtable/docs/
-[shell_img]: //gstatic.com/cloudssh/images/open-btn.png
-
+[product-docs]: https://cloud.google.com/bigtable
+[shell_img]: https://gstatic.com/cloudssh/images/open-btn.png
+[projects]: https://console.cloud.google.com/project
+[billing]: https://support.google.com/cloud/answer/6293499#enable-billing
+[enable_api]: https://console.cloud.google.com/flows/enableapi?apiid=bigtable.googleapis.com
+[auth]: https://cloud.google.com/docs/authentication/getting-started

--- a/samples/README.md
+++ b/samples/README.md
@@ -1,146 +1,80 @@
+[//]: # "This README.md file is auto-generated, all changes to this file will be lost."
+[//]: # "To regenerate it, use `python -m synthtool`."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
-# Cloud Bigtable: Node.js Samples
+# [Cloud Bigtable: Node.js Samples](https://github.com/googleapis/nodejs-bigtable)
 
 [![Open in Cloud Shell][shell_img]][shell_link]
 
-[Cloud Bigtable](https://cloud.google.com/bigtable/docs/) is Google&#x27;s NoSQL Big Data database service. It&#x27;s the same database that powers many core Google services, including Search, Analytics, Maps, and Gmail.
+
 
 ## Table of Contents
 
-<!-- START doctoc generated TOC please keep comment here to allow auto update -->
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-
-
-- [Before you begin](#before-you-begin)
-- [Samples](#samples)
-  - [Hello World](#hello-world)
-  - [Instances](#instances)
-
-<!-- END doctoc generated TOC please keep comment here to allow auto update -->
-
+* [Before you begin](#before-you-begin)
+* [Samples](#samples)
+  * [Instances](#instances)
+  * [Quickstart](#quickstart)
+  * [Tableadmin](#tableadmin)
 
 ## Before you begin
 
-Before running the samples, make sure you've followed the steps in the
-[Before you begin section](../README.md#before-you-begin) of the client
-library's README.
+Before running the samples, make sure you've followed the steps outlined in
+[Using the client library](https://github.com/googleapis/nodejs-bigtable#using-the-client-library).
 
 ## Samples
 
-### Quickstart
-The [Quick start](quickstart.js) sample shows a basic usage of the Bigtable client library: reading rows from a table.
 
-Follow the [cbt tutorial](https://cloud.google.com/bigtable/docs/quickstart-cbt) to install the cbt command line tool.
-Here are the cbt commands to create a table, column family and add some data:
-```
-   cbt createtable my-table
-   cbt createfamily my-table cf1
-   cbt set my-table r1 cf1:c1=test-value
-```
-
-Run the quick start to read the row you just wrote using `cbt`:
-```
-   node quickstart.js
-```
-Expected output similar to:
-```
-    Row key: r1
-    Data: {
-        "cf1": {
-            "c1": [
-                {
-                    "value": "test-value",
-                    "labels": [],
-                    "timestamp": "1526104247827000"
-                }
-            ]
-        }
-    }
-```
-
-### Hello World
-
-View the [Hello World][hello_world_directory] sample to see a basic usage of
-the Bigtable client library.
 
 ### Instances
 
-View the [source code][instances_0_code].
+View the [source code](https://github.com/googleapis/nodejs-bigtable/blob/master/samples/instances.js).
 
 [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-bigtable&page=editor&open_in_editor=samples/instances.js,samples/README.md)
 
-__Usage:__ `node instances.js --help`
+__Usage:__
 
-```
-instances.js <command>
 
-Commands:
-  instances.js run           Creates an Instance(type: PRODUCTION) and run basic instance-operations
-  instances.js dev-instance  Create Development Instance
-  instances.js del-instance  Delete the Instance
-  instances.js add-cluster   Add Cluster
-  instances.js del-cluster   Delete the Cluster
+`node instances.js`
 
-Options:
-  --version   Show version number                                                                              [boolean]
-  --instance  Cloud Bigtable Instance name
-  --cluster   Cloud Bigtable Cluster name
-  --help      Show help                                                                                        [boolean]
 
-Examples:
-  node instances.js run --instance [instanceName] --cluster     Run instance operations
-  [clusterName]
-  node instances.js dev-instance --instance [instanceName]      Create Development Instance
-  node instances.js del-instance --instance [instanceName]      Delete the Instance.
-  node instances.js add-cluster --instance [instanceName]       Add Cluster
-  --cluster [clusterName]
-  node instances.js del-cluster --instance [instanceName]       Delete the Cluster
-  --cluster [clusterName]
+-----
 
-For more information, see https://cloud.google.com/bigtable/docs
-```
 
-### Table / Column family management
 
-View the [source code](tableadmin.js).
-This sample showcases the basic table / column family operations:
-1. Create a table (if does not exist)
-1. List tables in the current project
-1. Retrieve table metadata
-1. Create column families with supported garbage collection(GC) rules
-1. List table column families and GC rules
-1. Update a column family GC rule
-1. Delete a column family
-1. Delete a table
 
-[![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-bigtable&page=editor&open_in_editor=samples/instances.js,samples/README.md)
+### Quickstart
 
-__Usage:__ `node tableadmin.js --help`
+View the [source code](https://github.com/googleapis/nodejs-bigtable/blob/master/samples/quickstart.js).
 
-```
-Commands:
-  tableadmin.js run     Create a table (if does not exist) and run basic table operations.
-  tableadmin.js delete  Delete table.
+[![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-bigtable&page=editor&open_in_editor=samples/quickstart.js,samples/README.md)
 
-Options:
-  --version   Show version number                                                                              [boolean]
-  --instance  Cloud Bigtable Instance name                                                                    [required]
-  --table     Cloud Bigtable Table name                                                                       [required]
-  --help      Show help                                                                                        [boolean]
+__Usage:__
 
-Examples:
-  node tableadmin.js run --instance [instanceName] --table      Create a table (if does not exist) and run basic table
-  [tableName]                                                   operations.
-  node tableadmin.js delete --instance [instanceName] --table   Delete a table.
-  [tableName]
 
-For more information, see https://cloud.google.com/bigtable/docs
-```
-[instances_0_docs]: https://cloud.google.com/bigtable/docs/
-[instances_0_code]: instances.js
+`node quickstart.js`
 
-[hello_world_directory]: hello-world
 
-[shell_img]: //gstatic.com/cloudssh/images/open-btn.png
+-----
+
+
+
+
+### Tableadmin
+
+View the [source code](https://github.com/googleapis/nodejs-bigtable/blob/master/samples/tableadmin.js).
+
+[![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-bigtable&page=editor&open_in_editor=samples/tableadmin.js,samples/README.md)
+
+__Usage:__
+
+
+`node tableadmin.js`
+
+
+
+
+
+
+[shell_img]: https://gstatic.com/cloudssh/images/open-btn.png
 [shell_link]: https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-bigtable&page=editor&open_in_editor=samples/README.md
+[product-docs]: https://cloud.google.com/bigtable


### PR DESCRIPTION
Adds a `.repo-metadata.json` which is required for the new docs site, regenerated documentation to match our new templates based on this file.