### PR TITLE
refactor: remove unused properties

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -402,8 +402,6 @@ export class Bigtable {
         libName: 'gccl',
         libVersion: PKG.version,
         scopes,
-        'grpc.max_send_message_length': -1,
-        'grpc.max_receive_message_length': -1,
       },
       options
     );

--- a/test/index.ts
+++ b/test/index.ts
@@ -161,8 +161,6 @@ describe('Bigtable', function() {
               libName: 'gccl',
               libVersion: PKG.version,
               scopes: EXPECTED_SCOPES,
-              'grpc.max_send_message_length': -1,
-              'grpc.max_receive_message_length': -1,
             },
             options
           )
@@ -191,8 +189,6 @@ describe('Bigtable', function() {
         libName: 'gccl',
         libVersion: PKG.version,
         scopes: EXPECTED_SCOPES,
-        'grpc.max_send_message_length': -1,
-        'grpc.max_receive_message_length': -1,
       };
 
       assert.deepStrictEqual(bigtable.options, {
@@ -232,8 +228,6 @@ describe('Bigtable', function() {
         libName: 'gccl',
         libVersion: PKG.version,
         scopes: EXPECTED_SCOPES,
-        'grpc.max_send_message_length': -1,
-        'grpc.max_receive_message_length': -1,
       };
 
       const bigtable = new Bigtable(options);
@@ -279,8 +273,6 @@ describe('Bigtable', function() {
         libName: 'gccl',
         libVersion: PKG.version,
         scopes: EXPECTED_SCOPES,
-        'grpc.max_send_message_length': -1,
-        'grpc.max_receive_message_length': -1,
       };
 
       const bigtable = new Bigtable(options);


### PR DESCRIPTION
Fixes #508
- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

`grpc-js` does not impose a limit to the message length (received or sent).

no longer need to override 
```ts
'grpc.max_send_message_length': -1, 
'grpc.max_receive_message_length': -1,
```
properties.