### PR TITLE
fix: safe integer bounds conversion

### DIFF
--- a/src/mutation.ts
+++ b/src/mutation.ts
@@ -111,7 +111,7 @@ export class Mutation {
       // tslint:disable-next-line no-any
       const num = Long.fromBytes(buf as any).toNumber();
 
-      if (Number.MIN_SAFE_INTEGER < num && num < Number.MAX_SAFE_INTEGER) {
+      if (Number.isSafeInteger(num)) {
         return num;
       }
     }

--- a/test/mutation.ts
+++ b/test/mutation.ts
@@ -81,6 +81,30 @@ describe('Bigtable/Mutation', function() {
         assert.strictEqual(num, decoded);
       });
 
+      it('should not convert a base64 encoded smaller than MIN_SAFE_INTEGER number when true', function() {
+        const num = Number.MIN_SAFE_INTEGER - 100;
+        const encoded = Buffer.from(Long.fromNumber(num).toBytesBE()).toString(
+          'base64'
+        );
+        const decoded = Mutation.convertFromBytes(encoded, {
+          isPossibleNumber: true,
+        });
+
+        assert.notStrictEqual(num, decoded);
+      });
+
+      it('should not convert a base64 encoded larger than MAX_SAFE_INTEGER number when true', function() {
+        const num = Number.MAX_SAFE_INTEGER + 100;
+        const encoded = Buffer.from(Long.fromNumber(num).toBytesBE()).toString(
+          'base64'
+        );
+        const decoded = Mutation.convertFromBytes(encoded, {
+          isPossibleNumber: true,
+        });
+
+        assert.notStrictEqual(num, decoded);
+      });
+
       it('should not convert a base64 encoded number when false', function() {
         const num = 10;
         const encoded = Buffer.from(Long.fromNumber(num).toBytesBE()).toString(

--- a/test/mutation.ts
+++ b/test/mutation.ts
@@ -56,6 +56,31 @@ describe('Bigtable/Mutation', function() {
 
         assert.strictEqual(num, decoded);
       });
+
+      it('should convert a base64 encoded MIN_SAFE_INTEGER number when true', function() {
+        const num = Number.MIN_SAFE_INTEGER;
+        const encoded = Buffer.from(Long.fromNumber(num).toBytesBE()).toString(
+          'base64'
+        );
+        const decoded = Mutation.convertFromBytes(encoded, {
+          isPossibleNumber: true,
+        });
+
+        assert.strictEqual(num, decoded);
+      });
+
+      it('should convert a base64 encoded MAX_SAFE_INTEGER number when true', function() {
+        const num = Number.MAX_SAFE_INTEGER;
+        const encoded = Buffer.from(Long.fromNumber(num).toBytesBE()).toString(
+          'base64'
+        );
+        const decoded = Mutation.convertFromBytes(encoded, {
+          isPossibleNumber: true,
+        });
+
+        assert.strictEqual(num, decoded);
+      });
+
       it('should not convert a base64 encoded number when false', function() {
         const num = 10;
         const encoded = Buffer.from(Long.fromNumber(num).toBytesBE()).toString(


### PR DESCRIPTION
Instead of checking `MIN_SAFE_INTEGER` and `MAX_SAFE_INTEGER` condition, Added embedded function `Number.isSafeInteger`  to check safe integer.

- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #575 
