### PR TITLE
feat: implement instance and table level IAM policy

### DIFF
--- a/samples/document-snippets/instance.js
+++ b/samples/document-snippets/instance.js
@@ -205,6 +205,67 @@ const snippets = {
     // [END bigtable_get_clusters]
   },
 
+  getIamPolicy: instanceId => {
+    // [START bigtable_get_instance_Iam_policy]
+    const Bigtable = require('@google-cloud/bigtable');
+    const bigtable = new Bigtable();
+    const instance = bigtable.instance(instanceId);
+
+    instance
+      .getIamPolicy()
+      .then(result => {
+        const policy = result[0];
+      })
+      .catch(err => {
+        // Handle the error.
+      });
+    // [END bigtable_get_instance_Iam_policy]
+  },
+
+  setIamPolicy: instanceId => {
+    // [START bigtable_set_instance_Iam_policy]
+    const Bigtable = require('@google-cloud/bigtable');
+    const bigtable = new Bigtable();
+    const instance = bigtable.instance(instanceId);
+
+    const policy = {
+      bindings: [
+        {
+          role: 'roles/bigtable.viewer',
+          members: ['user:mike@example.com', 'group:admins@example.com'],
+        },
+      ],
+    };
+
+    instance
+      .setIamPolicy(policy)
+      .then(result => {
+        const setPolicy = result[0];
+      })
+      .catch(err => {
+        // Handle the error
+      });
+    // [END bigtable_set_instance_Iam_policy]
+  },
+
+  testIamPermissions: instanceId => {
+    // [START bigtable_test_instance_Iam_permissions]
+    const Bigtable = require('@google-cloud/bigtable');
+    const bigtable = new Bigtable();
+    const instance = bigtable.instance(instanceId);
+
+    const permissions = ['bigtable.tables.get', 'bigtable.tables.readRows'];
+    instance
+      .testIamPermissions(permissions)
+      .then(result => {
+        const grantedPermissions = result[0];
+      })
+      .catch(err => {
+        // Handle the error
+      });
+    // [END bigtable_test_instance_Iam_permissions]
+  },
+
   getAppProfiles: instanceId => {
     // [START bigtable_get_app_profiles]
     const Bigtable = require('@google-cloud/bigtable');

--- a/samples/document-snippets/table.js
+++ b/samples/document-snippets/table.js
@@ -296,6 +296,70 @@ const snippets = {
     // [END bigtable_sample_row_keys]
   },
 
+  getIamPolicy: (instanceId, tableId) => {
+    // [START bigtable_get_table_Iam_policy]
+    const Bigtable = require('@google-cloud/bigtable');
+    const bigtable = new Bigtable();
+    const instance = bigtable.instance(instanceId);
+    const table = instance.table(tableId);
+
+    table
+      .getIamPolicy()
+      .then(result => {
+        const policy = result[0];
+      })
+      .catch(err => {
+        // Handle the error.
+      });
+    // [END bigtable_get_table_Iam_policy]
+  },
+
+  setIamPolicy: (instanceId, tableId) => {
+    // [START bigtable_set_table_Iam_policy]
+    const Bigtable = require('@google-cloud/bigtable');
+    const bigtable = new Bigtable();
+    const instance = bigtable.instance(instanceId);
+    const table = instance.table(tableId);
+
+    const policy = {
+      bindings: [
+        {
+          role: 'roles/bigtable.viewer',
+          members: ['user:mike@example.com', 'group:admins@example.com'],
+        },
+      ],
+    };
+
+    table
+      .setIamPolicy(policy)
+      .then(result => {
+        const setPolicy = result[0];
+      })
+      .catch(err => {
+        // Handle the error
+      });
+    // [END bigtable_set_table_Iam_policy]
+  },
+
+  testIamPermissions: (instanceId, tableId) => {
+    // [START bigtable_test_table_Iam_permissions]
+    const Bigtable = require('@google-cloud/bigtable');
+    const bigtable = new Bigtable();
+    const instance = bigtable.instance(instanceId);
+    const table = instance.table(tableId);
+
+    const permissions = ['bigtable.tables.get', 'bigtable.tables.readRows'];
+    table
+      .testIamPermissions(permissions)
+      .then(result => {
+        const grantedPermissions = result[0];
+      })
+      .catch(err => {
+        // Handle the error
+      });
+    // [END bigtable_test_table_Iam_permissions]
+  },
+
   delRows: (instanceId, tableId) => {
     const instance = bigtable.instance(instanceId);
     const table = instance.table(tableId);

--- a/src/instance.ts
+++ b/src/instance.ts
@@ -581,7 +581,7 @@ Please use the format 'my-instance' or '${bigtable.projectName}/instances/my-ins
    * @param {function} [callback] The callback function.
    * @param {?error} callback.error An error returned while making this request.
    * @param {Policy} policy The policy.
-   * 
+   *
    * @example <caption>include:samples/document-snippets/instance.js</caption>
    * region_tag:bigtable_get_instance_Iam_policy
    */
@@ -735,7 +735,7 @@ Please use the format 'my-instance' or '${bigtable.projectName}/instances/my-ins
    * @param {function} [callback] The callback function.
    * @param {?error} callback.error An error returned while making this request.
    * @param {Policy} policy The policy.
-   * 
+   *
    * @example <caption>include:samples/document-snippets/instance.js</caption>
    * region_tag:bigtable_set_instance_Iam_policy
    */
@@ -866,7 +866,7 @@ Please use the format 'my-instance' or '${bigtable.projectName}/instances/my-ins
    * @param {?error} callback.error An error returned while making this request.
    * @param {string[]} permissions A subset of permissions that the caller is
    *     allowed.
-   * 
+   *
    * @example <caption>include:samples/document-snippets/instance.js</caption>
    * region_tag:bigtable_test_instance_Iam_permissions
    */

--- a/src/instance.ts
+++ b/src/instance.ts
@@ -581,6 +581,9 @@ Please use the format 'my-instance' or '${bigtable.projectName}/instances/my-ins
    * @param {function} [callback] The callback function.
    * @param {?error} callback.error An error returned while making this request.
    * @param {Policy} policy The policy.
+   * 
+   * @example <caption>include:samples/document-snippets/instance.js</caption>
+   * region_tag:bigtable_get_instance_Iam_policy
    */
   getIamPolicy(
     optionsOrCallback?: GetIamPolicyOptions | GetIamPolicyCallback,
@@ -732,6 +735,9 @@ Please use the format 'my-instance' or '${bigtable.projectName}/instances/my-ins
    * @param {function} [callback] The callback function.
    * @param {?error} callback.error An error returned while making this request.
    * @param {Policy} policy The policy.
+   * 
+   * @example <caption>include:samples/document-snippets/instance.js</caption>
+   * region_tag:bigtable_set_instance_Iam_policy
    */
   setIamPolicy(
     policy: Policy,
@@ -860,6 +866,9 @@ Please use the format 'my-instance' or '${bigtable.projectName}/instances/my-ins
    * @param {?error} callback.error An error returned while making this request.
    * @param {string[]} permissions A subset of permissions that the caller is
    *     allowed.
+   * 
+   * @example <caption>include:samples/document-snippets/instance.js</caption>
+   * region_tag:bigtable_test_instance_Iam_permissions
    */
   testIamPermissions(
     permissions: string | string[],

--- a/src/table.ts
+++ b/src/table.ts
@@ -788,7 +788,7 @@ Please use the format 'prezzy' or '${instance.name}/tables/prezzy'.`);
    * @param {function} [callback] The callback function.
    * @param {?error} callback.error An error returned while making this request.
    * @param {Policy} policy The policy.
-   * 
+   *
    * @example <caption>include:samples/document-snippets/instance.js</caption>
    * region_tag:bigtable_get_table_Iam_policy
    */
@@ -1257,7 +1257,7 @@ Please use the format 'prezzy' or '${instance.name}/tables/prezzy'.`);
    * @param {function} [callback] The callback function.
    * @param {?error} callback.error An error returned while making this request.
    * @param {Policy} policy The policy.
-   * 
+   *
    * @example <caption>include:samples/document-snippets/instance.js</caption>
    * region_tag:bigtable_set_table_Iam_policy
    */
@@ -1319,7 +1319,7 @@ Please use the format 'prezzy' or '${instance.name}/tables/prezzy'.`);
    * @param {?error} callback.error An error returned while making this request.
    * @param {string[]} permissions A subset of permissions that the caller is
    *     allowed.
-   * 
+   *
    * @example <caption>include:samples/document-snippets/instance.js</caption>
    * region_tag:bigtable_test_table_Iam_permissions
    */

--- a/src/table.ts
+++ b/src/table.ts
@@ -87,7 +87,8 @@ export interface PolicyBinding {
 /**
  * @typedef {object} Expr
  * @property {string} [Expr.expression] The application context of the containing
- *     message determines which well-known feature set of CEL is supported.
+ *     message determines which well-known feature set of Common Expression Language
+ *     is supported.
  * @property {string} [Expr.title] An optional title for the expression, i.e. a
  *     short string describing its purpose. This can be used e.g. in UIs which
  *     allow to enter the expression.

--- a/src/table.ts
+++ b/src/table.ts
@@ -788,6 +788,9 @@ Please use the format 'prezzy' or '${instance.name}/tables/prezzy'.`);
    * @param {function} [callback] The callback function.
    * @param {?error} callback.error An error returned while making this request.
    * @param {Policy} policy The policy.
+   * 
+   * @example <caption>include:samples/document-snippets/instance.js</caption>
+   * region_tag:bigtable_get_table_Iam_policy
    */
   getIamPolicy(
     optionsOrCallback?: GetIamPolicyOptions | GetIamPolicyCallback,
@@ -1254,6 +1257,9 @@ Please use the format 'prezzy' or '${instance.name}/tables/prezzy'.`);
    * @param {function} [callback] The callback function.
    * @param {?error} callback.error An error returned while making this request.
    * @param {Policy} policy The policy.
+   * 
+   * @example <caption>include:samples/document-snippets/instance.js</caption>
+   * region_tag:bigtable_set_table_Iam_policy
    */
   setIamPolicy(
     policy: Policy,
@@ -1313,6 +1319,9 @@ Please use the format 'prezzy' or '${instance.name}/tables/prezzy'.`);
    * @param {?error} callback.error An error returned while making this request.
    * @param {string[]} permissions A subset of permissions that the caller is
    *     allowed.
+   * 
+   * @example <caption>include:samples/document-snippets/instance.js</caption>
+   * region_tag:bigtable_test_table_Iam_permissions
    */
   testIamPermissions(
     permissions: string | string[],

--- a/system-test/bigtable.ts
+++ b/system-test/bigtable.ts
@@ -23,7 +23,7 @@ import {AppProfile} from '../src/app-profile.js';
 import {Cluster} from '../src/cluster.js';
 import {Family} from '../src/family.js';
 import {Row} from '../src/row.js';
-import {Table} from '../src/table.js';
+import {Table, Policy} from '../src/table.js';
 
 const PREFIX = 'gcloud-tests-';
 
@@ -236,6 +236,34 @@ describe('Bigtable', () => {
 
     it('should get a table', async () => {
       await TABLE.get();
+    });
+
+    it('should get an Iam Policy for the table', async () => {
+      const policyProperties = ['version', 'bindings', 'etag'];
+      const [policy] = await TABLE.getIamPolicy();
+      policyProperties.forEach(property => {
+        assert.strictEqual(Object.keys(policy).includes(property), true);
+      });
+    });
+
+    it('should test Iam permissions', async () => {
+      const permissions = ['bigtable.tables.get', 'bigtable.tables.readRows'];
+      const [grantedPermissions] = await TABLE.testIamPermissions(permissions);
+      assert.strictEqual(grantedPermissions.length, permissions.length);
+      permissions.forEach(permission => {
+        assert.strictEqual(grantedPermissions.includes(permission), true);
+      });
+    });
+
+    it('should set Iam Policy on a table', async () => {
+      const table = INSTANCE.table(generateId('table'));
+      await table.create();
+
+      const [policy] = await table.getIamPolicy();
+      const [updatedPolicy] = await table.setIamPolicy(policy);
+      assert.notStrictEqual(updatedPolicy, null);
+
+      await table.delete();
     });
 
     it('should delete a table', async () => {

--- a/system-test/bigtable.ts
+++ b/system-test/bigtable.ts
@@ -105,6 +105,49 @@ describe('Bigtable', () => {
       const [metadata_] = await INSTANCE.getMetadata();
       assert.strictEqual(metadata.displayName, metadata_.displayName);
     });
+
+    it('should get an Iam Policy for the instance', async () => {
+      const policyProperties = ['version', 'bindings', 'etag'];
+      const [policy] = await INSTANCE.getIamPolicy();
+      policyProperties.forEach(property => {
+        assert.strictEqual(Object.keys(policy).includes(property), true);
+      });
+    });
+
+    it('should test Iam permissions for the instance', async () => {
+      const permissions = ['bigtable.tables.get', 'bigtable.tables.readRows'];
+      const [grantedPermissions] = await INSTANCE.testIamPermissions(
+        permissions
+      );
+      assert.strictEqual(grantedPermissions.length, permissions.length);
+      permissions.forEach(permission => {
+        assert.strictEqual(grantedPermissions.includes(permission), true);
+      });
+    });
+
+    it('should set Iam Policy on the instance', async () => {
+      const instance = bigtable.instance(generateId('instance'));
+      const clusteId = generateId('cluster');
+      const [, operation] = await (instance as any).create({
+        clusters: [
+          {
+            id: clusteId,
+            location: 'us-central1-c',
+            nodes: 3,
+          },
+        ],
+        labels: {
+          time_created: Date.now(),
+        },
+      });
+      await operation.promise();
+
+      const [policy] = await instance.getIamPolicy();
+      const [updatedPolicy] = await instance.setIamPolicy(policy);
+      assert.notStrictEqual(updatedPolicy, null);
+
+      await (instance as any).delete();
+    });
   });
 
   describe('appProfiles', () => {
@@ -246,7 +289,7 @@ describe('Bigtable', () => {
       });
     });
 
-    it('should test Iam permissions', async () => {
+    it('should test Iam permissions for the table', async () => {
       const permissions = ['bigtable.tables.get', 'bigtable.tables.readRows'];
       const [grantedPermissions] = await TABLE.testIamPermissions(permissions);
       assert.strictEqual(grantedPermissions.length, permissions.length);
@@ -255,7 +298,7 @@ describe('Bigtable', () => {
       });
     });
 
-    it('should set Iam Policy on a table', async () => {
+    it('should set Iam Policy on the table', async () => {
       const table = INSTANCE.table(generateId('table'));
       await table.create();
 

--- a/test/instance.ts
+++ b/test/instance.ts
@@ -17,12 +17,13 @@
 import * as paginator from '@google-cloud/paginator';
 import * as promisify from '@google-cloud/promisify';
 import * as assert from 'assert';
+import * as sinon from 'sinon';
 import * as proxyquire from 'proxyquire';
 
 import {AppProfile} from '../src/app-profile';
 import {Cluster} from '../src/cluster';
 import {Family} from '../src/family';
-import {Table} from '../src/table';
+import {Policy, Table} from '../src/table';
 
 let promisified = false;
 const fakePromisify = Object.assign({}, promisify, {
@@ -875,6 +876,57 @@ describe('Bigtable/Instance', function() {
     });
   });
 
+  describe('getIamPolicy', () => {
+    it('should provide the proper request options', done => {
+      instance.bigtable.request = config => {
+        assert.strictEqual(config.client, 'BigtableInstanceAdminClient');
+        assert.strictEqual(config.method, 'getIamPolicy');
+        assert.strictEqual(config.reqOpts.resource, instance.name);
+        assert.strictEqual(config.reqOpts.requestedPolicyVersion, undefined);
+        assert.strictEqual(config.gaxOpt, undefined);
+        done();
+      };
+      instance.getIamPolicy(assert.ifError);
+    });
+
+    it('should accept options', done => {
+      const requestedPolicyVersion = 0;
+      const gaxOptions = {};
+      const options = {gaxOptions, requestedPolicyVersion};
+
+      instance.bigtable.request = config => {
+        assert.strictEqual(config.gaxOpts, gaxOptions);
+        assert.strictEqual(
+          config.reqOpts.options.requestedPolicyVersion,
+          requestedPolicyVersion
+        );
+        done();
+      };
+      instance.getIamPolicy(options, assert.ifError);
+    });
+
+    it('should return error', done => {
+      const error = new Error('error');
+      instance.bigtable.request = (config, callback) => {
+        callback(error);
+      };
+      instance.getIamPolicy(err => {
+        assert.strictEqual(err, error);
+        done();
+      });
+    });
+
+    it('should call decodePolicyEtag', () => {
+      instance.bigtable.request = (config, callback) => {
+        callback(null, {});
+      };
+      const spy = sinon.stub(Table, 'decodePolicyEtag');
+      instance.getIamPolicy(assert.ifError);
+      assert.strictEqual(spy.calledOnce, true);
+      spy.restore();
+    });
+  });
+
   describe('getMetadata', function() {
     it('should make correct request', function(done) {
       instance.bigtable.request = function(config) {
@@ -1029,6 +1081,86 @@ describe('Bigtable/Instance', function() {
     });
   });
 
+  describe('setIamPolicy', () => {
+    const policy = {};
+    it('should provide the proper request options', done => {
+      instance.bigtable.request = config => {
+        assert.strictEqual(config.client, 'BigtableInstanceAdminClient');
+        assert.strictEqual(config.method, 'setIamPolicy');
+        assert.strictEqual(config.reqOpts.resource, instance.name);
+        assert.strictEqual(config.reqOpts.policy, policy);
+        assert.strictEqual(config.gaxOpt, undefined);
+        done();
+      };
+      instance.setIamPolicy(policy, assert.ifError);
+    });
+
+    it('should accept gaxOptions', done => {
+      const gaxOptions = {};
+
+      instance.bigtable.request = config => {
+        assert.strictEqual(config.gaxOpts, gaxOptions);
+        done();
+      };
+      instance.setIamPolicy(policy, gaxOptions, assert.ifError);
+    });
+
+    it('should pass policy to bigtable.request', done => {
+      const policy: Policy = {
+        bindings: [
+          {
+            role: 'roles/bigtable.viewer',
+            members: ['user:mike@example.com', 'group:admins@example.com'],
+            condition: {
+              title: 'expirable access',
+              description: 'Does not grant access after Sep 2020',
+              expression: "request.time <timestamp('2020-10-01T00:00:00.000Z')",
+            },
+          },
+        ],
+      };
+
+      instance.bigtable.request = config => {
+        assert.strictEqual(config.reqOpts.policy, policy);
+        done();
+      };
+      instance.setIamPolicy(policy, assert.ifError);
+    });
+
+    it('should encode policy etag', done => {
+      const policy = {etag: 'ABS'};
+      instance.bigtable.request = config => {
+        assert.deepStrictEqual(
+          config.reqOpts.policy.etag,
+          Buffer.from(policy.etag)
+        );
+        done();
+      };
+      instance.setIamPolicy(policy, assert.ifError);
+    });
+
+    it('should return error', done => {
+      const error = new Error('error');
+      instance.bigtable.request = (config, callback) => {
+        callback(error);
+      };
+      instance.setIamPolicy(policy, err => {
+        assert.strictEqual(err, error);
+        done();
+      });
+    });
+
+    it('should call decodePolicyEtag', () => {
+      instance.bigtable.request = (config, callback) => {
+        callback(null, {});
+      };
+      const spy = sinon.stub(Table, 'decodePolicyEtag');
+      instance.setIamPolicy(policy, assert.ifError);
+      assert.strictEqual(spy.calledOnce, true);
+      spy.restore();
+    });
+  });
+
   describe('setMetadata', function() {
     it('should provide the proper request options', function(done) {
       const metadata = {displayName: 'updateDisplayName'};
@@ -1085,6 +1217,64 @@ describe('Bigtable/Instance', function() {
       assert(table instanceof FakeTable);
       assert.strictEqual(args[0], instance);
       assert.strictEqual(args[1], TABLE_ID);
+    });
+  });
+
+  describe('testIamPermissions', () => {
+    const permissions = 'bigtable.tables.get';
+    it('should provide the proper request options', done => {
+      instance.bigtable.request = config => {
+        assert.strictEqual(config.client, 'BigtableInstanceAdminClient');
+        assert.strictEqual(config.method, 'testIamPermissions');
+        assert.strictEqual(config.reqOpts.resource, instance.name);
+        assert.deepStrictEqual(config.reqOpts.permissions, [permissions]);
+        assert.strictEqual(config.gaxOpt, undefined);
+        done();
+      };
+      instance.testIamPermissions(permissions, assert.ifError);
+    });
+
+    it('should accept permissions as array', done => {
+      const permissions = [`bigtable.tables.get`, `bigtable.tables.list`];
+      instance.bigtable.request = config => {
+        assert.deepStrictEqual(config.reqOpts.permissions, permissions);
+        done();
+      };
+      instance.testIamPermissions(permissions, assert.ifError);
+    });
+
+    it('should accept gaxOptions', done => {
+      const gaxOptions = {};
+      instance.bigtable.request = config => {
+        assert.strictEqual(config.gaxOpts, gaxOptions);
+        done();
+      };
+      instance.testIamPermissions(permissions, gaxOptions, assert.ifError);
+    });
+
+    it('should unpack permissions from resp object', done => {
+      const testPermissions = [`bigtable.tables.get`, `bigtable.tables.list`];
+      instance.bigtable.request = (config, callback) => {
+        callback(null, {permissions: testPermissions});
+      };
+      instance.testIamPermissions(testPermissions, (err, permissions) => {
+        assert.ifError(err);
+        assert.strictEqual(Array.isArray(permissions), true);
+        assert.deepStrictEqual(permissions, testPermissions);
+        done();
+      });
+    });
+
+    it('should return error', done => {
+      const permission = 'bigtable.tables.get';
+      const error = new Error('error');
+      instance.bigtable.request = (config, callback) => {
+        callback(error);
+      };
+      instance.testIamPermissions(permission, (err, resp) => {
+        assert.strictEqual(err, error);
+        done();
+      });
     });
   });
 });

--- a/test/table.ts
+++ b/test/table.ts
@@ -1504,6 +1504,7 @@ describe('Bigtable/Table', function() {
       const spy = sandbox.stub(Table, 'decodePolicyEtag');
       table.getIamPolicy(assert.ifError);
       assert.strictEqual(spy.calledOnce, true);
+      spy.restore();
     });
   });
 

--- a/test/table.ts
+++ b/test/table.ts
@@ -2722,11 +2722,11 @@ describe('Bigtable/Table', function() {
     it('should return policy with etag decoded to string', () => {
       const etagString = 'ABC';
       const policy = {
-        etag: Buffer.from(etagString)
-      }
+        etag: Buffer.from(etagString),
+      };
       assert.strictEqual(Table.decodePolicyEtag(policy).etag, etagString);
-    })
-  })
+    });
+  });
 
   describe('truncate', function() {
     it('should provide the proper request options', function(done) {


### PR DESCRIPTION
The new features allow user to check and tune [IAM policy](https://cloud.google.com/iam/docs/reference/rest/v1/Policy) for the resource (`instance`, `table`) level:

- `getIamPolicy` - allows a user obtain the current resource IAM policy.
- `setIamPolicy` - allows a user to set resource level IAM policy.
- `testIamPermissions` - allows a user to pass a list of [`permissions`](https://cloud.google.com/bigtable/docs/access-control#permissions) and get back a sub-list of granted permissions.

- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #581 
