### PR TITLE
fix(types): overload for bigtable.getInstances

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -73,9 +73,9 @@ export interface GetInstancesCallback {
   ): void;
 }
 export type GetInstancesResponse = [
-  Instance[] | null,
+  Instance[],
   {} | null,
-  google.bigtable.admin.v2.IListInstancesResponse | null
+  google.bigtable.admin.v2.IListInstancesResponse
 ];
 /**
  * @typedef {object} ClientConfig
@@ -603,21 +603,9 @@ export class Bigtable {
     );
   }
 
+  getInstances(gaxOptions?: CallOptions): Promise<GetInstancesResponse>;
   getInstances(callback: GetInstancesCallback): void;
   getInstances(gaxOptions: CallOptions, callback: GetInstancesCallback): void;
-  getInstances(gaxOptions?: CallOptions): Promise<GetInstancesResponse>;
-  /**
-   * Query object for listing instances.
-   *
-   * @typedef {object} CallOptions
-   * @property {boolean} [autoPaginate=true] Have pagination handled
-   *     automatically.
-   * @property {number} [maxApiCalls] Maximum number of API calls to make.
-   * @property {number} [maxResults] Maximum number of items to return.
-   * @property {number} [pageSize] Maximum number of results per page.
-   * @property {string} [pageToken] A previously-returned page token
-   *     representing part of the larger set of results to view.
-   */
   /**
    * @typedef {array} GetInstancesResponse
    * @property {Instance[]} 0 Array of {@link Instance} instances.
@@ -647,10 +635,8 @@ export class Bigtable {
    *   }
    * });
    *
-   * //-
-   * // To control how many API requests are made and page through the results
-   * // manually, set `autoPaginate` to `false`.
-   * //-
+   * @example <caption>To control how many API requests are made and page
+   * through the results manually, set `autoPaginate` to `false`.</caption>
    * function callback(err, instances, nextQuery, apiResponse) {
    *   if (nextQuery) {
    *     // More results exist.
@@ -662,9 +648,8 @@ export class Bigtable {
    *   autoPaginate: false
    * }, callback);
    *
-   * //-
-   * // If the callback is omitted, we'll return a Promise.
-   * //-
+   * @example <caption>If the callback is omitted, we'll return a Promise.
+   * </caption>
    * bigtable.getInstances().then(function(data) {
    *   const instances = data[0];
    * });

--- a/src/index.ts
+++ b/src/index.ts
@@ -616,15 +616,35 @@ export class Bigtable {
   ): void;
   getInstances(gaxOptions?: GetInstancesRequest): Promise<GetInstancesResponse>;
   /**
+   * Query object for listing instances.
+   *
+   * @typedef {object} GetInstancesRequest
+   * @property {boolean} [autoPaginate=true] Have pagination handled
+   *     automatically.
+   * @property {number} [maxApiCalls] Maximum number of API calls to make.
+   * @property {number} [maxResults] Maximum number of items to return.
+   * @property {number} [pageSize] Maximum number of results per page.
+   * @property {string} [pageToken] A previously-returned page token
+   *     representing part of the larger set of results to view.
+   */
+  /**
+   * @typedef {array} GetInstancesResponse
+   * @property {Instance[]} 0 Array of {@link Instance} instances.
+   * @property {object} 1 The full API response.
+   */
+  /**
+   * @callback GetInstancesCallback
+   * @param {?Error} err Request error, if any.
+   * @param {Instance[]} instances Array of {@link Instance} instances.
+   * @param {object} apiResponse The full API response.
+   */
+  /**
    * Get Instance objects for all of your Cloud Bigtable instances.
    *
-   * @param {object} [gaxOptions] Request configuration options, outlined here:
+   * @param {GetInstancesRequest} [gaxOptions] Request configuration options, outlined here:
    *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
-   * @param {function} callback The callback function.
-   * @param {?error} callback.error An error returned while making this request.
-   * @param {Instance[]} callback.instances List of all
-   *     instances.
-   * @param {object} callback.apiResponse The full API response.
+   * @param {GetInstancesCallback} [callback] The callback function.
+   * @returns {Promise<GetInstancesResponse>}
    *
    * @example
    * const Bigtable = require('@google-cloud/bigtable');

--- a/test/table.ts
+++ b/test/table.ts
@@ -770,7 +770,10 @@ describe('Bigtable/Table', function() {
         ],
       };
 
-      const formattedRows = [{key: 'c', data: {}}, {key: 'd', data: {}}];
+      const formattedRows = [
+        {key: 'c', data: {}},
+        {key: 'd', data: {}},
+      ];
 
       beforeEach(function() {
         sinon.stub(table, 'row').callsFake(function() {
@@ -1899,7 +1902,10 @@ describe('Bigtable/Table', function() {
 
   describe('getRows', function() {
     describe('success', function() {
-      const fakeRows = [{key: 'c', data: {}}, {key: 'd', data: {}}];
+      const fakeRows = [
+        {key: 'c', data: {}},
+        {key: 'd', data: {}},
+      ];
 
       beforeEach(function() {
         table.createReadStream = sinon.spy(function() {

--- a/test/table.ts
+++ b/test/table.ts
@@ -770,10 +770,7 @@ describe('Bigtable/Table', function() {
         ],
       };
 
-      const formattedRows = [
-        {key: 'c', data: {}},
-        {key: 'd', data: {}},
-      ];
+      const formattedRows = [{key: 'c', data: {}}, {key: 'd', data: {}}];
 
       beforeEach(function() {
         sinon.stub(table, 'row').callsFake(function() {
@@ -1902,10 +1899,7 @@ describe('Bigtable/Table', function() {
 
   describe('getRows', function() {
     describe('success', function() {
-      const fakeRows = [
-        {key: 'c', data: {}},
-        {key: 'd', data: {}},
-      ];
+      const fakeRows = [{key: 'c', data: {}}, {key: 'd', data: {}}];
 
       beforeEach(function() {
         table.createReadStream = sinon.spy(function() {


### PR DESCRIPTION
While accessing `bigtable.getInstances` with `async` function, it is giving error of return type.
Added overload and related document changes.

Fixes #564 