### PR TITLE
refactor: drop dependency on @google-cloud/common-grpc

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "posttest": "npm run check"
   },
   "dependencies": {
-    "@google-cloud/common-grpc": "^1.0.0",
+    "@google-cloud/common": "^2.2.2",
     "@google-cloud/paginator": "^2.0.0",
     "@google-cloud/projectify": "^1.0.0",
     "@google-cloud/promisify": "^1.0.0",
@@ -56,7 +56,6 @@
     "dot-prop": "^5.0.0",
     "escape-string-regexp": "^2.0.0",
     "extend": "^3.0.2",
-    "google-auth-library": "^5.0.0",
     "google-gax": "^1.6.3",
     "is": "^3.0.1",
     "is-utf8": "^0.2.1",

--- a/src/decorateStatus.ts
+++ b/src/decorateStatus.ts
@@ -53,7 +53,6 @@ export function decorateStatus(response) {
   if (response && GRPC_ERROR_CODE_TO_HTTP[response.code]) {
     const defaultResponseDetails = GRPC_ERROR_CODE_TO_HTTP[response.code];
     let message = defaultResponseDetails.message;
-
     if (response.message) {
       // gRPC error messages can be either stringified JSON or strings.
       try {
@@ -62,12 +61,14 @@ export function decorateStatus(response) {
         message = response.message;
       }
     }
-
     return extend(true, obj, response, {
       code: defaultResponseDetails.code,
       message,
     });
   }
-
   return null;
+}
+
+export function shouldRetryRequest(r: {code: number}) {
+  return [429, 500, 502, 503].includes(r.code);
 }

--- a/src/decorateStatus.ts
+++ b/src/decorateStatus.ts
@@ -1,0 +1,73 @@
+/*!
+ * Copyright 2019 Google LLC. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as extend from 'extend';
+
+/**
+ * @const {object} - A map of protobuf codes to HTTP status codes.
+ * @private
+ */
+const GRPC_ERROR_CODE_TO_HTTP = [
+  {code: 200, message: 'OK'},
+  {code: 499, message: 'Client Closed Request'},
+  {code: 500, message: 'Internal Server Error'},
+  {code: 400, message: 'Bad Request'},
+  {code: 504, message: 'Gateway Timeout'},
+  {code: 404, message: 'Not Found'},
+  {code: 409, message: 'Conflict'},
+  {code: 403, message: 'Forbidden'},
+  {code: 429, message: 'Too Many Requests'},
+  {code: 412, message: 'Precondition Failed'},
+  {code: 409, message: 'Conflict'},
+  {code: 400, message: 'Bad Request'},
+  {code: 501, message: 'Not Implemented'},
+  {code: 500, message: 'Internal Server Error'},
+  {code: 503, message: 'Service Unavailable'},
+  {code: 500, message: 'Internal Server Error'},
+  {code: 401, message: 'Unauthorized'},
+];
+
+/**
+ * Checks for a grpc status code and extends the supplied object with
+ * additional information.
+ *
+ * @param {object} obj - The object to be extended.
+ * @param {object} response - The grpc response.
+ * @return {object|null}
+ */
+export function decorateStatus(response) {
+  const obj = {};
+  if (response && GRPC_ERROR_CODE_TO_HTTP[response.code]) {
+    const defaultResponseDetails = GRPC_ERROR_CODE_TO_HTTP[response.code];
+    let message = defaultResponseDetails.message;
+
+    if (response.message) {
+      // gRPC error messages can be either stringified JSON or strings.
+      try {
+        message = JSON.parse(response.message).description;
+      } catch (e) {
+        message = response.message;
+      }
+    }
+
+    return extend(true, obj, response, {
+      code: defaultResponseDetails.code,
+      message,
+    });
+  }
+
+  return null;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,13 +41,11 @@
 /**
  * @namespace google.longrunning
  */
-
-import {Service} from '@google-cloud/common-grpc';
 import {replaceProjectIdToken} from '@google-cloud/projectify';
 import {promisifyAll} from '@google-cloud/promisify';
 import arrify = require('arrify');
 import * as extend from 'extend';
-import {GoogleAuth} from 'google-auth-library';
+import {GoogleAuth} from 'google-gax';
 import * as gax from 'google-gax';
 import * as is from 'is';
 import * as through from 'through2';
@@ -749,7 +747,7 @@ export class Bigtable {
             currentRetryAttempt: 0,
             noResponseRetries: 0,
             objectMode: true,
-            shouldRetryFn: (Service as any).shouldRetryRequest_,
+            shouldRetryFn: r => [429, 500, 502, 503].indexOf(r.code) > -1,
             request() {
               gaxStream = requestFn();
               return gaxStream;

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,6 +53,7 @@ import * as through from 'through2';
 import {AppProfile} from './app-profile';
 import {Cluster} from './cluster';
 import {Instance} from './instance';
+import {shouldRetryRequest} from './decorateStatus';
 
 const retryRequest = require('retry-request');
 const streamEvents = require('stream-events');
@@ -747,7 +748,7 @@ export class Bigtable {
             currentRetryAttempt: 0,
             noResponseRetries: 0,
             objectMode: true,
-            shouldRetryFn: r => [429, 500, 502, 503].indexOf(r.code) > -1,
+            shouldRetryFn: shouldRetryRequest,
             request() {
               gaxStream = requestFn();
               return gaxStream;

--- a/src/table.ts
+++ b/src/table.ts
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-import * as common from '@google-cloud/common-grpc';
+import * as common from '@google-cloud/common';
 import {promisifyAll} from '@google-cloud/promisify';
 import arrify = require('arrify');
+import {decorateStatus} from './decorateStatus';
 
 const concat = require('concat-stream');
 import * as is from 'is';
@@ -955,9 +956,7 @@ Please use the format 'prezzy' or '${instance.name}/tables/prezzy'.`);
               pendingEntryIndices.delete(originalEntriesIndex);
             }
 
-            const status = (common.Service as any).decorateStatus_(
-              entry.status
-            );
+            const status = decorateStatus(entry.status);
             status.entry = originalEntry;
 
             mutationErrorsByEntryIndex.set(originalEntriesIndex, status);

--- a/system-test/mutate-rows.ts
+++ b/system-test/mutate-rows.ts
@@ -18,7 +18,7 @@ const Bigtable = require('../src');
 const {tests} = require('../../system-test/data/mutate-rows-retry-test.json');
 
 import * as assert from 'assert';
-import {grpc} from '@google-cloud/common-grpc';
+import * as grpc from '@grpc/grpc-js';
 import * as sinon from 'sinon';
 import * as through from 'through2';
 

--- a/system-test/read-rows.ts
+++ b/system-test/read-rows.ts
@@ -18,8 +18,8 @@ import {Bigtable} from '../src';
 import {Mutation} from '../src/mutation.js';
 const {tests} = require('../../system-test/data/read-rows-retry-test.json');
 
+import * as grpc from '@grpc/grpc-js';
 import * as assert from 'assert';
-import {grpc} from '@google-cloud/common-grpc';
 import * as sinon from 'sinon';
 import * as through from 'through2';
 

--- a/test/common.ts
+++ b/test/common.ts
@@ -1,0 +1,59 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as assert from 'assert';
+import {shouldRetryRequest, decorateStatus} from '../src/decorateStatus';
+
+describe('decorateStatus', () => {
+  it('should attach the correct HTTP code', () => {
+    const grpcStatus = {code: 0};
+    const status = decorateStatus(grpcStatus);
+    assert.strictEqual(status.message, 'OK');
+  });
+
+  it('should return null if the code doesnt match', () => {
+    const grpcStatus = {code: 999};
+    const status = decorateStatus(grpcStatus);
+    assert.strictEqual(status, null);
+  });
+
+  it('should accept a basic message', () => {
+    const message = 'QUACK!';
+    const grpcStatus = {code: 1, message};
+    const status = decorateStatus(grpcStatus);
+    assert.strictEqual(status.message, message);
+  });
+
+  it('should parse JSON from the response message', () => {
+    const message = {
+      description: {
+        rubber: '🦆',
+      },
+    };
+    const grpcStatus = {code: 1, message: JSON.stringify(message)};
+    const status = decorateStatus(grpcStatus);
+    assert.deepStrictEqual(status.message, message.description);
+  });
+});
+
+describe('shouldRetryRequest_', () => {
+  it('should retry on 429, 500, 502, and 503', () => {
+    const s1 = shouldRetryRequest({code: 429});
+    assert.strictEqual(s1, true);
+    const s2 = shouldRetryRequest({code: 444});
+    assert.strictEqual(s2, false);
+  });
+});


### PR DESCRIPTION
This is more a conversation starter than anything.  The `@google-cloud/common-grpc` module creates a few problems for us:
- `google-gax`, `@google-cloud/common`, and `@google-cloud/common-grpc` all reference `google-auth-library`, which is causing diamond dependency issues when we update things
- We are looking to make broad updates to the transport layers, and I'd like to reduce the number of common core libs we try to use

There is some code copying in here in `decorateStatus` I don't feel great about.  Hoping @alexander-fenster will have suggestions on if/how/where in gax this could live.

With minimal effort, we could also drop the dependency on `@google-cloud/common`.  The error util libraries seem to be the only bits we're using.  We should have a single set of Error classes we're using, and have those potentially available in their own shared single use library.  