### PR TITLE
fix(types)!: improve types in index.ts

### DIFF
--- a/src/cluster.ts
+++ b/src/cluster.ts
@@ -59,15 +59,20 @@ export type GetClustersCallback = (
   clusters?: Cluster[],
   apiResponse?: google.bigtable.admin.v2.IListClustersResponse
 ) => void;
+export interface SetClusterMetadataOptions {
+  nodes: number;
+}
 export type SetClusterMetadataCallback = GenericOperationCallback<
   Operation | null | undefined
 >;
-
-export interface CreateClusterOptions {
-  gaxOptions?: CallOptions;
-  location?: string;
+export interface BasicClusterConfig {
+  location: string;
   nodes: number;
   storage?: string;
+}
+
+export interface CreateClusterOptions extends BasicClusterConfig {
+  gaxOptions?: CallOptions;
 }
 export type GetClusterMetadataCallback = (
   err: ServiceError | null,
@@ -367,18 +372,15 @@ Please use the format 'my-cluster' or '${instance.name}/clusters/my-cluster'.`);
   }
 
   setMetadata(
-    metadata: CreateClusterOptions
+    metadata: SetClusterMetadataOptions,
+    gaxOptions?: CallOptions
   ): Promise<SetClusterMetadataResponse>;
   setMetadata(
-    metadata: CreateClusterOptions,
-    gaxOptions: CallOptions
-  ): Promise<SetClusterMetadataResponse>;
-  setMetadata(
-    metadata: CreateClusterOptions,
+    metadata: SetClusterMetadataOptions,
     callback: SetClusterMetadataCallback
   ): void;
   setMetadata(
-    metadata: CreateClusterOptions,
+    metadata: SetClusterMetadataOptions,
     gaxOptions: CallOptions,
     callback: SetClusterMetadataCallback
   ): void;
@@ -399,7 +401,7 @@ Please use the format 'my-cluster' or '${instance.name}/clusters/my-cluster'.`);
    * region_tag:bigtable_cluster_set_meta
    */
   setMetadata(
-    metadata: CreateClusterOptions,
+    metadata: SetClusterMetadataOptions,
     gaxOptionsOrCallback?: CallOptions | SetClusterMetadataCallback,
     cb?: SetClusterMetadataCallback
   ): void | Promise<SetClusterMetadataResponse> {
@@ -412,22 +414,8 @@ Please use the format 'my-cluster' or '${instance.name}/clusters/my-cluster'.`);
 
     const reqOpts: ICluster = {
       name: this.name,
+      serveNodes: metadata.nodes,
     };
-
-    if (metadata.location) {
-      reqOpts.location = Cluster.getLocation_(
-        this.bigtable.projectId,
-        metadata.location
-      );
-    }
-
-    if (metadata.nodes) {
-      reqOpts.serveNodes = metadata.nodes;
-    }
-
-    if (metadata.storage) {
-      reqOpts.defaultStorageType = Cluster.getStorageType_(metadata.storage);
-    }
 
     this.bigtable.request<Operation>(
       {

--- a/src/cluster.ts
+++ b/src/cluster.ts
@@ -412,26 +412,16 @@ Please use the format 'my-cluster' or '${instance.name}/clusters/my-cluster'.`);
         ? gaxOptionsOrCallback
         : ({} as CallOptions);
 
-    const reqOpts: ICluster = {
-      name: this.name,
-      serveNodes: metadata.nodes,
-    };
-
+    const reqOpts: ICluster = Object.assign(
+      {},
+      {
+        name: this.name,
+        serveNodes: metadata.nodes,
+      },
+      metadata
+    );
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    if ((metadata as any).location) {
-      reqOpts.location = Cluster.getLocation_(
-        this.bigtable.projectId,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (metadata as any).location
-      );
-    }
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    if ((metadata as any).storage) {
-      reqOpts.defaultStorageType = Cluster.getStorageType_(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (metadata as any).storage
-      );
-    }
+    delete (reqOpts as any).nodes;
 
     this.bigtable.request<Operation>(
       {

--- a/src/cluster.ts
+++ b/src/cluster.ts
@@ -417,6 +417,22 @@ Please use the format 'my-cluster' or '${instance.name}/clusters/my-cluster'.`);
       serveNodes: metadata.nodes,
     };
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    if ((metadata as any).location) {
+      reqOpts.location = Cluster.getLocation_(
+        this.bigtable.projectId,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (metadata as any).location
+      );
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    if ((metadata as any).storage) {
+      reqOpts.defaultStorageType = Cluster.getStorageType_(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (metadata as any).storage
+      );
+    }
+
     this.bigtable.request<Operation>(
       {
         client: 'BigtableInstanceAdminClient',

--- a/src/cluster.ts
+++ b/src/cluster.ts
@@ -408,7 +408,7 @@ Please use the format 'my-cluster' or '${instance.name}/clusters/my-cluster'.`);
     const callback =
       typeof gaxOptionsOrCallback === 'function' ? gaxOptionsOrCallback : cb!;
     const gaxOptions =
-      typeof gaxOptionsOrCallback === 'object' && gaxOptionsOrCallback
+      typeof gaxOptionsOrCallback === 'object'
         ? gaxOptionsOrCallback
         : ({} as CallOptions);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -599,12 +599,14 @@ export class Bigtable {
   /**
    * @typedef {array} GetInstancesResponse
    * @property {Instance[]} 0 Array of {@link Instance} instances.
-   * @property {object} 1 The full API response.
+   * @property {string[]} 1 locations from which Instance information could not be retrieved
+   * @property {object} 2 The full API response.
    */
   /**
    * @callback GetInstancesCallback
    * @param {?Error} err Request error, if any.
    * @param {Instance[]} instances Array of {@link Instance} instances.
+   * @param {string[]} locations from which Instance information could not be retrieved
    * @param {object} apiResponse The full API response.
    */
   /**
@@ -622,6 +624,9 @@ export class Bigtable {
    * bigtable.getInstances(function(err, instances) {
    *   if (!err) {
    *     // `instances` is an array of Instance objects.
+   *     if (failedLocations.length > 0) {
+   *       // These locations contain instances which could not be retrieved.
+   *     }
    *   }
    * });
    *
@@ -629,6 +634,11 @@ export class Bigtable {
    * </caption>
    * bigtable.getInstances().then(function(data) {
    *   const instances = data[0];
+   *
+   *   if (data[1]) {
+   *     // These locations contain instances which could not be retrieved.
+   *     const failedLocations = data[1]
+   *   }
    * });
    */
   getInstances(

--- a/src/index.ts
+++ b/src/index.ts
@@ -637,7 +637,7 @@ export class Bigtable {
    *
    *   if (data[1]) {
    *     // These locations contain instances which could not be retrieved.
-   *     const failedLocations = data[1]
+   *     const failedLocations = data[1];
    *   }
    * });
    */

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,14 +49,14 @@ const {grpc} = new gax.GrpcClient();
 export interface GetInstancesCallback {
   (
     err: ServiceError | null,
-    result?: Instance[] | null,
-    nextQuery?: {} | null,
-    response?: google.bigtable.admin.v2.IListInstancesResponse | null
+    result?: Instance[],
+    failedLocations?: string[],
+    response?: google.bigtable.admin.v2.IListInstancesResponse
   ): void;
 }
 export type GetInstancesResponse = [
   Instance[],
-  {} | null,
+  string[],
   google.bigtable.admin.v2.IListInstancesResponse
 ];
 
@@ -632,19 +632,6 @@ export class Bigtable {
    *   }
    * });
    *
-   * @example <caption>To control how many API requests are made and page
-   * through the results manually, set `autoPaginate` to `false`.</caption>
-   * function callback(err, instances, nextQuery, apiResponse) {
-   *   if (nextQuery) {
-   *     // More results exist.
-   *     bigtable.getInstances(nextQuery, callback);
-   *   }
-   * }
-   *
-   * bigtable.getInstances({
-   *   autoPaginate: false
-   * }, callback);
-   *
    * @example <caption>If the callback is omitted, we'll return a Promise.
    * </caption>
    * bigtable.getInstances().then(function(data) {
@@ -683,7 +670,7 @@ export class Bigtable {
           instance.metadata = instanceData;
           return instance;
         });
-        callback!(null, instances, resp);
+        callback!(null, instances, resp.failedLocations, resp);
       }
     );
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,6 @@ import {
   InstanceOptions,
   CreateInstanceCallback,
   CreateInstanceResponse,
-  ClusterInfo,
   IInstance,
 } from './instance';
 import {shouldRetryRequest} from './decorateStatus';
