### PR TITLE
fix: do not log warning for ignored grpc options

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -401,9 +401,7 @@ export class Bigtable {
       {
         libName: 'gccl',
         libVersion: PKG.version,
-        scopes,
-        'grpc.max_send_message_length': -1,
-        'grpc.max_receive_message_length': -1,
+        scopes
       },
       options
     );


### PR DESCRIPTION
Fixes #508

Not sure this is the correct fix for the problem, but gets rid of the warnings