### PR TITLE
fix: reduce through2 usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "docs-test": "linkinator docs",
     "fix": "gts fix",
     "prelint": "cd samples; npm link ../; npm install",
-    "lint": "gts fix",
+    "lint": "gts check",
     "prepare": "npm run compile",
     "samples-test": "cd samples/ && npm link ../ && npm install && npm test && cd ../",
     "snippet-test": "mocha samples/document-snippets/tests/*.js --timeout 600000",

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,6 @@ import arrify = require('arrify');
 import * as extend from 'extend';
 import {GoogleAuth, CallOptions} from 'google-gax';
 import * as gax from 'google-gax';
-import * as through from 'through2';
 import * as protos from '../protos/protos';
 import {AbortableDuplex} from '@google-cloud/common';
 
@@ -36,6 +35,7 @@ import {shouldRetryRequest} from './decorateStatus';
 import {google} from '../protos/protos';
 import {ServiceError} from 'google-gax';
 import * as v2 from './v2';
+import {PassThrough} from 'stream';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const retryRequest = require('retry-request');
@@ -748,8 +748,7 @@ export class Bigtable {
     };
 
     if (isStreamMode) {
-      stream = streamEvents(through.obj());
-
+      stream = streamEvents(new PassThrough({objectMode: true}));
       stream.abort = () => {
         if (gaxStream && gaxStream.cancel) {
           gaxStream.cancel();

--- a/system-test/mutate-rows.ts
+++ b/system-test/mutate-rows.ts
@@ -29,7 +29,7 @@ import {PartialFailureError} from '@google-cloud/common/build/src/util';
 import {Entry} from '../src/table';
 import {CancellableStream, GrpcClient} from 'google-gax';
 import {BigtableClient} from '../src/v2';
-import { PassThrough } from 'stream';
+import {PassThrough} from 'stream';
 
 const {grpc} = new GrpcClient();
 


### PR DESCRIPTION
This is the part where I admit to not understanding how the other stream fix y'all landed works, or if this would be subject to the same kind of problem.  I *do* know that the last 2 usages of `through2` in the codebase cause sample test failures if you swap them out with `PassThrough`.  Can I ask you both to poke holes in this?  