@@ -462,14 +461,13 @@ export class Bigtable {
 
   createInstance(
     id: string,
-    options?: InstanceOptions
+    options: InstanceOptions
   ): Promise<CreateInstanceResponse>;
   createInstance(
     id: string,
     options: InstanceOptions,
     callback: CreateInstanceCallback
   ): void;
-  createInstance(id: string, callback: CreateInstanceCallback): void;
   /**
    * Create a Cloud Bigtable instance.
    *
@@ -546,14 +544,9 @@ export class Bigtable {
    */
   createInstance(
     id: string,
-    optionsOrCallback?: InstanceOptions | CreateInstanceCallback,
-    cb?: CreateInstanceCallback
+    options: InstanceOptions,
+    callback?: CreateInstanceCallback
   ): void | Promise<CreateInstanceResponse> {
-    const options =
-      typeof optionsOrCallback === 'object' ? optionsOrCallback : {};
-    const callback =
-      typeof optionsOrCallback === 'function' ? optionsOrCallback : cb;
-
     const reqOpts = {
       parent: this.projectName,
       instanceId: id,
@@ -567,7 +560,7 @@ export class Bigtable {
       reqOpts.instance!.type = Instance.getTypeType_(options.type);
     }
 
-    reqOpts.clusters = arrify(options.clusters!).reduce((clusters, cluster) => {
+    reqOpts.clusters = arrify(options.clusters).reduce((clusters, cluster) => {
       if (!cluster.id) {
         throw new Error(
           'A cluster was provided without an `id` property defined.'
@@ -581,7 +574,7 @@ export class Bigtable {
       };
 
       return clusters;
-    }, {} as {[index: string]: ClusterInfo});
+    }, {} as {[index: string]: google.bigtable.admin.v2.ICluster});
 
     this.request(
       {

--- a/src/index.ts
+++ b/src/index.ts
@@ -547,6 +547,11 @@ export class Bigtable {
     options: InstanceOptions,
     callback?: CreateInstanceCallback
   ): void | Promise<CreateInstanceResponse> {
+    if (typeof options !== 'object') {
+      throw new Error(
+        'A configuration object is required to create an instance.'
+      );
+    }
     if (!options.clusters) {
       throw new Error(
         'At least one cluster configuration object is required to create an instance.'

--- a/src/index.ts
+++ b/src/index.ts
@@ -477,7 +477,7 @@ export class Bigtable {
    * @param {object} options Instance creation options.
    * @param {object[]} options.clusters The clusters to be created within the
    *     instance.
-   * @param {string} options.displayName The descriptive name for this instance
+   * @param {string} [options.displayName] The descriptive name for this instance
    *     as it appears in UIs.
    * @param {Object.<string, string>} [options.labels] Labels are a flexible and
    *     lightweight mechanism for organizing cloud resources into groups that

--- a/src/index.ts
+++ b/src/index.ts
@@ -547,6 +547,11 @@ export class Bigtable {
     options: InstanceOptions,
     callback?: CreateInstanceCallback
   ): void | Promise<CreateInstanceResponse> {
+    if (!options.clusters) {
+      throw new Error(
+        'At least one cluster configuration object is required to create an instance.'
+      );
+    }
     const reqOpts = {
       parent: this.projectName,
       instanceId: id,

--- a/src/instance.ts
+++ b/src/instance.ts
@@ -882,7 +882,8 @@ Please use the format 'my-instance' or '${bigtable.projectName}/instances/my-ins
       view: Table.VIEWS[options.view || 'unspecified'],
     });
 
-    delete reqOpts.gaxOptions;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (reqOpts as any).gaxOptions;
 
     this.bigtable.request<Table[]>(
       {

--- a/system-test/bigtable.ts
+++ b/system-test/bigtable.ts
@@ -83,8 +83,9 @@ describe('Bigtable', () => {
 
   describe('instances', () => {
     it('should get a list of instances', async () => {
-      const [instances] = await bigtable.getInstances();
+      const [instances, failedLocations] = await bigtable.getInstances();
       assert(instances.length > 0);
+      assert(Array.isArray(failedLocations));
     });
 
     it('should check if an instance exists', async () => {

--- a/test/cluster.ts
+++ b/test/cluster.ts
@@ -388,7 +388,7 @@ describe('Bigtable/Cluster', () => {
       cluster.setMetadata(options, assert.ifError);
     });
 
-    it('should accept and pass user provided unput through', done => {
+    it('should accept and pass user provided input through', done => {
       const options = {
         nodes: 3,
         location: 'us-west2-b',

--- a/test/cluster.ts
+++ b/test/cluster.ts
@@ -388,6 +388,22 @@ describe('Bigtable/Cluster', () => {
       cluster.setMetadata(options, assert.ifError);
     });
 
+    it('should respect the gaxOptions', done => {
+      const options = {
+        nodes: 3,
+      };
+      const gaxOptions = {};
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      cluster.bigtable.request = (config: any) => {
+        assert.strictEqual(config.reqOpts.serveNodes, options.nodes);
+        assert.strictEqual(config.gaxOpts, gaxOptions);
+        done();
+      };
+
+      cluster.setMetadata(options, gaxOptions, assert.ifError);
+    });
+
     it('should execute callback with all arguments', done => {
       const args = [{}, {}];
 

--- a/test/cluster.ts
+++ b/test/cluster.ts
@@ -374,30 +374,6 @@ describe('Bigtable/Cluster', () => {
       cluster.setMetadata({}, done);
     });
 
-    it('should respect the location option', done => {
-      const options = {
-        location: 'us-centralb-1',
-      };
-
-      const getLocation = Cluster.getLocation_;
-      const fakeLocation = 'a/b/c/d';
-
-      Cluster.getLocation_ = (project: string, location: string) => {
-        assert.strictEqual(project, PROJECT_ID);
-        assert.strictEqual(location, options.location);
-        return fakeLocation;
-      };
-
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      cluster.bigtable.request = (config: any) => {
-        assert.strictEqual(config.reqOpts.location, fakeLocation);
-        Cluster.getLocation_ = getLocation;
-        done();
-      };
-
-      cluster.setMetadata(options, assert.ifError);
-    });
-
     it('should respect the nodes option', done => {
       const options = {
         nodes: 3,
@@ -406,29 +382,6 @@ describe('Bigtable/Cluster', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       cluster.bigtable.request = (config: any) => {
         assert.strictEqual(config.reqOpts.serveNodes, options.nodes);
-        done();
-      };
-
-      cluster.setMetadata(options, assert.ifError);
-    });
-
-    it('should respect the storage option', done => {
-      const options = {
-        storage: 'ssd',
-      };
-
-      const getStorageType = Cluster.getStorageType_;
-      const fakeStorageType = 'a';
-
-      Cluster.getStorageType_ = (storage: {}) => {
-        assert.strictEqual(storage, options.storage);
-        return fakeStorageType;
-      };
-
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      cluster.bigtable.request = (config: any) => {
-        assert.strictEqual(config.reqOpts.defaultStorageType, fakeStorageType);
-        Cluster.getStorageType_ = getStorageType;
         done();
       };
 

--- a/test/cluster.ts
+++ b/test/cluster.ts
@@ -388,6 +388,52 @@ describe('Bigtable/Cluster', () => {
       cluster.setMetadata(options, assert.ifError);
     });
 
+    it('should accept and pass location to #request()', done => {
+      const options = {
+        nodes: 3,
+        location: 'us-west2-b',
+      };
+
+      let fakeLocation: string;
+
+      Cluster.getLocation_ = (project: string, location: string) => {
+        assert.strictEqual(project, PROJECT_ID);
+        assert.strictEqual(location, options.location);
+        fakeLocation = `a/b/c/${location}`;
+        return fakeLocation;
+      };
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      cluster.bigtable.request = (config: any) => {
+        assert.strictEqual(config.reqOpts.location, fakeLocation);
+        done();
+      };
+
+      cluster.setMetadata(options, assert.ifError);
+    });
+
+    it('should accept and pass storage to #request()', done => {
+      const options = {
+        nodes: 3,
+        storage: 'hdd',
+      };
+
+      const fakeStorageType = 'two';
+
+      Cluster.getStorageType_ = (type: string) => {
+        assert.strictEqual(type, options.storage);
+        return fakeStorageType;
+      };
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      cluster.bigtable.request = (config: any) => {
+        assert.strictEqual(config.reqOpts.defaultStorageType, fakeStorageType);
+        done();
+      };
+
+      cluster.setMetadata(options, assert.ifError);
+    });
+
     it('should respect the gaxOptions', done => {
       const options = {
         nodes: 3,

--- a/test/cluster.ts
+++ b/test/cluster.ts
@@ -388,46 +388,23 @@ describe('Bigtable/Cluster', () => {
       cluster.setMetadata(options, assert.ifError);
     });
 
-    it('should accept and pass location to #request()', done => {
+    it('should accept and pass user provided unput through', done => {
       const options = {
         nodes: 3,
         location: 'us-west2-b',
+        defaultStorageType: 'exellent_type',
       };
 
-      let fakeLocation: string;
-
-      Cluster.getLocation_ = (project: string, location: string) => {
-        assert.strictEqual(project, PROJECT_ID);
-        assert.strictEqual(location, options.location);
-        fakeLocation = `a/b/c/${location}`;
-        return fakeLocation;
-      };
+      const expectedReqOpts = Object.assign(
+        {},
+        {name: CLUSTER_NAME, serveNodes: options.nodes},
+        options
+      );
+      delete expectedReqOpts.nodes;
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       cluster.bigtable.request = (config: any) => {
-        assert.strictEqual(config.reqOpts.location, fakeLocation);
-        done();
-      };
-
-      cluster.setMetadata(options, assert.ifError);
-    });
-
-    it('should accept and pass storage to #request()', done => {
-      const options = {
-        nodes: 3,
-        storage: 'hdd',
-      };
-
-      const fakeStorageType = 'two';
-
-      Cluster.getStorageType_ = (type: string) => {
-        assert.strictEqual(type, options.storage);
-        return fakeStorageType;
-      };
-
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      cluster.bigtable.request = (config: any) => {
-        assert.strictEqual(config.reqOpts.defaultStorageType, fakeStorageType);
+        assert.deepStrictEqual(config.reqOpts, expectedReqOpts);
         done();
       };
 

--- a/test/index.ts
+++ b/test/index.ts
@@ -541,7 +541,7 @@ describe('Bigtable', () => {
       });
     });
 
-    it('should return an array of instance objects', done => {
+    it('should return an array of instance objects and failed locations', done => {
       const response = {
         instances: [
           {
@@ -551,6 +551,7 @@ describe('Bigtable', () => {
             name: 'b',
           },
         ],
+        failedLocations: ['projects/<project>/locations/<zone_id>'],
       };
       const fakeInstances = [{}, {}];
       bigtable.request = (config: {}, callback: Function) => {
@@ -563,12 +564,18 @@ describe('Bigtable', () => {
       };
 
       bigtable.getInstances(
-        (err: Error, instances: Instance[], apiResponse: {}) => {
+        (
+          err: Error,
+          instances: Instance[],
+          failedLocations: string[],
+          apiResponse: {}
+        ) => {
           assert.ifError(err);
           assert.strictEqual(instances[0], fakeInstances[0]);
           assert.strictEqual(instances[0].metadata, response.instances[0]);
           assert.strictEqual(instances[1], fakeInstances[1]);
           assert.strictEqual(instances[1].metadata, response.instances[1]);
+          assert.strictEqual(failedLocations, response.failedLocations);
           assert.strictEqual(apiResponse, response);
           done();
         }

--- a/test/index.ts
+++ b/test/index.ts
@@ -342,6 +342,15 @@ describe('Bigtable', () => {
 
   describe('createInstance', () => {
     const INSTANCE_ID = 'my-instance';
+    const CLUSTER = {
+      id: 'my-cluster',
+      location: 'us-central1-b',
+      nodes: 3,
+      storage: 'ssd',
+    };
+    const OPTIONS = {
+      clusters: [CLUSTER],
+    };
 
     it('should provide the proper request options', done => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -354,23 +363,28 @@ describe('Bigtable', () => {
         assert.strictEqual(config.gaxOpts, undefined);
         done();
       };
-      bigtable.createInstance(INSTANCE_ID, assert.ifError);
+      bigtable.createInstance(INSTANCE_ID, OPTIONS, assert.ifError);
     });
 
     it('should accept gaxOptions', done => {
       const gaxOptions = {};
+      const options = Object.assign({}, OPTIONS, {gaxOptions});
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       bigtable.request = (config: any) => {
         assert.strictEqual(config.gaxOpts, gaxOptions);
         done();
       };
-      bigtable.createInstance(INSTANCE_ID, {gaxOptions}, assert.ifError);
+      bigtable.createInstance(INSTANCE_ID, options, assert.ifError);
     });
 
     it('should respect the displayName option', done => {
-      const options = {
-        displayName: 'robocop',
-      };
+      const options = Object.assign(
+        {},
+        {
+          displayName: 'robocop',
+        },
+        OPTIONS
+      );
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       bigtable.request = (config: any) => {
         assert.strictEqual(
@@ -383,7 +397,7 @@ describe('Bigtable', () => {
     });
 
     it('should respect the type option', done => {
-      const options = {type: 'development'};
+      const options = Object.assign({}, {type: 'development'}, OPTIONS);
       const fakeTypeType = 99;
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       FakeInstance.getTypeType_ = (type: string) => {
@@ -399,11 +413,15 @@ describe('Bigtable', () => {
     });
 
     it('should respect the labels option', done => {
-      const options = {
-        labels: {
-          env: 'prod',
+      const options = Object.assign(
+        {},
+        {
+          labels: {
+            env: 'prod',
+          },
         },
-      };
+        OPTIONS
+      );
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       bigtable.request = (config: any) => {
         assert.deepStrictEqual(config.reqOpts.instance.labels, options.labels);
@@ -413,24 +431,15 @@ describe('Bigtable', () => {
     });
 
     it('should respect the clusters option', done => {
-      const cluster = {
-        id: 'my-cluster',
-        location: 'us-central1-b',
-        nodes: 3,
-        storage: 'ssd',
-      };
-      const options = {
-        clusters: [cluster],
-      };
       const fakeLocation = 'a/b/c/d';
       FakeCluster.getLocation_ = (project: string, location: string) => {
         assert.strictEqual(project, PROJECT_ID);
-        assert.strictEqual(location, cluster.location);
+        assert.strictEqual(location, OPTIONS.clusters[0].location);
         return fakeLocation;
       };
       const fakeStorage = 20;
       FakeCluster.getStorageType_ = (storage: {}) => {
-        assert.strictEqual(storage, cluster.storage);
+        assert.strictEqual(storage, OPTIONS.clusters[0].storage);
         return fakeStorage;
       };
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -438,7 +447,7 @@ describe('Bigtable', () => {
         assert.deepStrictEqual(config.reqOpts.clusters, {
           'my-cluster': {
             location: fakeLocation,
-            serveNodes: cluster.nodes,
+            serveNodes: OPTIONS.clusters[0].nodes,
             defaultStorageType: fakeStorage,
           },
         });
@@ -446,7 +455,7 @@ describe('Bigtable', () => {
         done();
       };
 
-      bigtable.createInstance(INSTANCE_ID, options, assert.ifError);
+      bigtable.createInstance(INSTANCE_ID, OPTIONS, assert.ifError);
     });
 
     it('should return an error to the callback', done => {
@@ -456,7 +465,7 @@ describe('Bigtable', () => {
       };
       bigtable.createInstance(
         INSTANCE_ID,
-        {},
+        OPTIONS,
         (err: Error, instance: Instance, operation: gax.Operation) => {
           assert.strictEqual(err, error);
           assert.strictEqual(instance, undefined);
@@ -482,7 +491,7 @@ describe('Bigtable', () => {
       };
       bigtable.createInstance(
         INSTANCE_ID,
-        {},
+        OPTIONS,
         (err: Error, instance: Instance, ...args: Array<{}>) => {
           assert.ifError(err);
           assert.strictEqual(instance, fakeInstance);
@@ -509,6 +518,12 @@ describe('Bigtable', () => {
       assert.throws(() => {
         bigtable.createInstance(INSTANCE_ID, options);
       }, /A cluster was provided without an `id` property defined\./);
+    });
+
+    it('should throw an error if cluster configuration is not provided', () => {
+      assert.throws(() => {
+        bigtable.createInstance(INSTANCE_ID, {}, assert.ifError);
+      }, /At least one cluster configuration object is required to create an instance\./);
     });
   });
 

--- a/test/index.ts
+++ b/test/index.ts
@@ -451,6 +451,7 @@ describe('Bigtable', () => {
       };
       bigtable.createInstance(
         INSTANCE_ID,
+        {},
         (err: Error, instance: Instance, operation: gax.Operation) => {
           assert.strictEqual(err, error);
           assert.strictEqual(instance, undefined);
@@ -476,6 +477,7 @@ describe('Bigtable', () => {
       };
       bigtable.createInstance(
         INSTANCE_ID,
+        {},
         (err: Error, instance: Instance, ...args: Array<{}>) => {
           assert.ifError(err);
           assert.strictEqual(instance, fakeInstance);

--- a/test/index.ts
+++ b/test/index.ts
@@ -520,6 +520,12 @@ describe('Bigtable', () => {
       }, /A cluster was provided without an `id` property defined\./);
     });
 
+    it('should throw an error if configuration object is not provided', () => {
+      assert.throws(() => {
+        bigtable.createInstance(INSTANCE_ID, assert.ifError);
+      }, /A configuration object is required to create an instance\./);
+    });
+
     it('should throw an error if cluster configuration is not provided', () => {
       assert.throws(() => {
         bigtable.createInstance(INSTANCE_ID, {}, assert.ifError);

--- a/test/index.ts
+++ b/test/index.ts
@@ -150,6 +150,11 @@ describe('Bigtable', () => {
       assert(promisified);
     });
 
+    it('should work without new', () => {
+      const bigtable = Bigtable();
+      assert(bigtable instanceof Bigtable);
+    });
+
     it('should initialize the API object', () => {
       assert.deepStrictEqual(bigtable.api, {});
     });

--- a/test/instance.ts
+++ b/test/instance.ts
@@ -1100,6 +1100,16 @@ describe('Bigtable/Instance', () => {
       instance.setMetadata(metadata, done);
     });
 
+    it('should accept gaxOptions', done => {
+      const gaxOptions = {};
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (instance.bigtable.request as Function) = (config: any) => {
+        assert.strictEqual(config.gaxOpts, gaxOptions);
+        done();
+      };
+      instance.setMetadata({}, gaxOptions, assert.ifError);
+    });
+
     it('should update metadata property with API response', done => {
       const response = {};
       sandbox

--- a/test/instance.ts
+++ b/test/instance.ts
@@ -95,7 +95,10 @@ class FakeTable extends Table {
 describe('Bigtable/Instance', () => {
   const INSTANCE_ID = 'my-instance';
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const BIGTABLE = {projectName: 'projects/my-project'} as Bigtable;
+  const BIGTABLE = {
+    projectName: 'projects/my-project',
+    projectId: 'my-project',
+  } as Bigtable;
   const INSTANCE_NAME = `${BIGTABLE.projectName}/instances/${INSTANCE_ID}`;
   const APP_PROFILE_ID = 'my-app-profile';
   const CLUSTER_ID = 'my-cluster';
@@ -200,18 +203,6 @@ describe('Bigtable/Instance', () => {
         callback(); // done()
       };
       instance.create(options, done);
-    });
-
-    it('should not require options', done => {
-      (instance.bigtable.createInstance as Function) = (
-        id: string,
-        options: {},
-        callback: Function
-      ) => {
-        assert.deepStrictEqual(options, {});
-        callback(); // done()
-      };
-      instance.create(done);
     });
   });
 
@@ -404,6 +395,7 @@ describe('Bigtable/Instance', () => {
     it('should respect the nodes option', done => {
       const options = {
         nodes: 3,
+        location: 'us-central1-c',
       };
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (instance.bigtable.request as Function) = (config: any) => {


### PR DESCRIPTION
BREAKING CHANGE: cluster.setMetadata(): only node count is updatable on an existing cluster; getInstancesCallback/Response: dropped nextQuery property as it is deprecated for this method, exposed failedLocations property; instance.createCluster(): removed unsupported params serveNodes and defaultStorageType

- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Improve type annotations, some clean up and minor refactoring.
