### PR TITLE
feat: check status of long running operation by its name

### DIFF
--- a/protos/protos.js
+++ b/protos/protos.js
@@ -812,13 +812,13 @@
                         CreateInstanceRequest.encode = function encode(message, writer) {
                             if (!writer)
                                 writer = $Writer.create();
-                            if (message.parent != null && Object.hasOwnProperty.call(message, "parent"))
+                            if (message.parent != null && message.hasOwnProperty("parent"))
                                 writer.uint32(/* id 1, wireType 2 =*/10).string(message.parent);
-                            if (message.instanceId != null && Object.hasOwnProperty.call(message, "instanceId"))
+                            if (message.instanceId != null && message.hasOwnProperty("instanceId"))
                                 writer.uint32(/* id 2, wireType 2 =*/18).string(message.instanceId);
-                            if (message.instance != null && Object.hasOwnProperty.call(message, "instance"))
+                            if (message.instance != null && message.hasOwnProperty("instance"))
                                 $root.google.bigtable.admin.v2.Instance.encode(message.instance, writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
-                            if (message.clusters != null && Object.hasOwnProperty.call(message, "clusters"))
+                            if (message.clusters != null && message.hasOwnProperty("clusters"))
                                 for (var keys = Object.keys(message.clusters), i = 0; i < keys.length; ++i) {
                                     writer.uint32(/* id 4, wireType 2 =*/34).fork().uint32(/* id 1, wireType 2 =*/10).string(keys[i]);
                                     $root.google.bigtable.admin.v2.Cluster.encode(message.clusters[keys[i]], writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim().ldelim();
@@ -1072,7 +1072,7 @@
                         GetInstanceRequest.encode = function encode(message, writer) {
                             if (!writer)
                                 writer = $Writer.create();
-                            if (message.name != null && Object.hasOwnProperty.call(message, "name"))
+                            if (message.name != null && message.hasOwnProperty("name"))
                                 writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
                             return writer;
                         };
@@ -1268,9 +1268,9 @@
                         ListInstancesRequest.encode = function encode(message, writer) {
                             if (!writer)
                                 writer = $Writer.create();
-                            if (message.parent != null && Object.hasOwnProperty.call(message, "parent"))
+                            if (message.parent != null && message.hasOwnProperty("parent"))
                                 writer.uint32(/* id 1, wireType 2 =*/10).string(message.parent);
-                            if (message.pageToken != null && Object.hasOwnProperty.call(message, "pageToken"))
+                            if (message.pageToken != null && message.hasOwnProperty("pageToken"))
                                 writer.uint32(/* id 2, wireType 2 =*/18).string(message.pageToken);
                             return writer;
                         };
@@ -1495,7 +1495,7 @@
                             if (message.failedLocations != null && message.failedLocations.length)
                                 for (var i = 0; i < message.failedLocations.length; ++i)
                                     writer.uint32(/* id 2, wireType 2 =*/18).string(message.failedLocations[i]);
-                            if (message.nextPageToken != null && Object.hasOwnProperty.call(message, "nextPageToken"))
+                            if (message.nextPageToken != null && message.hasOwnProperty("nextPageToken"))
                                 writer.uint32(/* id 3, wireType 2 =*/26).string(message.nextPageToken);
                             return writer;
                         };
@@ -1748,9 +1748,9 @@
                         PartialUpdateInstanceRequest.encode = function encode(message, writer) {
                             if (!writer)
                                 writer = $Writer.create();
-                            if (message.instance != null && Object.hasOwnProperty.call(message, "instance"))
+                            if (message.instance != null && message.hasOwnProperty("instance"))
                                 $root.google.bigtable.admin.v2.Instance.encode(message.instance, writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
-                            if (message.updateMask != null && Object.hasOwnProperty.call(message, "updateMask"))
+                            if (message.updateMask != null && message.hasOwnProperty("updateMask"))
                                 $root.google.protobuf.FieldMask.encode(message.updateMask, writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
                             return writer;
                         };
@@ -1959,7 +1959,7 @@
                         DeleteInstanceRequest.encode = function encode(message, writer) {
                             if (!writer)
                                 writer = $Writer.create();
-                            if (message.name != null && Object.hasOwnProperty.call(message, "name"))
+                            if (message.name != null && message.hasOwnProperty("name"))
                                 writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
                             return writer;
                         };
@@ -2164,11 +2164,11 @@
                         CreateClusterRequest.encode = function encode(message, writer) {
                             if (!writer)
                                 writer = $Writer.create();
-                            if (message.parent != null && Object.hasOwnProperty.call(message, "parent"))
+                            if (message.parent != null && message.hasOwnProperty("parent"))
                                 writer.uint32(/* id 1, wireType 2 =*/10).string(message.parent);
-                            if (message.clusterId != null && Object.hasOwnProperty.call(message, "clusterId"))
+                            if (message.clusterId != null && message.hasOwnProperty("clusterId"))
                                 writer.uint32(/* id 2, wireType 2 =*/18).string(message.clusterId);
-                            if (message.cluster != null && Object.hasOwnProperty.call(message, "cluster"))
+                            if (message.cluster != null && message.hasOwnProperty("cluster"))
                                 $root.google.bigtable.admin.v2.Cluster.encode(message.cluster, writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
                             return writer;
                         };
@@ -2383,7 +2383,7 @@
                         GetClusterRequest.encode = function encode(message, writer) {
                             if (!writer)
                                 writer = $Writer.create();
-                            if (message.name != null && Object.hasOwnProperty.call(message, "name"))
+                            if (message.name != null && message.hasOwnProperty("name"))
                                 writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
                             return writer;
                         };
@@ -2579,9 +2579,9 @@
                         ListClustersRequest.encode = function encode(message, writer) {
                             if (!writer)
                                 writer = $Writer.create();
-                            if (message.parent != null && Object.hasOwnProperty.call(message, "parent"))
+                            if (message.parent != null && message.hasOwnProperty("parent"))
                                 writer.uint32(/* id 1, wireType 2 =*/10).string(message.parent);
-                            if (message.pageToken != null && Object.hasOwnProperty.call(message, "pageToken"))
+                            if (message.pageToken != null && message.hasOwnProperty("pageToken"))
                                 writer.uint32(/* id 2, wireType 2 =*/18).string(message.pageToken);
                             return writer;
                         };
@@ -2806,7 +2806,7 @@
                             if (message.failedLocations != null && message.failedLocations.length)
                                 for (var i = 0; i < message.failedLocations.length; ++i)
                                     writer.uint32(/* id 2, wireType 2 =*/18).string(message.failedLocations[i]);
-                            if (message.nextPageToken != null && Object.hasOwnProperty.call(message, "nextPageToken"))
+                            if (message.nextPageToken != null && message.hasOwnProperty("nextPageToken"))
                                 writer.uint32(/* id 3, wireType 2 =*/26).string(message.nextPageToken);
                             return writer;
                         };
@@ -3050,7 +3050,7 @@
                         DeleteClusterRequest.encode = function encode(message, writer) {
                             if (!writer)
                                 writer = $Writer.create();
-                            if (message.name != null && Object.hasOwnProperty.call(message, "name"))
+                            if (message.name != null && message.hasOwnProperty("name"))
                                 writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
                             return writer;
                         };
@@ -3255,11 +3255,11 @@
                         CreateInstanceMetadata.encode = function encode(message, writer) {
                             if (!writer)
                                 writer = $Writer.create();
-                            if (message.originalRequest != null && Object.hasOwnProperty.call(message, "originalRequest"))
+                            if (message.originalRequest != null && message.hasOwnProperty("originalRequest"))
                                 $root.google.bigtable.admin.v2.CreateInstanceRequest.encode(message.originalRequest, writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
-                            if (message.requestTime != null && Object.hasOwnProperty.call(message, "requestTime"))
+                            if (message.requestTime != null && message.hasOwnProperty("requestTime"))
                                 $root.google.protobuf.Timestamp.encode(message.requestTime, writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
-                            if (message.finishTime != null && Object.hasOwnProperty.call(message, "finishTime"))
+                            if (message.finishTime != null && message.hasOwnProperty("finishTime"))
                                 $root.google.protobuf.Timestamp.encode(message.finishTime, writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
                             return writer;
                         };
@@ -3502,11 +3502,11 @@
                         UpdateInstanceMetadata.encode = function encode(message, writer) {
                             if (!writer)
                                 writer = $Writer.create();
-                            if (message.originalRequest != null && Object.hasOwnProperty.call(message, "originalRequest"))
+                            if (message.originalRequest != null && message.hasOwnProperty("originalRequest"))
                                 $root.google.bigtable.admin.v2.PartialUpdateInstanceRequest.encode(message.originalRequest, writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
-                            if (message.requestTime != null && Object.hasOwnProperty.call(message, "requestTime"))
+                            if (message.requestTime != null && message.hasOwnProperty("requestTime"))
                                 $root.google.protobuf.Timestamp.encode(message.requestTime, writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
-                            if (message.finishTime != null && Object.hasOwnProperty.call(message, "finishTime"))
+                            if (message.finishTime != null && message.hasOwnProperty("finishTime"))
                                 $root.google.protobuf.Timestamp.encode(message.finishTime, writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
                             return writer;
                         };
@@ -3749,11 +3749,11 @@
                         CreateClusterMetadata.encode = function encode(message, writer) {
                             if (!writer)
                                 writer = $Writer.create();
-                            if (message.originalRequest != null && Object.hasOwnProperty.call(message, "originalRequest"))
+                            if (message.originalRequest != null && message.hasOwnProperty("originalRequest"))
                                 $root.google.bigtable.admin.v2.CreateClusterRequest.encode(message.originalRequest, writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
-                            if (message.requestTime != null && Object.hasOwnProperty.call(message, "requestTime"))
+                            if (message.requestTime != null && message.hasOwnProperty("requestTime"))
                                 $root.google.protobuf.Timestamp.encode(message.requestTime, writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
-                            if (message.finishTime != null && Object.hasOwnProperty.call(message, "finishTime"))
+                            if (message.finishTime != null && message.hasOwnProperty("finishTime"))
                                 $root.google.protobuf.Timestamp.encode(message.finishTime, writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
                             return writer;
                         };
@@ -3996,11 +3996,11 @@
                         UpdateClusterMetadata.encode = function encode(message, writer) {
                             if (!writer)
                                 writer = $Writer.create();
-                            if (message.originalRequest != null && Object.hasOwnProperty.call(message, "originalRequest"))
+                            if (message.originalRequest != null && message.hasOwnProperty("originalRequest"))
                                 $root.google.bigtable.admin.v2.Cluster.encode(message.originalRequest, writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
-                            if (message.requestTime != null && Object.hasOwnProperty.call(message, "requestTime"))
+                            if (message.requestTime != null && message.hasOwnProperty("requestTime"))
                                 $root.google.protobuf.Timestamp.encode(message.requestTime, writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
-                            if (message.finishTime != null && Object.hasOwnProperty.call(message, "finishTime"))
+                            if (message.finishTime != null && message.hasOwnProperty("finishTime"))
                                 $root.google.protobuf.Timestamp.encode(message.finishTime, writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
                             return writer;
                         };
@@ -4252,13 +4252,13 @@
                         CreateAppProfileRequest.encode = function encode(message, writer) {
                             if (!writer)
                                 writer = $Writer.create();
-                            if (message.parent != null && Object.hasOwnProperty.call(message, "parent"))
+                            if (message.parent != null && message.hasOwnProperty("parent"))
                                 writer.uint32(/* id 1, wireType 2 =*/10).string(message.parent);
-                            if (message.appProfileId != null && Object.hasOwnProperty.call(message, "appProfileId"))
+                            if (message.appProfileId != null && message.hasOwnProperty("appProfileId"))
                                 writer.uint32(/* id 2, wireType 2 =*/18).string(message.appProfileId);
-                            if (message.appProfile != null && Object.hasOwnProperty.call(message, "appProfile"))
+                            if (message.appProfile != null && message.hasOwnProperty("appProfile"))
                                 $root.google.bigtable.admin.v2.AppProfile.encode(message.appProfile, writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
-                            if (message.ignoreWarnings != null && Object.hasOwnProperty.call(message, "ignoreWarnings"))
+                            if (message.ignoreWarnings != null && message.hasOwnProperty("ignoreWarnings"))
                                 writer.uint32(/* id 4, wireType 0 =*/32).bool(message.ignoreWarnings);
                             return writer;
                         };
@@ -4484,7 +4484,7 @@
                         GetAppProfileRequest.encode = function encode(message, writer) {
                             if (!writer)
                                 writer = $Writer.create();
-                            if (message.name != null && Object.hasOwnProperty.call(message, "name"))
+                            if (message.name != null && message.hasOwnProperty("name"))
                                 writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
                             return writer;
                         };
@@ -4689,11 +4689,11 @@
                         ListAppProfilesRequest.encode = function encode(message, writer) {
                             if (!writer)
                                 writer = $Writer.create();
-                            if (message.parent != null && Object.hasOwnProperty.call(message, "parent"))
+                            if (message.parent != null && message.hasOwnProperty("parent"))
                                 writer.uint32(/* id 1, wireType 2 =*/10).string(message.parent);
-                            if (message.pageToken != null && Object.hasOwnProperty.call(message, "pageToken"))
+                            if (message.pageToken != null && message.hasOwnProperty("pageToken"))
                                 writer.uint32(/* id 2, wireType 2 =*/18).string(message.pageToken);
-                            if (message.pageSize != null && Object.hasOwnProperty.call(message, "pageSize"))
+                            if (message.pageSize != null && message.hasOwnProperty("pageSize"))
                                 writer.uint32(/* id 3, wireType 0 =*/24).int32(message.pageSize);
                             return writer;
                         };
@@ -4926,7 +4926,7 @@
                             if (message.appProfiles != null && message.appProfiles.length)
                                 for (var i = 0; i < message.appProfiles.length; ++i)
                                     $root.google.bigtable.admin.v2.AppProfile.encode(message.appProfiles[i], writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
-                            if (message.nextPageToken != null && Object.hasOwnProperty.call(message, "nextPageToken"))
+                            if (message.nextPageToken != null && message.hasOwnProperty("nextPageToken"))
                                 writer.uint32(/* id 2, wireType 2 =*/18).string(message.nextPageToken);
                             if (message.failedLocations != null && message.failedLocations.length)
                                 for (var i = 0; i < message.failedLocations.length; ++i)
@@ -5191,11 +5191,11 @@
                         UpdateAppProfileRequest.encode = function encode(message, writer) {
                             if (!writer)
                                 writer = $Writer.create();
-                            if (message.appProfile != null && Object.hasOwnProperty.call(message, "appProfile"))
+                            if (message.appProfile != null && message.hasOwnProperty("appProfile"))
                                 $root.google.bigtable.admin.v2.AppProfile.encode(message.appProfile, writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
-                            if (message.updateMask != null && Object.hasOwnProperty.call(message, "updateMask"))
+                            if (message.updateMask != null && message.hasOwnProperty("updateMask"))
                                 $root.google.protobuf.FieldMask.encode(message.updateMask, writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
-                            if (message.ignoreWarnings != null && Object.hasOwnProperty.call(message, "ignoreWarnings"))
+                            if (message.ignoreWarnings != null && message.hasOwnProperty("ignoreWarnings"))
                                 writer.uint32(/* id 3, wireType 0 =*/24).bool(message.ignoreWarnings);
                             return writer;
                         };
@@ -5424,9 +5424,9 @@
                         DeleteAppProfileRequest.encode = function encode(message, writer) {
                             if (!writer)
                                 writer = $Writer.create();
-                            if (message.name != null && Object.hasOwnProperty.call(message, "name"))
+                            if (message.name != null && message.hasOwnProperty("name"))
                                 writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
-                            if (message.ignoreWarnings != null && Object.hasOwnProperty.call(message, "ignoreWarnings"))
+                            if (message.ignoreWarnings != null && message.hasOwnProperty("ignoreWarnings"))
                                 writer.uint32(/* id 2, wireType 0 =*/16).bool(message.ignoreWarnings);
                             return writer;
                         };
@@ -5822,15 +5822,15 @@
                         Instance.encode = function encode(message, writer) {
                             if (!writer)
                                 writer = $Writer.create();
-                            if (message.name != null && Object.hasOwnProperty.call(message, "name"))
+                            if (message.name != null && message.hasOwnProperty("name"))
                                 writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
-                            if (message.displayName != null && Object.hasOwnProperty.call(message, "displayName"))
+                            if (message.displayName != null && message.hasOwnProperty("displayName"))
                                 writer.uint32(/* id 2, wireType 2 =*/18).string(message.displayName);
-                            if (message.state != null && Object.hasOwnProperty.call(message, "state"))
+                            if (message.state != null && message.hasOwnProperty("state"))
                                 writer.uint32(/* id 3, wireType 0 =*/24).int32(message.state);
-                            if (message.type != null && Object.hasOwnProperty.call(message, "type"))
+                            if (message.type != null && message.hasOwnProperty("type"))
                                 writer.uint32(/* id 4, wireType 0 =*/32).int32(message.type);
-                            if (message.labels != null && Object.hasOwnProperty.call(message, "labels"))
+                            if (message.labels != null && message.hasOwnProperty("labels"))
                                 for (var keys = Object.keys(message.labels), i = 0; i < keys.length; ++i)
                                     writer.uint32(/* id 5, wireType 2 =*/42).fork().uint32(/* id 1, wireType 2 =*/10).string(keys[i]).uint32(/* id 2, wireType 2 =*/18).string(message.labels[keys[i]]).ldelim();
                             return writer;
@@ -6063,7 +6063,7 @@
                         /**
                          * State enum.
                          * @name google.bigtable.admin.v2.Instance.State
-                         * @enum {number}
+                         * @enum {string}
                          * @property {number} STATE_NOT_KNOWN=0 STATE_NOT_KNOWN value
                          * @property {number} READY=1 READY value
                          * @property {number} CREATING=2 CREATING value
@@ -6079,7 +6079,7 @@
                         /**
                          * Type enum.
                          * @name google.bigtable.admin.v2.Instance.Type
-                         * @enum {number}
+                         * @enum {string}
                          * @property {number} TYPE_UNSPECIFIED=0 TYPE_UNSPECIFIED value
                          * @property {number} PRODUCTION=1 PRODUCTION value
                          * @property {number} DEVELOPMENT=2 DEVELOPMENT value
@@ -6187,15 +6187,15 @@
                         Cluster.encode = function encode(message, writer) {
                             if (!writer)
                                 writer = $Writer.create();
-                            if (message.name != null && Object.hasOwnProperty.call(message, "name"))
+                            if (message.name != null && message.hasOwnProperty("name"))
                                 writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
-                            if (message.location != null && Object.hasOwnProperty.call(message, "location"))
+                            if (message.location != null && message.hasOwnProperty("location"))
                                 writer.uint32(/* id 2, wireType 2 =*/18).string(message.location);
-                            if (message.state != null && Object.hasOwnProperty.call(message, "state"))
+                            if (message.state != null && message.hasOwnProperty("state"))
                                 writer.uint32(/* id 3, wireType 0 =*/24).int32(message.state);
-                            if (message.serveNodes != null && Object.hasOwnProperty.call(message, "serveNodes"))
+                            if (message.serveNodes != null && message.hasOwnProperty("serveNodes"))
                                 writer.uint32(/* id 4, wireType 0 =*/32).int32(message.serveNodes);
-                            if (message.defaultStorageType != null && Object.hasOwnProperty.call(message, "defaultStorageType"))
+                            if (message.defaultStorageType != null && message.hasOwnProperty("defaultStorageType"))
                                 writer.uint32(/* id 5, wireType 0 =*/40).int32(message.defaultStorageType);
                             return writer;
                         };
@@ -6417,7 +6417,7 @@
                         /**
                          * State enum.
                          * @name google.bigtable.admin.v2.Cluster.State
-                         * @enum {number}
+                         * @enum {string}
                          * @property {number} STATE_NOT_KNOWN=0 STATE_NOT_KNOWN value
                          * @property {number} READY=1 READY value
                          * @property {number} CREATING=2 CREATING value
@@ -6543,15 +6543,15 @@
                         AppProfile.encode = function encode(message, writer) {
                             if (!writer)
                                 writer = $Writer.create();
-                            if (message.name != null && Object.hasOwnProperty.call(message, "name"))
+                            if (message.name != null && message.hasOwnProperty("name"))
                                 writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
-                            if (message.etag != null && Object.hasOwnProperty.call(message, "etag"))
+                            if (message.etag != null && message.hasOwnProperty("etag"))
                                 writer.uint32(/* id 2, wireType 2 =*/18).string(message.etag);
-                            if (message.description != null && Object.hasOwnProperty.call(message, "description"))
+                            if (message.description != null && message.hasOwnProperty("description"))
                                 writer.uint32(/* id 3, wireType 2 =*/26).string(message.description);
-                            if (message.multiClusterRoutingUseAny != null && Object.hasOwnProperty.call(message, "multiClusterRoutingUseAny"))
+                            if (message.multiClusterRoutingUseAny != null && message.hasOwnProperty("multiClusterRoutingUseAny"))
                                 $root.google.bigtable.admin.v2.AppProfile.MultiClusterRoutingUseAny.encode(message.multiClusterRoutingUseAny, writer.uint32(/* id 5, wireType 2 =*/42).fork()).ldelim();
-                            if (message.singleClusterRouting != null && Object.hasOwnProperty.call(message, "singleClusterRouting"))
+                            if (message.singleClusterRouting != null && message.hasOwnProperty("singleClusterRouting"))
                                 $root.google.bigtable.admin.v2.AppProfile.SingleClusterRouting.encode(message.singleClusterRouting, writer.uint32(/* id 6, wireType 2 =*/50).fork()).ldelim();
                             return writer;
                         };
@@ -6972,9 +6972,9 @@
                             SingleClusterRouting.encode = function encode(message, writer) {
                                 if (!writer)
                                     writer = $Writer.create();
-                                if (message.clusterId != null && Object.hasOwnProperty.call(message, "clusterId"))
+                                if (message.clusterId != null && message.hasOwnProperty("clusterId"))
                                     writer.uint32(/* id 1, wireType 2 =*/10).string(message.clusterId);
-                                if (message.allowTransactionalWrites != null && Object.hasOwnProperty.call(message, "allowTransactionalWrites"))
+                                if (message.allowTransactionalWrites != null && message.hasOwnProperty("allowTransactionalWrites"))
                                     writer.uint32(/* id 2, wireType 0 =*/16).bool(message.allowTransactionalWrites);
                                 return writer;
                             };
@@ -7123,7 +7123,7 @@
                     /**
                      * StorageType enum.
                      * @name google.bigtable.admin.v2.StorageType
-                     * @enum {number}
+                     * @enum {string}
                      * @property {number} STORAGE_TYPE_UNSPECIFIED=0 STORAGE_TYPE_UNSPECIFIED value
                      * @property {number} SSD=1 SSD value
                      * @property {number} HDD=2 HDD value
@@ -7210,11 +7210,11 @@
                         OperationProgress.encode = function encode(message, writer) {
                             if (!writer)
                                 writer = $Writer.create();
-                            if (message.progressPercent != null && Object.hasOwnProperty.call(message, "progressPercent"))
+                            if (message.progressPercent != null && message.hasOwnProperty("progressPercent"))
                                 writer.uint32(/* id 1, wireType 0 =*/8).int32(message.progressPercent);
-                            if (message.startTime != null && Object.hasOwnProperty.call(message, "startTime"))
+                            if (message.startTime != null && message.hasOwnProperty("startTime"))
                                 $root.google.protobuf.Timestamp.encode(message.startTime, writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
-                            if (message.endTime != null && Object.hasOwnProperty.call(message, "endTime"))
+                            if (message.endTime != null && message.hasOwnProperty("endTime"))
                                 $root.google.protobuf.Timestamp.encode(message.endTime, writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
                             return writer;
                         };
@@ -8223,11 +8223,11 @@
                         CreateTableRequest.encode = function encode(message, writer) {
                             if (!writer)
                                 writer = $Writer.create();
-                            if (message.parent != null && Object.hasOwnProperty.call(message, "parent"))
+                            if (message.parent != null && message.hasOwnProperty("parent"))
                                 writer.uint32(/* id 1, wireType 2 =*/10).string(message.parent);
-                            if (message.tableId != null && Object.hasOwnProperty.call(message, "tableId"))
+                            if (message.tableId != null && message.hasOwnProperty("tableId"))
                                 writer.uint32(/* id 2, wireType 2 =*/18).string(message.tableId);
-                            if (message.table != null && Object.hasOwnProperty.call(message, "table"))
+                            if (message.table != null && message.hasOwnProperty("table"))
                                 $root.google.bigtable.admin.v2.Table.encode(message.table, writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
                             if (message.initialSplits != null && message.initialSplits.length)
                                 for (var i = 0; i < message.initialSplits.length; ++i)
@@ -8473,7 +8473,7 @@
                             Split.encode = function encode(message, writer) {
                                 if (!writer)
                                     writer = $Writer.create();
-                                if (message.key != null && Object.hasOwnProperty.call(message, "key"))
+                                if (message.key != null && message.hasOwnProperty("key"))
                                     writer.uint32(/* id 1, wireType 2 =*/10).bytes(message.key);
                                 return writer;
                             };
@@ -8690,11 +8690,11 @@
                         CreateTableFromSnapshotRequest.encode = function encode(message, writer) {
                             if (!writer)
                                 writer = $Writer.create();
-                            if (message.parent != null && Object.hasOwnProperty.call(message, "parent"))
+                            if (message.parent != null && message.hasOwnProperty("parent"))
                                 writer.uint32(/* id 1, wireType 2 =*/10).string(message.parent);
-                            if (message.tableId != null && Object.hasOwnProperty.call(message, "tableId"))
+                            if (message.tableId != null && message.hasOwnProperty("tableId"))
                                 writer.uint32(/* id 2, wireType 2 =*/18).string(message.tableId);
-                            if (message.sourceSnapshot != null && Object.hasOwnProperty.call(message, "sourceSnapshot"))
+                            if (message.sourceSnapshot != null && message.hasOwnProperty("sourceSnapshot"))
                                 writer.uint32(/* id 3, wireType 2 =*/26).string(message.sourceSnapshot);
                             return writer;
                         };
@@ -8936,11 +8936,11 @@
                         DropRowRangeRequest.encode = function encode(message, writer) {
                             if (!writer)
                                 writer = $Writer.create();
-                            if (message.name != null && Object.hasOwnProperty.call(message, "name"))
+                            if (message.name != null && message.hasOwnProperty("name"))
                                 writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
-                            if (message.rowKeyPrefix != null && Object.hasOwnProperty.call(message, "rowKeyPrefix"))
+                            if (message.rowKeyPrefix != null && message.hasOwnProperty("rowKeyPrefix"))
                                 writer.uint32(/* id 2, wireType 2 =*/18).bytes(message.rowKeyPrefix);
-                            if (message.deleteAllDataFromTable != null && Object.hasOwnProperty.call(message, "deleteAllDataFromTable"))
+                            if (message.deleteAllDataFromTable != null && message.hasOwnProperty("deleteAllDataFromTable"))
                                 writer.uint32(/* id 3, wireType 0 =*/24).bool(message.deleteAllDataFromTable);
                             return writer;
                         };
@@ -9190,13 +9190,13 @@
                         ListTablesRequest.encode = function encode(message, writer) {
                             if (!writer)
                                 writer = $Writer.create();
-                            if (message.parent != null && Object.hasOwnProperty.call(message, "parent"))
+                            if (message.parent != null && message.hasOwnProperty("parent"))
                                 writer.uint32(/* id 1, wireType 2 =*/10).string(message.parent);
-                            if (message.view != null && Object.hasOwnProperty.call(message, "view"))
+                            if (message.view != null && message.hasOwnProperty("view"))
                                 writer.uint32(/* id 2, wireType 0 =*/16).int32(message.view);
-                            if (message.pageToken != null && Object.hasOwnProperty.call(message, "pageToken"))
+                            if (message.pageToken != null && message.hasOwnProperty("pageToken"))
                                 writer.uint32(/* id 3, wireType 2 =*/26).string(message.pageToken);
-                            if (message.pageSize != null && Object.hasOwnProperty.call(message, "pageSize"))
+                            if (message.pageSize != null && message.hasOwnProperty("pageSize"))
                                 writer.uint32(/* id 4, wireType 0 =*/32).int32(message.pageSize);
                             return writer;
                         };
@@ -9458,7 +9458,7 @@
                             if (message.tables != null && message.tables.length)
                                 for (var i = 0; i < message.tables.length; ++i)
                                     $root.google.bigtable.admin.v2.Table.encode(message.tables[i], writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
-                            if (message.nextPageToken != null && Object.hasOwnProperty.call(message, "nextPageToken"))
+                            if (message.nextPageToken != null && message.hasOwnProperty("nextPageToken"))
                                 writer.uint32(/* id 2, wireType 2 =*/18).string(message.nextPageToken);
                             return writer;
                         };
@@ -9685,9 +9685,9 @@
                         GetTableRequest.encode = function encode(message, writer) {
                             if (!writer)
                                 writer = $Writer.create();
-                            if (message.name != null && Object.hasOwnProperty.call(message, "name"))
+                            if (message.name != null && message.hasOwnProperty("name"))
                                 writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
-                            if (message.view != null && Object.hasOwnProperty.call(message, "view"))
+                            if (message.view != null && message.hasOwnProperty("view"))
                                 writer.uint32(/* id 2, wireType 0 =*/16).int32(message.view);
                             return writer;
                         };
@@ -9914,7 +9914,7 @@
                         DeleteTableRequest.encode = function encode(message, writer) {
                             if (!writer)
                                 writer = $Writer.create();
-                            if (message.name != null && Object.hasOwnProperty.call(message, "name"))
+                            if (message.name != null && message.hasOwnProperty("name"))
                                 writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
                             return writer;
                         };
@@ -10111,7 +10111,7 @@
                         ModifyColumnFamiliesRequest.encode = function encode(message, writer) {
                             if (!writer)
                                 writer = $Writer.create();
-                            if (message.name != null && Object.hasOwnProperty.call(message, "name"))
+                            if (message.name != null && message.hasOwnProperty("name"))
                                 writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
                             if (message.modifications != null && message.modifications.length)
                                 for (var i = 0; i < message.modifications.length; ++i)
@@ -10370,13 +10370,13 @@
                             Modification.encode = function encode(message, writer) {
                                 if (!writer)
                                     writer = $Writer.create();
-                                if (message.id != null && Object.hasOwnProperty.call(message, "id"))
+                                if (message.id != null && message.hasOwnProperty("id"))
                                     writer.uint32(/* id 1, wireType 2 =*/10).string(message.id);
-                                if (message.create != null && Object.hasOwnProperty.call(message, "create"))
+                                if (message.create != null && message.hasOwnProperty("create"))
                                     $root.google.bigtable.admin.v2.ColumnFamily.encode(message.create, writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
-                                if (message.update != null && Object.hasOwnProperty.call(message, "update"))
+                                if (message.update != null && message.hasOwnProperty("update"))
                                     $root.google.bigtable.admin.v2.ColumnFamily.encode(message.update, writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
-                                if (message.drop != null && Object.hasOwnProperty.call(message, "drop"))
+                                if (message.drop != null && message.hasOwnProperty("drop"))
                                     writer.uint32(/* id 4, wireType 0 =*/32).bool(message.drop);
                                 return writer;
                             };
@@ -10628,7 +10628,7 @@
                         GenerateConsistencyTokenRequest.encode = function encode(message, writer) {
                             if (!writer)
                                 writer = $Writer.create();
-                            if (message.name != null && Object.hasOwnProperty.call(message, "name"))
+                            if (message.name != null && message.hasOwnProperty("name"))
                                 writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
                             return writer;
                         };
@@ -10815,7 +10815,7 @@
                         GenerateConsistencyTokenResponse.encode = function encode(message, writer) {
                             if (!writer)
                                 writer = $Writer.create();
-                            if (message.consistencyToken != null && Object.hasOwnProperty.call(message, "consistencyToken"))
+                            if (message.consistencyToken != null && message.hasOwnProperty("consistencyToken"))
                                 writer.uint32(/* id 1, wireType 2 =*/10).string(message.consistencyToken);
                             return writer;
                         };
@@ -11011,9 +11011,9 @@
                         CheckConsistencyRequest.encode = function encode(message, writer) {
                             if (!writer)
                                 writer = $Writer.create();
-                            if (message.name != null && Object.hasOwnProperty.call(message, "name"))
+                            if (message.name != null && message.hasOwnProperty("name"))
                                 writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
-                            if (message.consistencyToken != null && Object.hasOwnProperty.call(message, "consistencyToken"))
+                            if (message.consistencyToken != null && message.hasOwnProperty("consistencyToken"))
                                 writer.uint32(/* id 2, wireType 2 =*/18).string(message.consistencyToken);
                             return writer;
                         };
@@ -11212,7 +11212,7 @@
                         CheckConsistencyResponse.encode = function encode(message, writer) {
                             if (!writer)
                                 writer = $Writer.create();
-                            if (message.consistent != null && Object.hasOwnProperty.call(message, "consistent"))
+                            if (message.consistent != null && message.hasOwnProperty("consistent"))
                                 writer.uint32(/* id 1, wireType 0 =*/8).bool(message.consistent);
                             return writer;
                         };
@@ -11435,15 +11435,15 @@
                         SnapshotTableRequest.encode = function encode(message, writer) {
                             if (!writer)
                                 writer = $Writer.create();
-                            if (message.name != null && Object.hasOwnProperty.call(message, "name"))
+                            if (message.name != null && message.hasOwnProperty("name"))
                                 writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
-                            if (message.cluster != null && Object.hasOwnProperty.call(message, "cluster"))
+                            if (message.cluster != null && message.hasOwnProperty("cluster"))
                                 writer.uint32(/* id 2, wireType 2 =*/18).string(message.cluster);
-                            if (message.snapshotId != null && Object.hasOwnProperty.call(message, "snapshotId"))
+                            if (message.snapshotId != null && message.hasOwnProperty("snapshotId"))
                                 writer.uint32(/* id 3, wireType 2 =*/26).string(message.snapshotId);
-                            if (message.ttl != null && Object.hasOwnProperty.call(message, "ttl"))
+                            if (message.ttl != null && message.hasOwnProperty("ttl"))
                                 $root.google.protobuf.Duration.encode(message.ttl, writer.uint32(/* id 4, wireType 2 =*/34).fork()).ldelim();
-                            if (message.description != null && Object.hasOwnProperty.call(message, "description"))
+                            if (message.description != null && message.hasOwnProperty("description"))
                                 writer.uint32(/* id 5, wireType 2 =*/42).string(message.description);
                             return writer;
                         };
@@ -11680,7 +11680,7 @@
                         GetSnapshotRequest.encode = function encode(message, writer) {
                             if (!writer)
                                 writer = $Writer.create();
-                            if (message.name != null && Object.hasOwnProperty.call(message, "name"))
+                            if (message.name != null && message.hasOwnProperty("name"))
                                 writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
                             return writer;
                         };
@@ -11885,11 +11885,11 @@
                         ListSnapshotsRequest.encode = function encode(message, writer) {
                             if (!writer)
                                 writer = $Writer.create();
-                            if (message.parent != null && Object.hasOwnProperty.call(message, "parent"))
+                            if (message.parent != null && message.hasOwnProperty("parent"))
                                 writer.uint32(/* id 1, wireType 2 =*/10).string(message.parent);
-                            if (message.pageSize != null && Object.hasOwnProperty.call(message, "pageSize"))
+                            if (message.pageSize != null && message.hasOwnProperty("pageSize"))
                                 writer.uint32(/* id 2, wireType 0 =*/16).int32(message.pageSize);
-                            if (message.pageToken != null && Object.hasOwnProperty.call(message, "pageToken"))
+                            if (message.pageToken != null && message.hasOwnProperty("pageToken"))
                                 writer.uint32(/* id 3, wireType 2 =*/26).string(message.pageToken);
                             return writer;
                         };
@@ -12112,7 +12112,7 @@
                             if (message.snapshots != null && message.snapshots.length)
                                 for (var i = 0; i < message.snapshots.length; ++i)
                                     $root.google.bigtable.admin.v2.Snapshot.encode(message.snapshots[i], writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
-                            if (message.nextPageToken != null && Object.hasOwnProperty.call(message, "nextPageToken"))
+                            if (message.nextPageToken != null && message.hasOwnProperty("nextPageToken"))
                                 writer.uint32(/* id 2, wireType 2 =*/18).string(message.nextPageToken);
                             return writer;
                         };
@@ -12330,7 +12330,7 @@
                         DeleteSnapshotRequest.encode = function encode(message, writer) {
                             if (!writer)
                                 writer = $Writer.create();
-                            if (message.name != null && Object.hasOwnProperty.call(message, "name"))
+                            if (message.name != null && message.hasOwnProperty("name"))
                                 writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
                             return writer;
                         };
@@ -12535,11 +12535,11 @@
                         SnapshotTableMetadata.encode = function encode(message, writer) {
                             if (!writer)
                                 writer = $Writer.create();
-                            if (message.originalRequest != null && Object.hasOwnProperty.call(message, "originalRequest"))
+                            if (message.originalRequest != null && message.hasOwnProperty("originalRequest"))
                                 $root.google.bigtable.admin.v2.SnapshotTableRequest.encode(message.originalRequest, writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
-                            if (message.requestTime != null && Object.hasOwnProperty.call(message, "requestTime"))
+                            if (message.requestTime != null && message.hasOwnProperty("requestTime"))
                                 $root.google.protobuf.Timestamp.encode(message.requestTime, writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
-                            if (message.finishTime != null && Object.hasOwnProperty.call(message, "finishTime"))
+                            if (message.finishTime != null && message.hasOwnProperty("finishTime"))
                                 $root.google.protobuf.Timestamp.encode(message.finishTime, writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
                             return writer;
                         };
@@ -12782,11 +12782,11 @@
                         CreateTableFromSnapshotMetadata.encode = function encode(message, writer) {
                             if (!writer)
                                 writer = $Writer.create();
-                            if (message.originalRequest != null && Object.hasOwnProperty.call(message, "originalRequest"))
+                            if (message.originalRequest != null && message.hasOwnProperty("originalRequest"))
                                 $root.google.bigtable.admin.v2.CreateTableFromSnapshotRequest.encode(message.originalRequest, writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
-                            if (message.requestTime != null && Object.hasOwnProperty.call(message, "requestTime"))
+                            if (message.requestTime != null && message.hasOwnProperty("requestTime"))
                                 $root.google.protobuf.Timestamp.encode(message.requestTime, writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
-                            if (message.finishTime != null && Object.hasOwnProperty.call(message, "finishTime"))
+                            if (message.finishTime != null && message.hasOwnProperty("finishTime"))
                                 $root.google.protobuf.Timestamp.encode(message.finishTime, writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
                             return writer;
                         };
@@ -13029,11 +13029,11 @@
                         CreateBackupRequest.encode = function encode(message, writer) {
                             if (!writer)
                                 writer = $Writer.create();
-                            if (message.parent != null && Object.hasOwnProperty.call(message, "parent"))
+                            if (message.parent != null && message.hasOwnProperty("parent"))
                                 writer.uint32(/* id 1, wireType 2 =*/10).string(message.parent);
-                            if (message.backupId != null && Object.hasOwnProperty.call(message, "backupId"))
+                            if (message.backupId != null && message.hasOwnProperty("backupId"))
                                 writer.uint32(/* id 2, wireType 2 =*/18).string(message.backupId);
-                            if (message.backup != null && Object.hasOwnProperty.call(message, "backup"))
+                            if (message.backup != null && message.hasOwnProperty("backup"))
                                 $root.google.bigtable.admin.v2.Backup.encode(message.backup, writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
                             return writer;
                         };
@@ -13275,13 +13275,13 @@
                         CreateBackupMetadata.encode = function encode(message, writer) {
                             if (!writer)
                                 writer = $Writer.create();
-                            if (message.name != null && Object.hasOwnProperty.call(message, "name"))
+                            if (message.name != null && message.hasOwnProperty("name"))
                                 writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
-                            if (message.sourceTable != null && Object.hasOwnProperty.call(message, "sourceTable"))
+                            if (message.sourceTable != null && message.hasOwnProperty("sourceTable"))
                                 writer.uint32(/* id 2, wireType 2 =*/18).string(message.sourceTable);
-                            if (message.startTime != null && Object.hasOwnProperty.call(message, "startTime"))
+                            if (message.startTime != null && message.hasOwnProperty("startTime"))
                                 $root.google.protobuf.Timestamp.encode(message.startTime, writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
-                            if (message.endTime != null && Object.hasOwnProperty.call(message, "endTime"))
+                            if (message.endTime != null && message.hasOwnProperty("endTime"))
                                 $root.google.protobuf.Timestamp.encode(message.endTime, writer.uint32(/* id 4, wireType 2 =*/34).fork()).ldelim();
                             return writer;
                         };
@@ -13512,7 +13512,7 @@
                         GetBackupRequest.encode = function encode(message, writer) {
                             if (!writer)
                                 writer = $Writer.create();
-                            if (message.name != null && Object.hasOwnProperty.call(message, "name"))
+                            if (message.name != null && message.hasOwnProperty("name"))
                                 writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
                             return writer;
                         };
@@ -13708,9 +13708,9 @@
                         UpdateBackupRequest.encode = function encode(message, writer) {
                             if (!writer)
                                 writer = $Writer.create();
-                            if (message.backup != null && Object.hasOwnProperty.call(message, "backup"))
+                            if (message.backup != null && message.hasOwnProperty("backup"))
                                 $root.google.bigtable.admin.v2.Backup.encode(message.backup, writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
-                            if (message.updateMask != null && Object.hasOwnProperty.call(message, "updateMask"))
+                            if (message.updateMask != null && message.hasOwnProperty("updateMask"))
                                 $root.google.protobuf.FieldMask.encode(message.updateMask, writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
                             return writer;
                         };
@@ -13919,7 +13919,7 @@
                         DeleteBackupRequest.encode = function encode(message, writer) {
                             if (!writer)
                                 writer = $Writer.create();
-                            if (message.name != null && Object.hasOwnProperty.call(message, "name"))
+                            if (message.name != null && message.hasOwnProperty("name"))
                                 writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
                             return writer;
                         };
@@ -14142,15 +14142,15 @@
                         ListBackupsRequest.encode = function encode(message, writer) {
                             if (!writer)
                                 writer = $Writer.create();
-                            if (message.parent != null && Object.hasOwnProperty.call(message, "parent"))
+                            if (message.parent != null && message.hasOwnProperty("parent"))
                                 writer.uint32(/* id 1, wireType 2 =*/10).string(message.parent);
-                            if (message.filter != null && Object.hasOwnProperty.call(message, "filter"))
+                            if (message.filter != null && message.hasOwnProperty("filter"))
                                 writer.uint32(/* id 2, wireType 2 =*/18).string(message.filter);
-                            if (message.orderBy != null && Object.hasOwnProperty.call(message, "orderBy"))
+                            if (message.orderBy != null && message.hasOwnProperty("orderBy"))
                                 writer.uint32(/* id 3, wireType 2 =*/26).string(message.orderBy);
-                            if (message.pageSize != null && Object.hasOwnProperty.call(message, "pageSize"))
+                            if (message.pageSize != null && message.hasOwnProperty("pageSize"))
                                 writer.uint32(/* id 4, wireType 0 =*/32).int32(message.pageSize);
-                            if (message.pageToken != null && Object.hasOwnProperty.call(message, "pageToken"))
+                            if (message.pageToken != null && message.hasOwnProperty("pageToken"))
                                 writer.uint32(/* id 5, wireType 2 =*/42).string(message.pageToken);
                             return writer;
                         };
@@ -14395,7 +14395,7 @@
                             if (message.backups != null && message.backups.length)
                                 for (var i = 0; i < message.backups.length; ++i)
                                     $root.google.bigtable.admin.v2.Backup.encode(message.backups[i], writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
-                            if (message.nextPageToken != null && Object.hasOwnProperty.call(message, "nextPageToken"))
+                            if (message.nextPageToken != null && message.hasOwnProperty("nextPageToken"))
                                 writer.uint32(/* id 2, wireType 2 =*/18).string(message.nextPageToken);
                             return writer;
                         };
@@ -14645,11 +14645,11 @@
                         RestoreTableRequest.encode = function encode(message, writer) {
                             if (!writer)
                                 writer = $Writer.create();
-                            if (message.parent != null && Object.hasOwnProperty.call(message, "parent"))
+                            if (message.parent != null && message.hasOwnProperty("parent"))
                                 writer.uint32(/* id 1, wireType 2 =*/10).string(message.parent);
-                            if (message.tableId != null && Object.hasOwnProperty.call(message, "tableId"))
+                            if (message.tableId != null && message.hasOwnProperty("tableId"))
                                 writer.uint32(/* id 2, wireType 2 =*/18).string(message.tableId);
-                            if (message.backup != null && Object.hasOwnProperty.call(message, "backup"))
+                            if (message.backup != null && message.hasOwnProperty("backup"))
                                 writer.uint32(/* id 3, wireType 2 =*/26).string(message.backup);
                             return writer;
                         };
@@ -14914,15 +14914,15 @@
                         RestoreTableMetadata.encode = function encode(message, writer) {
                             if (!writer)
                                 writer = $Writer.create();
-                            if (message.name != null && Object.hasOwnProperty.call(message, "name"))
+                            if (message.name != null && message.hasOwnProperty("name"))
                                 writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
-                            if (message.sourceType != null && Object.hasOwnProperty.call(message, "sourceType"))
+                            if (message.sourceType != null && message.hasOwnProperty("sourceType"))
                                 writer.uint32(/* id 2, wireType 0 =*/16).int32(message.sourceType);
-                            if (message.backupInfo != null && Object.hasOwnProperty.call(message, "backupInfo"))
+                            if (message.backupInfo != null && message.hasOwnProperty("backupInfo"))
                                 $root.google.bigtable.admin.v2.BackupInfo.encode(message.backupInfo, writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
-                            if (message.optimizeTableOperationName != null && Object.hasOwnProperty.call(message, "optimizeTableOperationName"))
+                            if (message.optimizeTableOperationName != null && message.hasOwnProperty("optimizeTableOperationName"))
                                 writer.uint32(/* id 4, wireType 2 =*/34).string(message.optimizeTableOperationName);
-                            if (message.progress != null && Object.hasOwnProperty.call(message, "progress"))
+                            if (message.progress != null && message.hasOwnProperty("progress"))
                                 $root.google.bigtable.admin.v2.OperationProgress.encode(message.progress, writer.uint32(/* id 5, wireType 2 =*/42).fork()).ldelim();
                             return writer;
                         };
@@ -15192,9 +15192,9 @@
                         OptimizeRestoredTableMetadata.encode = function encode(message, writer) {
                             if (!writer)
                                 writer = $Writer.create();
-                            if (message.name != null && Object.hasOwnProperty.call(message, "name"))
+                            if (message.name != null && message.hasOwnProperty("name"))
                                 writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
-                            if (message.progress != null && Object.hasOwnProperty.call(message, "progress"))
+                            if (message.progress != null && message.hasOwnProperty("progress"))
                                 $root.google.bigtable.admin.v2.OperationProgress.encode(message.progress, writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
                             return writer;
                         };
@@ -15345,7 +15345,7 @@
                     /**
                      * RestoreSourceType enum.
                      * @name google.bigtable.admin.v2.RestoreSourceType
-                     * @enum {number}
+                     * @enum {string}
                      * @property {number} RESTORE_SOURCE_TYPE_UNSPECIFIED=0 RESTORE_SOURCE_TYPE_UNSPECIFIED value
                      * @property {number} BACKUP=1 BACKUP value
                      */
@@ -15435,9 +15435,9 @@
                         RestoreInfo.encode = function encode(message, writer) {
                             if (!writer)
                                 writer = $Writer.create();
-                            if (message.sourceType != null && Object.hasOwnProperty.call(message, "sourceType"))
+                            if (message.sourceType != null && message.hasOwnProperty("sourceType"))
                                 writer.uint32(/* id 1, wireType 0 =*/8).int32(message.sourceType);
-                            if (message.backupInfo != null && Object.hasOwnProperty.call(message, "backupInfo"))
+                            if (message.backupInfo != null && message.hasOwnProperty("backupInfo"))
                                 $root.google.bigtable.admin.v2.BackupInfo.encode(message.backupInfo, writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
                             return writer;
                         };
@@ -15697,21 +15697,21 @@
                         Table.encode = function encode(message, writer) {
                             if (!writer)
                                 writer = $Writer.create();
-                            if (message.name != null && Object.hasOwnProperty.call(message, "name"))
+                            if (message.name != null && message.hasOwnProperty("name"))
                                 writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
-                            if (message.clusterStates != null && Object.hasOwnProperty.call(message, "clusterStates"))
+                            if (message.clusterStates != null && message.hasOwnProperty("clusterStates"))
                                 for (var keys = Object.keys(message.clusterStates), i = 0; i < keys.length; ++i) {
                                     writer.uint32(/* id 2, wireType 2 =*/18).fork().uint32(/* id 1, wireType 2 =*/10).string(keys[i]);
                                     $root.google.bigtable.admin.v2.Table.ClusterState.encode(message.clusterStates[keys[i]], writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim().ldelim();
                                 }
-                            if (message.columnFamilies != null && Object.hasOwnProperty.call(message, "columnFamilies"))
+                            if (message.columnFamilies != null && message.hasOwnProperty("columnFamilies"))
                                 for (var keys = Object.keys(message.columnFamilies), i = 0; i < keys.length; ++i) {
                                     writer.uint32(/* id 3, wireType 2 =*/26).fork().uint32(/* id 1, wireType 2 =*/10).string(keys[i]);
                                     $root.google.bigtable.admin.v2.ColumnFamily.encode(message.columnFamilies[keys[i]], writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim().ldelim();
                                 }
-                            if (message.granularity != null && Object.hasOwnProperty.call(message, "granularity"))
+                            if (message.granularity != null && message.hasOwnProperty("granularity"))
                                 writer.uint32(/* id 4, wireType 0 =*/32).int32(message.granularity);
-                            if (message.restoreInfo != null && Object.hasOwnProperty.call(message, "restoreInfo"))
+                            if (message.restoreInfo != null && message.hasOwnProperty("restoreInfo"))
                                 $root.google.bigtable.admin.v2.RestoreInfo.encode(message.restoreInfo, writer.uint32(/* id 6, wireType 2 =*/50).fork()).ldelim();
                             return writer;
                         };
@@ -16007,7 +16007,7 @@
                             ClusterState.encode = function encode(message, writer) {
                                 if (!writer)
                                     writer = $Writer.create();
-                                if (message.replicationState != null && Object.hasOwnProperty.call(message, "replicationState"))
+                                if (message.replicationState != null && message.hasOwnProperty("replicationState"))
                                     writer.uint32(/* id 1, wireType 0 =*/8).int32(message.replicationState);
                                 return writer;
                             };
@@ -16171,7 +16171,7 @@
                             /**
                              * ReplicationState enum.
                              * @name google.bigtable.admin.v2.Table.ClusterState.ReplicationState
-                             * @enum {number}
+                             * @enum {string}
                              * @property {number} STATE_NOT_KNOWN=0 STATE_NOT_KNOWN value
                              * @property {number} INITIALIZING=1 INITIALIZING value
                              * @property {number} PLANNED_MAINTENANCE=2 PLANNED_MAINTENANCE value
@@ -16196,7 +16196,7 @@
                         /**
                          * TimestampGranularity enum.
                          * @name google.bigtable.admin.v2.Table.TimestampGranularity
-                         * @enum {number}
+                         * @enum {string}
                          * @property {number} TIMESTAMP_GRANULARITY_UNSPECIFIED=0 TIMESTAMP_GRANULARITY_UNSPECIFIED value
                          * @property {number} MILLIS=1 MILLIS value
                          */
@@ -16210,7 +16210,7 @@
                         /**
                          * View enum.
                          * @name google.bigtable.admin.v2.Table.View
-                         * @enum {number}
+                         * @enum {string}
                          * @property {number} VIEW_UNSPECIFIED=0 VIEW_UNSPECIFIED value
                          * @property {number} NAME_ONLY=1 NAME_ONLY value
                          * @property {number} SCHEMA_VIEW=2 SCHEMA_VIEW value
@@ -16286,7 +16286,7 @@
                         ColumnFamily.encode = function encode(message, writer) {
                             if (!writer)
                                 writer = $Writer.create();
-                            if (message.gcRule != null && Object.hasOwnProperty.call(message, "gcRule"))
+                            if (message.gcRule != null && message.hasOwnProperty("gcRule"))
                                 $root.google.bigtable.admin.v2.GcRule.encode(message.gcRule, writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
                             return writer;
                         };
@@ -16519,13 +16519,13 @@
                         GcRule.encode = function encode(message, writer) {
                             if (!writer)
                                 writer = $Writer.create();
-                            if (message.maxNumVersions != null && Object.hasOwnProperty.call(message, "maxNumVersions"))
+                            if (message.maxNumVersions != null && message.hasOwnProperty("maxNumVersions"))
                                 writer.uint32(/* id 1, wireType 0 =*/8).int32(message.maxNumVersions);
-                            if (message.maxAge != null && Object.hasOwnProperty.call(message, "maxAge"))
+                            if (message.maxAge != null && message.hasOwnProperty("maxAge"))
                                 $root.google.protobuf.Duration.encode(message.maxAge, writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
-                            if (message.intersection != null && Object.hasOwnProperty.call(message, "intersection"))
+                            if (message.intersection != null && message.hasOwnProperty("intersection"))
                                 $root.google.bigtable.admin.v2.GcRule.Intersection.encode(message.intersection, writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
-                            if (message.union != null && Object.hasOwnProperty.call(message, "union"))
+                            if (message.union != null && message.hasOwnProperty("union"))
                                 $root.google.bigtable.admin.v2.GcRule.Union.encode(message.union, writer.uint32(/* id 4, wireType 2 =*/34).fork()).ldelim();
                             return writer;
                         };
@@ -17255,19 +17255,19 @@
                         Snapshot.encode = function encode(message, writer) {
                             if (!writer)
                                 writer = $Writer.create();
-                            if (message.name != null && Object.hasOwnProperty.call(message, "name"))
+                            if (message.name != null && message.hasOwnProperty("name"))
                                 writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
-                            if (message.sourceTable != null && Object.hasOwnProperty.call(message, "sourceTable"))
+                            if (message.sourceTable != null && message.hasOwnProperty("sourceTable"))
                                 $root.google.bigtable.admin.v2.Table.encode(message.sourceTable, writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
-                            if (message.dataSizeBytes != null && Object.hasOwnProperty.call(message, "dataSizeBytes"))
+                            if (message.dataSizeBytes != null && message.hasOwnProperty("dataSizeBytes"))
                                 writer.uint32(/* id 3, wireType 0 =*/24).int64(message.dataSizeBytes);
-                            if (message.createTime != null && Object.hasOwnProperty.call(message, "createTime"))
+                            if (message.createTime != null && message.hasOwnProperty("createTime"))
                                 $root.google.protobuf.Timestamp.encode(message.createTime, writer.uint32(/* id 4, wireType 2 =*/34).fork()).ldelim();
-                            if (message.deleteTime != null && Object.hasOwnProperty.call(message, "deleteTime"))
+                            if (message.deleteTime != null && message.hasOwnProperty("deleteTime"))
                                 $root.google.protobuf.Timestamp.encode(message.deleteTime, writer.uint32(/* id 5, wireType 2 =*/42).fork()).ldelim();
-                            if (message.state != null && Object.hasOwnProperty.call(message, "state"))
+                            if (message.state != null && message.hasOwnProperty("state"))
                                 writer.uint32(/* id 6, wireType 0 =*/48).int32(message.state);
-                            if (message.description != null && Object.hasOwnProperty.call(message, "description"))
+                            if (message.description != null && message.hasOwnProperty("description"))
                                 writer.uint32(/* id 7, wireType 2 =*/58).string(message.description);
                             return writer;
                         };
@@ -17512,7 +17512,7 @@
                         /**
                          * State enum.
                          * @name google.bigtable.admin.v2.Snapshot.State
-                         * @enum {number}
+                         * @enum {string}
                          * @property {number} STATE_NOT_KNOWN=0 STATE_NOT_KNOWN value
                          * @property {number} READY=1 READY value
                          * @property {number} CREATING=2 CREATING value
@@ -17638,19 +17638,19 @@
                         Backup.encode = function encode(message, writer) {
                             if (!writer)
                                 writer = $Writer.create();
-                            if (message.name != null && Object.hasOwnProperty.call(message, "name"))
+                            if (message.name != null && message.hasOwnProperty("name"))
                                 writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
-                            if (message.sourceTable != null && Object.hasOwnProperty.call(message, "sourceTable"))
+                            if (message.sourceTable != null && message.hasOwnProperty("sourceTable"))
                                 writer.uint32(/* id 2, wireType 2 =*/18).string(message.sourceTable);
-                            if (message.expireTime != null && Object.hasOwnProperty.call(message, "expireTime"))
+                            if (message.expireTime != null && message.hasOwnProperty("expireTime"))
                                 $root.google.protobuf.Timestamp.encode(message.expireTime, writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
-                            if (message.startTime != null && Object.hasOwnProperty.call(message, "startTime"))
+                            if (message.startTime != null && message.hasOwnProperty("startTime"))
                                 $root.google.protobuf.Timestamp.encode(message.startTime, writer.uint32(/* id 4, wireType 2 =*/34).fork()).ldelim();
-                            if (message.endTime != null && Object.hasOwnProperty.call(message, "endTime"))
+                            if (message.endTime != null && message.hasOwnProperty("endTime"))
                                 $root.google.protobuf.Timestamp.encode(message.endTime, writer.uint32(/* id 5, wireType 2 =*/42).fork()).ldelim();
-                            if (message.sizeBytes != null && Object.hasOwnProperty.call(message, "sizeBytes"))
+                            if (message.sizeBytes != null && message.hasOwnProperty("sizeBytes"))
                                 writer.uint32(/* id 6, wireType 0 =*/48).int64(message.sizeBytes);
-                            if (message.state != null && Object.hasOwnProperty.call(message, "state"))
+                            if (message.state != null && message.hasOwnProperty("state"))
                                 writer.uint32(/* id 7, wireType 0 =*/56).int32(message.state);
                             return writer;
                         };
@@ -17895,7 +17895,7 @@
                         /**
                          * State enum.
                          * @name google.bigtable.admin.v2.Backup.State
-                         * @enum {number}
+                         * @enum {string}
                          * @property {number} STATE_UNSPECIFIED=0 STATE_UNSPECIFIED value
                          * @property {number} CREATING=1 CREATING value
                          * @property {number} READY=2 READY value
@@ -17994,13 +17994,13 @@
                         BackupInfo.encode = function encode(message, writer) {
                             if (!writer)
                                 writer = $Writer.create();
-                            if (message.backup != null && Object.hasOwnProperty.call(message, "backup"))
+                            if (message.backup != null && message.hasOwnProperty("backup"))
                                 writer.uint32(/* id 1, wireType 2 =*/10).string(message.backup);
-                            if (message.startTime != null && Object.hasOwnProperty.call(message, "startTime"))
+                            if (message.startTime != null && message.hasOwnProperty("startTime"))
                                 $root.google.protobuf.Timestamp.encode(message.startTime, writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
-                            if (message.endTime != null && Object.hasOwnProperty.call(message, "endTime"))
+                            if (message.endTime != null && message.hasOwnProperty("endTime"))
                                 $root.google.protobuf.Timestamp.encode(message.endTime, writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
-                            if (message.sourceTable != null && Object.hasOwnProperty.call(message, "sourceTable"))
+                            if (message.sourceTable != null && message.hasOwnProperty("sourceTable"))
                                 writer.uint32(/* id 4, wireType 2 =*/34).string(message.sourceTable);
                             return writer;
                         };
@@ -18515,15 +18515,15 @@
                     ReadRowsRequest.encode = function encode(message, writer) {
                         if (!writer)
                             writer = $Writer.create();
-                        if (message.tableName != null && Object.hasOwnProperty.call(message, "tableName"))
+                        if (message.tableName != null && message.hasOwnProperty("tableName"))
                             writer.uint32(/* id 1, wireType 2 =*/10).string(message.tableName);
-                        if (message.rows != null && Object.hasOwnProperty.call(message, "rows"))
+                        if (message.rows != null && message.hasOwnProperty("rows"))
                             $root.google.bigtable.v2.RowSet.encode(message.rows, writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
-                        if (message.filter != null && Object.hasOwnProperty.call(message, "filter"))
+                        if (message.filter != null && message.hasOwnProperty("filter"))
                             $root.google.bigtable.v2.RowFilter.encode(message.filter, writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
-                        if (message.rowsLimit != null && Object.hasOwnProperty.call(message, "rowsLimit"))
+                        if (message.rowsLimit != null && message.hasOwnProperty("rowsLimit"))
                             writer.uint32(/* id 4, wireType 0 =*/32).int64(message.rowsLimit);
-                        if (message.appProfileId != null && Object.hasOwnProperty.call(message, "appProfileId"))
+                        if (message.appProfileId != null && message.hasOwnProperty("appProfileId"))
                             writer.uint32(/* id 5, wireType 2 =*/42).string(message.appProfileId);
                         return writer;
                     };
@@ -18792,7 +18792,7 @@
                         if (message.chunks != null && message.chunks.length)
                             for (var i = 0; i < message.chunks.length; ++i)
                                 $root.google.bigtable.v2.ReadRowsResponse.CellChunk.encode(message.chunks[i], writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
-                        if (message.lastScannedRowKey != null && Object.hasOwnProperty.call(message, "lastScannedRowKey"))
+                        if (message.lastScannedRowKey != null && message.hasOwnProperty("lastScannedRowKey"))
                             writer.uint32(/* id 2, wireType 2 =*/18).bytes(message.lastScannedRowKey);
                         return writer;
                     };
@@ -19103,24 +19103,24 @@
                         CellChunk.encode = function encode(message, writer) {
                             if (!writer)
                                 writer = $Writer.create();
-                            if (message.rowKey != null && Object.hasOwnProperty.call(message, "rowKey"))
+                            if (message.rowKey != null && message.hasOwnProperty("rowKey"))
                                 writer.uint32(/* id 1, wireType 2 =*/10).bytes(message.rowKey);
-                            if (message.familyName != null && Object.hasOwnProperty.call(message, "familyName"))
+                            if (message.familyName != null && message.hasOwnProperty("familyName"))
                                 $root.google.protobuf.StringValue.encode(message.familyName, writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
-                            if (message.qualifier != null && Object.hasOwnProperty.call(message, "qualifier"))
+                            if (message.qualifier != null && message.hasOwnProperty("qualifier"))
                                 $root.google.protobuf.BytesValue.encode(message.qualifier, writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
-                            if (message.timestampMicros != null && Object.hasOwnProperty.call(message, "timestampMicros"))
+                            if (message.timestampMicros != null && message.hasOwnProperty("timestampMicros"))
                                 writer.uint32(/* id 4, wireType 0 =*/32).int64(message.timestampMicros);
                             if (message.labels != null && message.labels.length)
                                 for (var i = 0; i < message.labels.length; ++i)
                                     writer.uint32(/* id 5, wireType 2 =*/42).string(message.labels[i]);
-                            if (message.value != null && Object.hasOwnProperty.call(message, "value"))
+                            if (message.value != null && message.hasOwnProperty("value"))
                                 writer.uint32(/* id 6, wireType 2 =*/50).bytes(message.value);
-                            if (message.valueSize != null && Object.hasOwnProperty.call(message, "valueSize"))
+                            if (message.valueSize != null && message.hasOwnProperty("valueSize"))
                                 writer.uint32(/* id 7, wireType 0 =*/56).int32(message.valueSize);
-                            if (message.resetRow != null && Object.hasOwnProperty.call(message, "resetRow"))
+                            if (message.resetRow != null && message.hasOwnProperty("resetRow"))
                                 writer.uint32(/* id 8, wireType 0 =*/64).bool(message.resetRow);
-                            if (message.commitRow != null && Object.hasOwnProperty.call(message, "commitRow"))
+                            if (message.commitRow != null && message.hasOwnProperty("commitRow"))
                                 writer.uint32(/* id 9, wireType 0 =*/72).bool(message.commitRow);
                             return writer;
                         };
@@ -19476,9 +19476,9 @@
                     SampleRowKeysRequest.encode = function encode(message, writer) {
                         if (!writer)
                             writer = $Writer.create();
-                        if (message.tableName != null && Object.hasOwnProperty.call(message, "tableName"))
+                        if (message.tableName != null && message.hasOwnProperty("tableName"))
                             writer.uint32(/* id 1, wireType 2 =*/10).string(message.tableName);
-                        if (message.appProfileId != null && Object.hasOwnProperty.call(message, "appProfileId"))
+                        if (message.appProfileId != null && message.hasOwnProperty("appProfileId"))
                             writer.uint32(/* id 2, wireType 2 =*/18).string(message.appProfileId);
                         return writer;
                     };
@@ -19686,9 +19686,9 @@
                     SampleRowKeysResponse.encode = function encode(message, writer) {
                         if (!writer)
                             writer = $Writer.create();
-                        if (message.rowKey != null && Object.hasOwnProperty.call(message, "rowKey"))
+                        if (message.rowKey != null && message.hasOwnProperty("rowKey"))
                             writer.uint32(/* id 1, wireType 2 =*/10).bytes(message.rowKey);
-                        if (message.offsetBytes != null && Object.hasOwnProperty.call(message, "offsetBytes"))
+                        if (message.offsetBytes != null && message.hasOwnProperty("offsetBytes"))
                             writer.uint32(/* id 2, wireType 0 =*/16).int64(message.offsetBytes);
                         return writer;
                     };
@@ -19938,14 +19938,14 @@
                     MutateRowRequest.encode = function encode(message, writer) {
                         if (!writer)
                             writer = $Writer.create();
-                        if (message.tableName != null && Object.hasOwnProperty.call(message, "tableName"))
+                        if (message.tableName != null && message.hasOwnProperty("tableName"))
                             writer.uint32(/* id 1, wireType 2 =*/10).string(message.tableName);
-                        if (message.rowKey != null && Object.hasOwnProperty.call(message, "rowKey"))
+                        if (message.rowKey != null && message.hasOwnProperty("rowKey"))
                             writer.uint32(/* id 2, wireType 2 =*/18).bytes(message.rowKey);
                         if (message.mutations != null && message.mutations.length)
                             for (var i = 0; i < message.mutations.length; ++i)
                                 $root.google.bigtable.v2.Mutation.encode(message.mutations[i], writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
-                        if (message.appProfileId != null && Object.hasOwnProperty.call(message, "appProfileId"))
+                        if (message.appProfileId != null && message.hasOwnProperty("appProfileId"))
                             writer.uint32(/* id 4, wireType 2 =*/34).string(message.appProfileId);
                         return writer;
                     };
@@ -20374,12 +20374,12 @@
                     MutateRowsRequest.encode = function encode(message, writer) {
                         if (!writer)
                             writer = $Writer.create();
-                        if (message.tableName != null && Object.hasOwnProperty.call(message, "tableName"))
+                        if (message.tableName != null && message.hasOwnProperty("tableName"))
                             writer.uint32(/* id 1, wireType 2 =*/10).string(message.tableName);
                         if (message.entries != null && message.entries.length)
                             for (var i = 0; i < message.entries.length; ++i)
                                 $root.google.bigtable.v2.MutateRowsRequest.Entry.encode(message.entries[i], writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
-                        if (message.appProfileId != null && Object.hasOwnProperty.call(message, "appProfileId"))
+                        if (message.appProfileId != null && message.hasOwnProperty("appProfileId"))
                             writer.uint32(/* id 3, wireType 2 =*/26).string(message.appProfileId);
                         return writer;
                     };
@@ -20616,7 +20616,7 @@
                         Entry.encode = function encode(message, writer) {
                             if (!writer)
                                 writer = $Writer.create();
-                            if (message.rowKey != null && Object.hasOwnProperty.call(message, "rowKey"))
+                            if (message.rowKey != null && message.hasOwnProperty("rowKey"))
                                 writer.uint32(/* id 1, wireType 2 =*/10).bytes(message.rowKey);
                             if (message.mutations != null && message.mutations.length)
                                 for (var i = 0; i < message.mutations.length; ++i)
@@ -21063,9 +21063,9 @@
                         Entry.encode = function encode(message, writer) {
                             if (!writer)
                                 writer = $Writer.create();
-                            if (message.index != null && Object.hasOwnProperty.call(message, "index"))
+                            if (message.index != null && message.hasOwnProperty("index"))
                                 writer.uint32(/* id 1, wireType 0 =*/8).int64(message.index);
-                            if (message.status != null && Object.hasOwnProperty.call(message, "status"))
+                            if (message.status != null && message.hasOwnProperty("status"))
                                 $root.google.rpc.Status.encode(message.status, writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
                             return writer;
                         };
@@ -21333,9 +21333,9 @@
                     CheckAndMutateRowRequest.encode = function encode(message, writer) {
                         if (!writer)
                             writer = $Writer.create();
-                        if (message.tableName != null && Object.hasOwnProperty.call(message, "tableName"))
+                        if (message.tableName != null && message.hasOwnProperty("tableName"))
                             writer.uint32(/* id 1, wireType 2 =*/10).string(message.tableName);
-                        if (message.rowKey != null && Object.hasOwnProperty.call(message, "rowKey"))
+                        if (message.rowKey != null && message.hasOwnProperty("rowKey"))
                             writer.uint32(/* id 2, wireType 2 =*/18).bytes(message.rowKey);
                         if (message.trueMutations != null && message.trueMutations.length)
                             for (var i = 0; i < message.trueMutations.length; ++i)
@@ -21343,9 +21343,9 @@
                         if (message.falseMutations != null && message.falseMutations.length)
                             for (var i = 0; i < message.falseMutations.length; ++i)
                                 $root.google.bigtable.v2.Mutation.encode(message.falseMutations[i], writer.uint32(/* id 5, wireType 2 =*/42).fork()).ldelim();
-                        if (message.predicateFilter != null && Object.hasOwnProperty.call(message, "predicateFilter"))
+                        if (message.predicateFilter != null && message.hasOwnProperty("predicateFilter"))
                             $root.google.bigtable.v2.RowFilter.encode(message.predicateFilter, writer.uint32(/* id 6, wireType 2 =*/50).fork()).ldelim();
-                        if (message.appProfileId != null && Object.hasOwnProperty.call(message, "appProfileId"))
+                        if (message.appProfileId != null && message.hasOwnProperty("appProfileId"))
                             writer.uint32(/* id 7, wireType 2 =*/58).string(message.appProfileId);
                         return writer;
                     };
@@ -21642,7 +21642,7 @@
                     CheckAndMutateRowResponse.encode = function encode(message, writer) {
                         if (!writer)
                             writer = $Writer.create();
-                        if (message.predicateMatched != null && Object.hasOwnProperty.call(message, "predicateMatched"))
+                        if (message.predicateMatched != null && message.hasOwnProperty("predicateMatched"))
                             writer.uint32(/* id 1, wireType 0 =*/8).bool(message.predicateMatched);
                         return writer;
                     };
@@ -21857,14 +21857,14 @@
                     ReadModifyWriteRowRequest.encode = function encode(message, writer) {
                         if (!writer)
                             writer = $Writer.create();
-                        if (message.tableName != null && Object.hasOwnProperty.call(message, "tableName"))
+                        if (message.tableName != null && message.hasOwnProperty("tableName"))
                             writer.uint32(/* id 1, wireType 2 =*/10).string(message.tableName);
-                        if (message.rowKey != null && Object.hasOwnProperty.call(message, "rowKey"))
+                        if (message.rowKey != null && message.hasOwnProperty("rowKey"))
                             writer.uint32(/* id 2, wireType 2 =*/18).bytes(message.rowKey);
                         if (message.rules != null && message.rules.length)
                             for (var i = 0; i < message.rules.length; ++i)
                                 $root.google.bigtable.v2.ReadModifyWriteRule.encode(message.rules[i], writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
-                        if (message.appProfileId != null && Object.hasOwnProperty.call(message, "appProfileId"))
+                        if (message.appProfileId != null && message.hasOwnProperty("appProfileId"))
                             writer.uint32(/* id 4, wireType 2 =*/34).string(message.appProfileId);
                         return writer;
                     };
@@ -22114,7 +22114,7 @@
                     ReadModifyWriteRowResponse.encode = function encode(message, writer) {
                         if (!writer)
                             writer = $Writer.create();
-                        if (message.row != null && Object.hasOwnProperty.call(message, "row"))
+                        if (message.row != null && message.hasOwnProperty("row"))
                             $root.google.bigtable.v2.Row.encode(message.row, writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
                         return writer;
                     };
@@ -22316,7 +22316,7 @@
                     Row.encode = function encode(message, writer) {
                         if (!writer)
                             writer = $Writer.create();
-                        if (message.key != null && Object.hasOwnProperty.call(message, "key"))
+                        if (message.key != null && message.hasOwnProperty("key"))
                             writer.uint32(/* id 1, wireType 2 =*/10).bytes(message.key);
                         if (message.families != null && message.families.length)
                             for (var i = 0; i < message.families.length; ++i)
@@ -22556,7 +22556,7 @@
                     Family.encode = function encode(message, writer) {
                         if (!writer)
                             writer = $Writer.create();
-                        if (message.name != null && Object.hasOwnProperty.call(message, "name"))
+                        if (message.name != null && message.hasOwnProperty("name"))
                             writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
                         if (message.columns != null && message.columns.length)
                             for (var i = 0; i < message.columns.length; ++i)
@@ -22787,7 +22787,7 @@
                     Column.encode = function encode(message, writer) {
                         if (!writer)
                             writer = $Writer.create();
-                        if (message.qualifier != null && Object.hasOwnProperty.call(message, "qualifier"))
+                        if (message.qualifier != null && message.hasOwnProperty("qualifier"))
                             writer.uint32(/* id 1, wireType 2 =*/10).bytes(message.qualifier);
                         if (message.cells != null && message.cells.length)
                             for (var i = 0; i < message.cells.length; ++i)
@@ -23036,9 +23036,9 @@
                     Cell.encode = function encode(message, writer) {
                         if (!writer)
                             writer = $Writer.create();
-                        if (message.timestampMicros != null && Object.hasOwnProperty.call(message, "timestampMicros"))
+                        if (message.timestampMicros != null && message.hasOwnProperty("timestampMicros"))
                             writer.uint32(/* id 1, wireType 0 =*/8).int64(message.timestampMicros);
-                        if (message.value != null && Object.hasOwnProperty.call(message, "value"))
+                        if (message.value != null && message.hasOwnProperty("value"))
                             writer.uint32(/* id 2, wireType 2 =*/18).bytes(message.value);
                         if (message.labels != null && message.labels.length)
                             for (var i = 0; i < message.labels.length; ++i)
@@ -23341,13 +23341,13 @@
                     RowRange.encode = function encode(message, writer) {
                         if (!writer)
                             writer = $Writer.create();
-                        if (message.startKeyClosed != null && Object.hasOwnProperty.call(message, "startKeyClosed"))
+                        if (message.startKeyClosed != null && message.hasOwnProperty("startKeyClosed"))
                             writer.uint32(/* id 1, wireType 2 =*/10).bytes(message.startKeyClosed);
-                        if (message.startKeyOpen != null && Object.hasOwnProperty.call(message, "startKeyOpen"))
+                        if (message.startKeyOpen != null && message.hasOwnProperty("startKeyOpen"))
                             writer.uint32(/* id 2, wireType 2 =*/18).bytes(message.startKeyOpen);
-                        if (message.endKeyOpen != null && Object.hasOwnProperty.call(message, "endKeyOpen"))
+                        if (message.endKeyOpen != null && message.hasOwnProperty("endKeyOpen"))
                             writer.uint32(/* id 3, wireType 2 =*/26).bytes(message.endKeyOpen);
-                        if (message.endKeyClosed != null && Object.hasOwnProperty.call(message, "endKeyClosed"))
+                        if (message.endKeyClosed != null && message.hasOwnProperty("endKeyClosed"))
                             writer.uint32(/* id 4, wireType 2 =*/34).bytes(message.endKeyClosed);
                         return writer;
                     };
@@ -23910,15 +23910,15 @@
                     ColumnRange.encode = function encode(message, writer) {
                         if (!writer)
                             writer = $Writer.create();
-                        if (message.familyName != null && Object.hasOwnProperty.call(message, "familyName"))
+                        if (message.familyName != null && message.hasOwnProperty("familyName"))
                             writer.uint32(/* id 1, wireType 2 =*/10).string(message.familyName);
-                        if (message.startQualifierClosed != null && Object.hasOwnProperty.call(message, "startQualifierClosed"))
+                        if (message.startQualifierClosed != null && message.hasOwnProperty("startQualifierClosed"))
                             writer.uint32(/* id 2, wireType 2 =*/18).bytes(message.startQualifierClosed);
-                        if (message.startQualifierOpen != null && Object.hasOwnProperty.call(message, "startQualifierOpen"))
+                        if (message.startQualifierOpen != null && message.hasOwnProperty("startQualifierOpen"))
                             writer.uint32(/* id 3, wireType 2 =*/26).bytes(message.startQualifierOpen);
-                        if (message.endQualifierClosed != null && Object.hasOwnProperty.call(message, "endQualifierClosed"))
+                        if (message.endQualifierClosed != null && message.hasOwnProperty("endQualifierClosed"))
                             writer.uint32(/* id 4, wireType 2 =*/34).bytes(message.endQualifierClosed);
-                        if (message.endQualifierOpen != null && Object.hasOwnProperty.call(message, "endQualifierOpen"))
+                        if (message.endQualifierOpen != null && message.hasOwnProperty("endQualifierOpen"))
                             writer.uint32(/* id 5, wireType 2 =*/42).bytes(message.endQualifierOpen);
                         return writer;
                     };
@@ -24191,9 +24191,9 @@
                     TimestampRange.encode = function encode(message, writer) {
                         if (!writer)
                             writer = $Writer.create();
-                        if (message.startTimestampMicros != null && Object.hasOwnProperty.call(message, "startTimestampMicros"))
+                        if (message.startTimestampMicros != null && message.hasOwnProperty("startTimestampMicros"))
                             writer.uint32(/* id 1, wireType 0 =*/8).int64(message.startTimestampMicros);
-                        if (message.endTimestampMicros != null && Object.hasOwnProperty.call(message, "endTimestampMicros"))
+                        if (message.endTimestampMicros != null && message.hasOwnProperty("endTimestampMicros"))
                             writer.uint32(/* id 2, wireType 0 =*/16).int64(message.endTimestampMicros);
                         return writer;
                     };
@@ -24472,13 +24472,13 @@
                     ValueRange.encode = function encode(message, writer) {
                         if (!writer)
                             writer = $Writer.create();
-                        if (message.startValueClosed != null && Object.hasOwnProperty.call(message, "startValueClosed"))
+                        if (message.startValueClosed != null && message.hasOwnProperty("startValueClosed"))
                             writer.uint32(/* id 1, wireType 2 =*/10).bytes(message.startValueClosed);
-                        if (message.startValueOpen != null && Object.hasOwnProperty.call(message, "startValueOpen"))
+                        if (message.startValueOpen != null && message.hasOwnProperty("startValueOpen"))
                             writer.uint32(/* id 2, wireType 2 =*/18).bytes(message.startValueOpen);
-                        if (message.endValueClosed != null && Object.hasOwnProperty.call(message, "endValueClosed"))
+                        if (message.endValueClosed != null && message.hasOwnProperty("endValueClosed"))
                             writer.uint32(/* id 3, wireType 2 =*/26).bytes(message.endValueClosed);
-                        if (message.endValueOpen != null && Object.hasOwnProperty.call(message, "endValueOpen"))
+                        if (message.endValueOpen != null && message.hasOwnProperty("endValueOpen"))
                             writer.uint32(/* id 4, wireType 2 =*/34).bytes(message.endValueOpen);
                         return writer;
                     };
@@ -24906,43 +24906,43 @@
                     RowFilter.encode = function encode(message, writer) {
                         if (!writer)
                             writer = $Writer.create();
-                        if (message.chain != null && Object.hasOwnProperty.call(message, "chain"))
+                        if (message.chain != null && message.hasOwnProperty("chain"))
                             $root.google.bigtable.v2.RowFilter.Chain.encode(message.chain, writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
-                        if (message.interleave != null && Object.hasOwnProperty.call(message, "interleave"))
+                        if (message.interleave != null && message.hasOwnProperty("interleave"))
                             $root.google.bigtable.v2.RowFilter.Interleave.encode(message.interleave, writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
-                        if (message.condition != null && Object.hasOwnProperty.call(message, "condition"))
+                        if (message.condition != null && message.hasOwnProperty("condition"))
                             $root.google.bigtable.v2.RowFilter.Condition.encode(message.condition, writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
-                        if (message.rowKeyRegexFilter != null && Object.hasOwnProperty.call(message, "rowKeyRegexFilter"))
+                        if (message.rowKeyRegexFilter != null && message.hasOwnProperty("rowKeyRegexFilter"))
                             writer.uint32(/* id 4, wireType 2 =*/34).bytes(message.rowKeyRegexFilter);
-                        if (message.familyNameRegexFilter != null && Object.hasOwnProperty.call(message, "familyNameRegexFilter"))
+                        if (message.familyNameRegexFilter != null && message.hasOwnProperty("familyNameRegexFilter"))
                             writer.uint32(/* id 5, wireType 2 =*/42).string(message.familyNameRegexFilter);
-                        if (message.columnQualifierRegexFilter != null && Object.hasOwnProperty.call(message, "columnQualifierRegexFilter"))
+                        if (message.columnQualifierRegexFilter != null && message.hasOwnProperty("columnQualifierRegexFilter"))
                             writer.uint32(/* id 6, wireType 2 =*/50).bytes(message.columnQualifierRegexFilter);
-                        if (message.columnRangeFilter != null && Object.hasOwnProperty.call(message, "columnRangeFilter"))
+                        if (message.columnRangeFilter != null && message.hasOwnProperty("columnRangeFilter"))
                             $root.google.bigtable.v2.ColumnRange.encode(message.columnRangeFilter, writer.uint32(/* id 7, wireType 2 =*/58).fork()).ldelim();
-                        if (message.timestampRangeFilter != null && Object.hasOwnProperty.call(message, "timestampRangeFilter"))
+                        if (message.timestampRangeFilter != null && message.hasOwnProperty("timestampRangeFilter"))
                             $root.google.bigtable.v2.TimestampRange.encode(message.timestampRangeFilter, writer.uint32(/* id 8, wireType 2 =*/66).fork()).ldelim();
-                        if (message.valueRegexFilter != null && Object.hasOwnProperty.call(message, "valueRegexFilter"))
+                        if (message.valueRegexFilter != null && message.hasOwnProperty("valueRegexFilter"))
                             writer.uint32(/* id 9, wireType 2 =*/74).bytes(message.valueRegexFilter);
-                        if (message.cellsPerRowOffsetFilter != null && Object.hasOwnProperty.call(message, "cellsPerRowOffsetFilter"))
+                        if (message.cellsPerRowOffsetFilter != null && message.hasOwnProperty("cellsPerRowOffsetFilter"))
                             writer.uint32(/* id 10, wireType 0 =*/80).int32(message.cellsPerRowOffsetFilter);
-                        if (message.cellsPerRowLimitFilter != null && Object.hasOwnProperty.call(message, "cellsPerRowLimitFilter"))
+                        if (message.cellsPerRowLimitFilter != null && message.hasOwnProperty("cellsPerRowLimitFilter"))
                             writer.uint32(/* id 11, wireType 0 =*/88).int32(message.cellsPerRowLimitFilter);
-                        if (message.cellsPerColumnLimitFilter != null && Object.hasOwnProperty.call(message, "cellsPerColumnLimitFilter"))
+                        if (message.cellsPerColumnLimitFilter != null && message.hasOwnProperty("cellsPerColumnLimitFilter"))
                             writer.uint32(/* id 12, wireType 0 =*/96).int32(message.cellsPerColumnLimitFilter);
-                        if (message.stripValueTransformer != null && Object.hasOwnProperty.call(message, "stripValueTransformer"))
+                        if (message.stripValueTransformer != null && message.hasOwnProperty("stripValueTransformer"))
                             writer.uint32(/* id 13, wireType 0 =*/104).bool(message.stripValueTransformer);
-                        if (message.rowSampleFilter != null && Object.hasOwnProperty.call(message, "rowSampleFilter"))
+                        if (message.rowSampleFilter != null && message.hasOwnProperty("rowSampleFilter"))
                             writer.uint32(/* id 14, wireType 1 =*/113).double(message.rowSampleFilter);
-                        if (message.valueRangeFilter != null && Object.hasOwnProperty.call(message, "valueRangeFilter"))
+                        if (message.valueRangeFilter != null && message.hasOwnProperty("valueRangeFilter"))
                             $root.google.bigtable.v2.ValueRange.encode(message.valueRangeFilter, writer.uint32(/* id 15, wireType 2 =*/122).fork()).ldelim();
-                        if (message.sink != null && Object.hasOwnProperty.call(message, "sink"))
+                        if (message.sink != null && message.hasOwnProperty("sink"))
                             writer.uint32(/* id 16, wireType 0 =*/128).bool(message.sink);
-                        if (message.passAllFilter != null && Object.hasOwnProperty.call(message, "passAllFilter"))
+                        if (message.passAllFilter != null && message.hasOwnProperty("passAllFilter"))
                             writer.uint32(/* id 17, wireType 0 =*/136).bool(message.passAllFilter);
-                        if (message.blockAllFilter != null && Object.hasOwnProperty.call(message, "blockAllFilter"))
+                        if (message.blockAllFilter != null && message.hasOwnProperty("blockAllFilter"))
                             writer.uint32(/* id 18, wireType 0 =*/144).bool(message.blockAllFilter);
-                        if (message.applyLabelTransformer != null && Object.hasOwnProperty.call(message, "applyLabelTransformer"))
+                        if (message.applyLabelTransformer != null && message.hasOwnProperty("applyLabelTransformer"))
                             writer.uint32(/* id 19, wireType 2 =*/154).string(message.applyLabelTransformer);
                         return writer;
                     };
@@ -25915,11 +25915,11 @@
                         Condition.encode = function encode(message, writer) {
                             if (!writer)
                                 writer = $Writer.create();
-                            if (message.predicateFilter != null && Object.hasOwnProperty.call(message, "predicateFilter"))
+                            if (message.predicateFilter != null && message.hasOwnProperty("predicateFilter"))
                                 $root.google.bigtable.v2.RowFilter.encode(message.predicateFilter, writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
-                            if (message.trueFilter != null && Object.hasOwnProperty.call(message, "trueFilter"))
+                            if (message.trueFilter != null && message.hasOwnProperty("trueFilter"))
                                 $root.google.bigtable.v2.RowFilter.encode(message.trueFilter, writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
-                            if (message.falseFilter != null && Object.hasOwnProperty.call(message, "falseFilter"))
+                            if (message.falseFilter != null && message.hasOwnProperty("falseFilter"))
                                 $root.google.bigtable.v2.RowFilter.encode(message.falseFilter, writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
                             return writer;
                         };
@@ -26188,13 +26188,13 @@
                     Mutation.encode = function encode(message, writer) {
                         if (!writer)
                             writer = $Writer.create();
-                        if (message.setCell != null && Object.hasOwnProperty.call(message, "setCell"))
+                        if (message.setCell != null && message.hasOwnProperty("setCell"))
                             $root.google.bigtable.v2.Mutation.SetCell.encode(message.setCell, writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
-                        if (message.deleteFromColumn != null && Object.hasOwnProperty.call(message, "deleteFromColumn"))
+                        if (message.deleteFromColumn != null && message.hasOwnProperty("deleteFromColumn"))
                             $root.google.bigtable.v2.Mutation.DeleteFromColumn.encode(message.deleteFromColumn, writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
-                        if (message.deleteFromFamily != null && Object.hasOwnProperty.call(message, "deleteFromFamily"))
+                        if (message.deleteFromFamily != null && message.hasOwnProperty("deleteFromFamily"))
                             $root.google.bigtable.v2.Mutation.DeleteFromFamily.encode(message.deleteFromFamily, writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
-                        if (message.deleteFromRow != null && Object.hasOwnProperty.call(message, "deleteFromRow"))
+                        if (message.deleteFromRow != null && message.hasOwnProperty("deleteFromRow"))
                             $root.google.bigtable.v2.Mutation.DeleteFromRow.encode(message.deleteFromRow, writer.uint32(/* id 4, wireType 2 =*/34).fork()).ldelim();
                         return writer;
                     };
@@ -26484,13 +26484,13 @@
                         SetCell.encode = function encode(message, writer) {
                             if (!writer)
                                 writer = $Writer.create();
-                            if (message.familyName != null && Object.hasOwnProperty.call(message, "familyName"))
+                            if (message.familyName != null && message.hasOwnProperty("familyName"))
                                 writer.uint32(/* id 1, wireType 2 =*/10).string(message.familyName);
-                            if (message.columnQualifier != null && Object.hasOwnProperty.call(message, "columnQualifier"))
+                            if (message.columnQualifier != null && message.hasOwnProperty("columnQualifier"))
                                 writer.uint32(/* id 2, wireType 2 =*/18).bytes(message.columnQualifier);
-                            if (message.timestampMicros != null && Object.hasOwnProperty.call(message, "timestampMicros"))
+                            if (message.timestampMicros != null && message.hasOwnProperty("timestampMicros"))
                                 writer.uint32(/* id 3, wireType 0 =*/24).int64(message.timestampMicros);
-                            if (message.value != null && Object.hasOwnProperty.call(message, "value"))
+                            if (message.value != null && message.hasOwnProperty("value"))
                                 writer.uint32(/* id 4, wireType 2 =*/34).bytes(message.value);
                             return writer;
                         };
@@ -26761,11 +26761,11 @@
                         DeleteFromColumn.encode = function encode(message, writer) {
                             if (!writer)
                                 writer = $Writer.create();
-                            if (message.familyName != null && Object.hasOwnProperty.call(message, "familyName"))
+                            if (message.familyName != null && message.hasOwnProperty("familyName"))
                                 writer.uint32(/* id 1, wireType 2 =*/10).string(message.familyName);
-                            if (message.columnQualifier != null && Object.hasOwnProperty.call(message, "columnQualifier"))
+                            if (message.columnQualifier != null && message.hasOwnProperty("columnQualifier"))
                                 writer.uint32(/* id 2, wireType 2 =*/18).bytes(message.columnQualifier);
-                            if (message.timeRange != null && Object.hasOwnProperty.call(message, "timeRange"))
+                            if (message.timeRange != null && message.hasOwnProperty("timeRange"))
                                 $root.google.bigtable.v2.TimestampRange.encode(message.timeRange, writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
                             return writer;
                         };
@@ -26989,7 +26989,7 @@
                         DeleteFromFamily.encode = function encode(message, writer) {
                             if (!writer)
                                 writer = $Writer.create();
-                            if (message.familyName != null && Object.hasOwnProperty.call(message, "familyName"))
+                            if (message.familyName != null && message.hasOwnProperty("familyName"))
                                 writer.uint32(/* id 1, wireType 2 =*/10).string(message.familyName);
                             return writer;
                         };
@@ -27380,13 +27380,13 @@
                     ReadModifyWriteRule.encode = function encode(message, writer) {
                         if (!writer)
                             writer = $Writer.create();
-                        if (message.familyName != null && Object.hasOwnProperty.call(message, "familyName"))
+                        if (message.familyName != null && message.hasOwnProperty("familyName"))
                             writer.uint32(/* id 1, wireType 2 =*/10).string(message.familyName);
-                        if (message.columnQualifier != null && Object.hasOwnProperty.call(message, "columnQualifier"))
+                        if (message.columnQualifier != null && message.hasOwnProperty("columnQualifier"))
                             writer.uint32(/* id 2, wireType 2 =*/18).bytes(message.columnQualifier);
-                        if (message.appendValue != null && Object.hasOwnProperty.call(message, "appendValue"))
+                        if (message.appendValue != null && message.hasOwnProperty("appendValue"))
                             writer.uint32(/* id 3, wireType 2 =*/26).bytes(message.appendValue);
-                        if (message.incrementAmount != null && Object.hasOwnProperty.call(message, "incrementAmount"))
+                        if (message.incrementAmount != null && message.hasOwnProperty("incrementAmount"))
                             writer.uint32(/* id 4, wireType 0 =*/32).int64(message.incrementAmount);
                         return writer;
                     };
@@ -27668,7 +27668,7 @@
                     if (message.rules != null && message.rules.length)
                         for (var i = 0; i < message.rules.length; ++i)
                             $root.google.api.HttpRule.encode(message.rules[i], writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
-                    if (message.fullyDecodeReservedExpansion != null && Object.hasOwnProperty.call(message, "fullyDecodeReservedExpansion"))
+                    if (message.fullyDecodeReservedExpansion != null && message.hasOwnProperty("fullyDecodeReservedExpansion"))
                         writer.uint32(/* id 2, wireType 0 =*/16).bool(message.fullyDecodeReservedExpansion);
                     return writer;
                 };
@@ -27982,26 +27982,26 @@
                 HttpRule.encode = function encode(message, writer) {
                     if (!writer)
                         writer = $Writer.create();
-                    if (message.selector != null && Object.hasOwnProperty.call(message, "selector"))
+                    if (message.selector != null && message.hasOwnProperty("selector"))
                         writer.uint32(/* id 1, wireType 2 =*/10).string(message.selector);
-                    if (message.get != null && Object.hasOwnProperty.call(message, "get"))
+                    if (message.get != null && message.hasOwnProperty("get"))
                         writer.uint32(/* id 2, wireType 2 =*/18).string(message.get);
-                    if (message.put != null && Object.hasOwnProperty.call(message, "put"))
+                    if (message.put != null && message.hasOwnProperty("put"))
                         writer.uint32(/* id 3, wireType 2 =*/26).string(message.put);
-                    if (message.post != null && Object.hasOwnProperty.call(message, "post"))
+                    if (message.post != null && message.hasOwnProperty("post"))
                         writer.uint32(/* id 4, wireType 2 =*/34).string(message.post);
-                    if (message["delete"] != null && Object.hasOwnProperty.call(message, "delete"))
+                    if (message["delete"] != null && message.hasOwnProperty("delete"))
                         writer.uint32(/* id 5, wireType 2 =*/42).string(message["delete"]);
-                    if (message.patch != null && Object.hasOwnProperty.call(message, "patch"))
+                    if (message.patch != null && message.hasOwnProperty("patch"))
                         writer.uint32(/* id 6, wireType 2 =*/50).string(message.patch);
-                    if (message.body != null && Object.hasOwnProperty.call(message, "body"))
+                    if (message.body != null && message.hasOwnProperty("body"))
                         writer.uint32(/* id 7, wireType 2 =*/58).string(message.body);
-                    if (message.custom != null && Object.hasOwnProperty.call(message, "custom"))
+                    if (message.custom != null && message.hasOwnProperty("custom"))
                         $root.google.api.CustomHttpPattern.encode(message.custom, writer.uint32(/* id 8, wireType 2 =*/66).fork()).ldelim();
                     if (message.additionalBindings != null && message.additionalBindings.length)
                         for (var i = 0; i < message.additionalBindings.length; ++i)
                             $root.google.api.HttpRule.encode(message.additionalBindings[i], writer.uint32(/* id 11, wireType 2 =*/90).fork()).ldelim();
-                    if (message.responseBody != null && Object.hasOwnProperty.call(message, "responseBody"))
+                    if (message.responseBody != null && message.hasOwnProperty("responseBody"))
                         writer.uint32(/* id 12, wireType 2 =*/98).string(message.responseBody);
                     return writer;
                 };
@@ -28358,9 +28358,9 @@
                 CustomHttpPattern.encode = function encode(message, writer) {
                     if (!writer)
                         writer = $Writer.create();
-                    if (message.kind != null && Object.hasOwnProperty.call(message, "kind"))
+                    if (message.kind != null && message.hasOwnProperty("kind"))
                         writer.uint32(/* id 1, wireType 2 =*/10).string(message.kind);
-                    if (message.path != null && Object.hasOwnProperty.call(message, "path"))
+                    if (message.path != null && message.hasOwnProperty("path"))
                         writer.uint32(/* id 2, wireType 2 =*/18).string(message.path);
                     return writer;
                 };
@@ -28506,7 +28506,7 @@
             /**
              * FieldBehavior enum.
              * @name google.api.FieldBehavior
-             * @enum {number}
+             * @enum {string}
              * @property {number} FIELD_BEHAVIOR_UNSPECIFIED=0 FIELD_BEHAVIOR_UNSPECIFIED value
              * @property {number} OPTIONAL=1 OPTIONAL value
              * @property {number} REQUIRED=2 REQUIRED value
@@ -28627,18 +28627,18 @@
                 ResourceDescriptor.encode = function encode(message, writer) {
                     if (!writer)
                         writer = $Writer.create();
-                    if (message.type != null && Object.hasOwnProperty.call(message, "type"))
+                    if (message.type != null && message.hasOwnProperty("type"))
                         writer.uint32(/* id 1, wireType 2 =*/10).string(message.type);
                     if (message.pattern != null && message.pattern.length)
                         for (var i = 0; i < message.pattern.length; ++i)
                             writer.uint32(/* id 2, wireType 2 =*/18).string(message.pattern[i]);
-                    if (message.nameField != null && Object.hasOwnProperty.call(message, "nameField"))
+                    if (message.nameField != null && message.hasOwnProperty("nameField"))
                         writer.uint32(/* id 3, wireType 2 =*/26).string(message.nameField);
-                    if (message.history != null && Object.hasOwnProperty.call(message, "history"))
+                    if (message.history != null && message.hasOwnProperty("history"))
                         writer.uint32(/* id 4, wireType 0 =*/32).int32(message.history);
-                    if (message.plural != null && Object.hasOwnProperty.call(message, "plural"))
+                    if (message.plural != null && message.hasOwnProperty("plural"))
                         writer.uint32(/* id 5, wireType 2 =*/42).string(message.plural);
-                    if (message.singular != null && Object.hasOwnProperty.call(message, "singular"))
+                    if (message.singular != null && message.hasOwnProperty("singular"))
                         writer.uint32(/* id 6, wireType 2 =*/50).string(message.singular);
                     return writer;
                 };
@@ -28858,7 +28858,7 @@
                 /**
                  * History enum.
                  * @name google.api.ResourceDescriptor.History
-                 * @enum {number}
+                 * @enum {string}
                  * @property {number} HISTORY_UNSPECIFIED=0 HISTORY_UNSPECIFIED value
                  * @property {number} ORIGINALLY_SINGLE_PATTERN=1 ORIGINALLY_SINGLE_PATTERN value
                  * @property {number} FUTURE_MULTI_PATTERN=2 FUTURE_MULTI_PATTERN value
@@ -28939,9 +28939,9 @@
                 ResourceReference.encode = function encode(message, writer) {
                     if (!writer)
                         writer = $Writer.create();
-                    if (message.type != null && Object.hasOwnProperty.call(message, "type"))
+                    if (message.type != null && message.hasOwnProperty("type"))
                         writer.uint32(/* id 1, wireType 2 =*/10).string(message.type);
-                    if (message.childType != null && Object.hasOwnProperty.call(message, "childType"))
+                    if (message.childType != null && message.hasOwnProperty("childType"))
                         writer.uint32(/* id 2, wireType 2 =*/18).string(message.childType);
                     return writer;
                 };
@@ -29466,9 +29466,9 @@
                 FileDescriptorProto.encode = function encode(message, writer) {
                     if (!writer)
                         writer = $Writer.create();
-                    if (message.name != null && Object.hasOwnProperty.call(message, "name"))
+                    if (message.name != null && message.hasOwnProperty("name"))
                         writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
-                    if (message["package"] != null && Object.hasOwnProperty.call(message, "package"))
+                    if (message["package"] != null && message.hasOwnProperty("package"))
                         writer.uint32(/* id 2, wireType 2 =*/18).string(message["package"]);
                     if (message.dependency != null && message.dependency.length)
                         for (var i = 0; i < message.dependency.length; ++i)
@@ -29485,9 +29485,9 @@
                     if (message.extension != null && message.extension.length)
                         for (var i = 0; i < message.extension.length; ++i)
                             $root.google.protobuf.FieldDescriptorProto.encode(message.extension[i], writer.uint32(/* id 7, wireType 2 =*/58).fork()).ldelim();
-                    if (message.options != null && Object.hasOwnProperty.call(message, "options"))
+                    if (message.options != null && message.hasOwnProperty("options"))
                         $root.google.protobuf.FileOptions.encode(message.options, writer.uint32(/* id 8, wireType 2 =*/66).fork()).ldelim();
-                    if (message.sourceCodeInfo != null && Object.hasOwnProperty.call(message, "sourceCodeInfo"))
+                    if (message.sourceCodeInfo != null && message.hasOwnProperty("sourceCodeInfo"))
                         $root.google.protobuf.SourceCodeInfo.encode(message.sourceCodeInfo, writer.uint32(/* id 9, wireType 2 =*/74).fork()).ldelim();
                     if (message.publicDependency != null && message.publicDependency.length)
                         for (var i = 0; i < message.publicDependency.length; ++i)
@@ -29495,7 +29495,7 @@
                     if (message.weakDependency != null && message.weakDependency.length)
                         for (var i = 0; i < message.weakDependency.length; ++i)
                             writer.uint32(/* id 11, wireType 0 =*/88).int32(message.weakDependency[i]);
-                    if (message.syntax != null && Object.hasOwnProperty.call(message, "syntax"))
+                    if (message.syntax != null && message.hasOwnProperty("syntax"))
                         writer.uint32(/* id 12, wireType 2 =*/98).string(message.syntax);
                     return writer;
                 };
@@ -30033,7 +30033,7 @@
                 DescriptorProto.encode = function encode(message, writer) {
                     if (!writer)
                         writer = $Writer.create();
-                    if (message.name != null && Object.hasOwnProperty.call(message, "name"))
+                    if (message.name != null && message.hasOwnProperty("name"))
                         writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
                     if (message.field != null && message.field.length)
                         for (var i = 0; i < message.field.length; ++i)
@@ -30050,7 +30050,7 @@
                     if (message.extension != null && message.extension.length)
                         for (var i = 0; i < message.extension.length; ++i)
                             $root.google.protobuf.FieldDescriptorProto.encode(message.extension[i], writer.uint32(/* id 6, wireType 2 =*/50).fork()).ldelim();
-                    if (message.options != null && Object.hasOwnProperty.call(message, "options"))
+                    if (message.options != null && message.hasOwnProperty("options"))
                         $root.google.protobuf.MessageOptions.encode(message.options, writer.uint32(/* id 7, wireType 2 =*/58).fork()).ldelim();
                     if (message.oneofDecl != null && message.oneofDecl.length)
                         for (var i = 0; i < message.oneofDecl.length; ++i)
@@ -30515,11 +30515,11 @@
                     ExtensionRange.encode = function encode(message, writer) {
                         if (!writer)
                             writer = $Writer.create();
-                        if (message.start != null && Object.hasOwnProperty.call(message, "start"))
+                        if (message.start != null && message.hasOwnProperty("start"))
                             writer.uint32(/* id 1, wireType 0 =*/8).int32(message.start);
-                        if (message.end != null && Object.hasOwnProperty.call(message, "end"))
+                        if (message.end != null && message.hasOwnProperty("end"))
                             writer.uint32(/* id 2, wireType 0 =*/16).int32(message.end);
-                        if (message.options != null && Object.hasOwnProperty.call(message, "options"))
+                        if (message.options != null && message.hasOwnProperty("options"))
                             $root.google.protobuf.ExtensionRangeOptions.encode(message.options, writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
                         return writer;
                     };
@@ -30743,9 +30743,9 @@
                     ReservedRange.encode = function encode(message, writer) {
                         if (!writer)
                             writer = $Writer.create();
-                        if (message.start != null && Object.hasOwnProperty.call(message, "start"))
+                        if (message.start != null && message.hasOwnProperty("start"))
                             writer.uint32(/* id 1, wireType 0 =*/8).int32(message.start);
-                        if (message.end != null && Object.hasOwnProperty.call(message, "end"))
+                        if (message.end != null && message.hasOwnProperty("end"))
                             writer.uint32(/* id 2, wireType 0 =*/16).int32(message.end);
                         return writer;
                     };
@@ -31236,25 +31236,25 @@
                 FieldDescriptorProto.encode = function encode(message, writer) {
                     if (!writer)
                         writer = $Writer.create();
-                    if (message.name != null && Object.hasOwnProperty.call(message, "name"))
+                    if (message.name != null && message.hasOwnProperty("name"))
                         writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
-                    if (message.extendee != null && Object.hasOwnProperty.call(message, "extendee"))
+                    if (message.extendee != null && message.hasOwnProperty("extendee"))
                         writer.uint32(/* id 2, wireType 2 =*/18).string(message.extendee);
-                    if (message.number != null && Object.hasOwnProperty.call(message, "number"))
+                    if (message.number != null && message.hasOwnProperty("number"))
                         writer.uint32(/* id 3, wireType 0 =*/24).int32(message.number);
-                    if (message.label != null && Object.hasOwnProperty.call(message, "label"))
+                    if (message.label != null && message.hasOwnProperty("label"))
                         writer.uint32(/* id 4, wireType 0 =*/32).int32(message.label);
-                    if (message.type != null && Object.hasOwnProperty.call(message, "type"))
+                    if (message.type != null && message.hasOwnProperty("type"))
                         writer.uint32(/* id 5, wireType 0 =*/40).int32(message.type);
-                    if (message.typeName != null && Object.hasOwnProperty.call(message, "typeName"))
+                    if (message.typeName != null && message.hasOwnProperty("typeName"))
                         writer.uint32(/* id 6, wireType 2 =*/50).string(message.typeName);
-                    if (message.defaultValue != null && Object.hasOwnProperty.call(message, "defaultValue"))
+                    if (message.defaultValue != null && message.hasOwnProperty("defaultValue"))
                         writer.uint32(/* id 7, wireType 2 =*/58).string(message.defaultValue);
-                    if (message.options != null && Object.hasOwnProperty.call(message, "options"))
+                    if (message.options != null && message.hasOwnProperty("options"))
                         $root.google.protobuf.FieldOptions.encode(message.options, writer.uint32(/* id 8, wireType 2 =*/66).fork()).ldelim();
-                    if (message.oneofIndex != null && Object.hasOwnProperty.call(message, "oneofIndex"))
+                    if (message.oneofIndex != null && message.hasOwnProperty("oneofIndex"))
                         writer.uint32(/* id 9, wireType 0 =*/72).int32(message.oneofIndex);
-                    if (message.jsonName != null && Object.hasOwnProperty.call(message, "jsonName"))
+                    if (message.jsonName != null && message.hasOwnProperty("jsonName"))
                         writer.uint32(/* id 10, wireType 2 =*/82).string(message.jsonName);
                     return writer;
                 };
@@ -31601,7 +31601,7 @@
                 /**
                  * Type enum.
                  * @name google.protobuf.FieldDescriptorProto.Type
-                 * @enum {number}
+                 * @enum {string}
                  * @property {number} TYPE_DOUBLE=1 TYPE_DOUBLE value
                  * @property {number} TYPE_FLOAT=2 TYPE_FLOAT value
                  * @property {number} TYPE_INT64=3 TYPE_INT64 value
@@ -31647,7 +31647,7 @@
                 /**
                  * Label enum.
                  * @name google.protobuf.FieldDescriptorProto.Label
-                 * @enum {number}
+                 * @enum {string}
                  * @property {number} LABEL_OPTIONAL=1 LABEL_OPTIONAL value
                  * @property {number} LABEL_REQUIRED=2 LABEL_REQUIRED value
                  * @property {number} LABEL_REPEATED=3 LABEL_REPEATED value
@@ -31728,9 +31728,9 @@
                 OneofDescriptorProto.encode = function encode(message, writer) {
                     if (!writer)
                         writer = $Writer.create();
-                    if (message.name != null && Object.hasOwnProperty.call(message, "name"))
+                    if (message.name != null && message.hasOwnProperty("name"))
                         writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
-                    if (message.options != null && Object.hasOwnProperty.call(message, "options"))
+                    if (message.options != null && message.hasOwnProperty("options"))
                         $root.google.protobuf.OneofOptions.encode(message.options, writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
                     return writer;
                 };
@@ -31973,12 +31973,12 @@
                 EnumDescriptorProto.encode = function encode(message, writer) {
                     if (!writer)
                         writer = $Writer.create();
-                    if (message.name != null && Object.hasOwnProperty.call(message, "name"))
+                    if (message.name != null && message.hasOwnProperty("name"))
                         writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
                     if (message.value != null && message.value.length)
                         for (var i = 0; i < message.value.length; ++i)
                             $root.google.protobuf.EnumValueDescriptorProto.encode(message.value[i], writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
-                    if (message.options != null && Object.hasOwnProperty.call(message, "options"))
+                    if (message.options != null && message.hasOwnProperty("options"))
                         $root.google.protobuf.EnumOptions.encode(message.options, writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
                     if (message.reservedRange != null && message.reservedRange.length)
                         for (var i = 0; i < message.reservedRange.length; ++i)
@@ -32281,9 +32281,9 @@
                     EnumReservedRange.encode = function encode(message, writer) {
                         if (!writer)
                             writer = $Writer.create();
-                        if (message.start != null && Object.hasOwnProperty.call(message, "start"))
+                        if (message.start != null && message.hasOwnProperty("start"))
                             writer.uint32(/* id 1, wireType 0 =*/8).int32(message.start);
-                        if (message.end != null && Object.hasOwnProperty.call(message, "end"))
+                        if (message.end != null && message.hasOwnProperty("end"))
                             writer.uint32(/* id 2, wireType 0 =*/16).int32(message.end);
                         return writer;
                     };
@@ -32503,11 +32503,11 @@
                 EnumValueDescriptorProto.encode = function encode(message, writer) {
                     if (!writer)
                         writer = $Writer.create();
-                    if (message.name != null && Object.hasOwnProperty.call(message, "name"))
+                    if (message.name != null && message.hasOwnProperty("name"))
                         writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
-                    if (message.number != null && Object.hasOwnProperty.call(message, "number"))
+                    if (message.number != null && message.hasOwnProperty("number"))
                         writer.uint32(/* id 2, wireType 0 =*/16).int32(message.number);
-                    if (message.options != null && Object.hasOwnProperty.call(message, "options"))
+                    if (message.options != null && message.hasOwnProperty("options"))
                         $root.google.protobuf.EnumValueOptions.encode(message.options, writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
                     return writer;
                 };
@@ -32741,12 +32741,12 @@
                 ServiceDescriptorProto.encode = function encode(message, writer) {
                     if (!writer)
                         writer = $Writer.create();
-                    if (message.name != null && Object.hasOwnProperty.call(message, "name"))
+                    if (message.name != null && message.hasOwnProperty("name"))
                         writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
                     if (message.method != null && message.method.length)
                         for (var i = 0; i < message.method.length; ++i)
                             $root.google.protobuf.MethodDescriptorProto.encode(message.method[i], writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
-                    if (message.options != null && Object.hasOwnProperty.call(message, "options"))
+                    if (message.options != null && message.hasOwnProperty("options"))
                         $root.google.protobuf.ServiceOptions.encode(message.options, writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
                     return writer;
                 };
@@ -33026,17 +33026,17 @@
                 MethodDescriptorProto.encode = function encode(message, writer) {
                     if (!writer)
                         writer = $Writer.create();
-                    if (message.name != null && Object.hasOwnProperty.call(message, "name"))
+                    if (message.name != null && message.hasOwnProperty("name"))
                         writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
-                    if (message.inputType != null && Object.hasOwnProperty.call(message, "inputType"))
+                    if (message.inputType != null && message.hasOwnProperty("inputType"))
                         writer.uint32(/* id 2, wireType 2 =*/18).string(message.inputType);
-                    if (message.outputType != null && Object.hasOwnProperty.call(message, "outputType"))
+                    if (message.outputType != null && message.hasOwnProperty("outputType"))
                         writer.uint32(/* id 3, wireType 2 =*/26).string(message.outputType);
-                    if (message.options != null && Object.hasOwnProperty.call(message, "options"))
+                    if (message.options != null && message.hasOwnProperty("options"))
                         $root.google.protobuf.MethodOptions.encode(message.options, writer.uint32(/* id 4, wireType 2 =*/34).fork()).ldelim();
-                    if (message.clientStreaming != null && Object.hasOwnProperty.call(message, "clientStreaming"))
+                    if (message.clientStreaming != null && message.hasOwnProperty("clientStreaming"))
                         writer.uint32(/* id 5, wireType 0 =*/40).bool(message.clientStreaming);
-                    if (message.serverStreaming != null && Object.hasOwnProperty.call(message, "serverStreaming"))
+                    if (message.serverStreaming != null && message.hasOwnProperty("serverStreaming"))
                         writer.uint32(/* id 6, wireType 0 =*/48).bool(message.serverStreaming);
                     return writer;
                 };
@@ -33475,45 +33475,45 @@
                 FileOptions.encode = function encode(message, writer) {
                     if (!writer)
                         writer = $Writer.create();
-                    if (message.javaPackage != null && Object.hasOwnProperty.call(message, "javaPackage"))
+                    if (message.javaPackage != null && message.hasOwnProperty("javaPackage"))
                         writer.uint32(/* id 1, wireType 2 =*/10).string(message.javaPackage);
-                    if (message.javaOuterClassname != null && Object.hasOwnProperty.call(message, "javaOuterClassname"))
+                    if (message.javaOuterClassname != null && message.hasOwnProperty("javaOuterClassname"))
                         writer.uint32(/* id 8, wireType 2 =*/66).string(message.javaOuterClassname);
-                    if (message.optimizeFor != null && Object.hasOwnProperty.call(message, "optimizeFor"))
+                    if (message.optimizeFor != null && message.hasOwnProperty("optimizeFor"))
                         writer.uint32(/* id 9, wireType 0 =*/72).int32(message.optimizeFor);
-                    if (message.javaMultipleFiles != null && Object.hasOwnProperty.call(message, "javaMultipleFiles"))
+                    if (message.javaMultipleFiles != null && message.hasOwnProperty("javaMultipleFiles"))
                         writer.uint32(/* id 10, wireType 0 =*/80).bool(message.javaMultipleFiles);
-                    if (message.goPackage != null && Object.hasOwnProperty.call(message, "goPackage"))
+                    if (message.goPackage != null && message.hasOwnProperty("goPackage"))
                         writer.uint32(/* id 11, wireType 2 =*/90).string(message.goPackage);
-                    if (message.ccGenericServices != null && Object.hasOwnProperty.call(message, "ccGenericServices"))
+                    if (message.ccGenericServices != null && message.hasOwnProperty("ccGenericServices"))
                         writer.uint32(/* id 16, wireType 0 =*/128).bool(message.ccGenericServices);
-                    if (message.javaGenericServices != null && Object.hasOwnProperty.call(message, "javaGenericServices"))
+                    if (message.javaGenericServices != null && message.hasOwnProperty("javaGenericServices"))
                         writer.uint32(/* id 17, wireType 0 =*/136).bool(message.javaGenericServices);
-                    if (message.pyGenericServices != null && Object.hasOwnProperty.call(message, "pyGenericServices"))
+                    if (message.pyGenericServices != null && message.hasOwnProperty("pyGenericServices"))
                         writer.uint32(/* id 18, wireType 0 =*/144).bool(message.pyGenericServices);
-                    if (message.javaGenerateEqualsAndHash != null && Object.hasOwnProperty.call(message, "javaGenerateEqualsAndHash"))
+                    if (message.javaGenerateEqualsAndHash != null && message.hasOwnProperty("javaGenerateEqualsAndHash"))
                         writer.uint32(/* id 20, wireType 0 =*/160).bool(message.javaGenerateEqualsAndHash);
-                    if (message.deprecated != null && Object.hasOwnProperty.call(message, "deprecated"))
+                    if (message.deprecated != null && message.hasOwnProperty("deprecated"))
                         writer.uint32(/* id 23, wireType 0 =*/184).bool(message.deprecated);
-                    if (message.javaStringCheckUtf8 != null && Object.hasOwnProperty.call(message, "javaStringCheckUtf8"))
+                    if (message.javaStringCheckUtf8 != null && message.hasOwnProperty("javaStringCheckUtf8"))
                         writer.uint32(/* id 27, wireType 0 =*/216).bool(message.javaStringCheckUtf8);
-                    if (message.ccEnableArenas != null && Object.hasOwnProperty.call(message, "ccEnableArenas"))
+                    if (message.ccEnableArenas != null && message.hasOwnProperty("ccEnableArenas"))
                         writer.uint32(/* id 31, wireType 0 =*/248).bool(message.ccEnableArenas);
-                    if (message.objcClassPrefix != null && Object.hasOwnProperty.call(message, "objcClassPrefix"))
+                    if (message.objcClassPrefix != null && message.hasOwnProperty("objcClassPrefix"))
                         writer.uint32(/* id 36, wireType 2 =*/290).string(message.objcClassPrefix);
-                    if (message.csharpNamespace != null && Object.hasOwnProperty.call(message, "csharpNamespace"))
+                    if (message.csharpNamespace != null && message.hasOwnProperty("csharpNamespace"))
                         writer.uint32(/* id 37, wireType 2 =*/298).string(message.csharpNamespace);
-                    if (message.swiftPrefix != null && Object.hasOwnProperty.call(message, "swiftPrefix"))
+                    if (message.swiftPrefix != null && message.hasOwnProperty("swiftPrefix"))
                         writer.uint32(/* id 39, wireType 2 =*/314).string(message.swiftPrefix);
-                    if (message.phpClassPrefix != null && Object.hasOwnProperty.call(message, "phpClassPrefix"))
+                    if (message.phpClassPrefix != null && message.hasOwnProperty("phpClassPrefix"))
                         writer.uint32(/* id 40, wireType 2 =*/322).string(message.phpClassPrefix);
-                    if (message.phpNamespace != null && Object.hasOwnProperty.call(message, "phpNamespace"))
+                    if (message.phpNamespace != null && message.hasOwnProperty("phpNamespace"))
                         writer.uint32(/* id 41, wireType 2 =*/330).string(message.phpNamespace);
-                    if (message.phpGenericServices != null && Object.hasOwnProperty.call(message, "phpGenericServices"))
+                    if (message.phpGenericServices != null && message.hasOwnProperty("phpGenericServices"))
                         writer.uint32(/* id 42, wireType 0 =*/336).bool(message.phpGenericServices);
-                    if (message.phpMetadataNamespace != null && Object.hasOwnProperty.call(message, "phpMetadataNamespace"))
+                    if (message.phpMetadataNamespace != null && message.hasOwnProperty("phpMetadataNamespace"))
                         writer.uint32(/* id 44, wireType 2 =*/354).string(message.phpMetadataNamespace);
-                    if (message.rubyPackage != null && Object.hasOwnProperty.call(message, "rubyPackage"))
+                    if (message.rubyPackage != null && message.hasOwnProperty("rubyPackage"))
                         writer.uint32(/* id 45, wireType 2 =*/362).string(message.rubyPackage);
                     if (message.uninterpretedOption != null && message.uninterpretedOption.length)
                         for (var i = 0; i < message.uninterpretedOption.length; ++i)
@@ -33940,7 +33940,7 @@
                 /**
                  * OptimizeMode enum.
                  * @name google.protobuf.FileOptions.OptimizeMode
-                 * @enum {number}
+                 * @enum {string}
                  * @property {number} SPEED=1 SPEED value
                  * @property {number} CODE_SIZE=2 CODE_SIZE value
                  * @property {number} LITE_RUNTIME=3 LITE_RUNTIME value
@@ -34058,18 +34058,18 @@
                 MessageOptions.encode = function encode(message, writer) {
                     if (!writer)
                         writer = $Writer.create();
-                    if (message.messageSetWireFormat != null && Object.hasOwnProperty.call(message, "messageSetWireFormat"))
+                    if (message.messageSetWireFormat != null && message.hasOwnProperty("messageSetWireFormat"))
                         writer.uint32(/* id 1, wireType 0 =*/8).bool(message.messageSetWireFormat);
-                    if (message.noStandardDescriptorAccessor != null && Object.hasOwnProperty.call(message, "noStandardDescriptorAccessor"))
+                    if (message.noStandardDescriptorAccessor != null && message.hasOwnProperty("noStandardDescriptorAccessor"))
                         writer.uint32(/* id 2, wireType 0 =*/16).bool(message.noStandardDescriptorAccessor);
-                    if (message.deprecated != null && Object.hasOwnProperty.call(message, "deprecated"))
+                    if (message.deprecated != null && message.hasOwnProperty("deprecated"))
                         writer.uint32(/* id 3, wireType 0 =*/24).bool(message.deprecated);
-                    if (message.mapEntry != null && Object.hasOwnProperty.call(message, "mapEntry"))
+                    if (message.mapEntry != null && message.hasOwnProperty("mapEntry"))
                         writer.uint32(/* id 7, wireType 0 =*/56).bool(message.mapEntry);
                     if (message.uninterpretedOption != null && message.uninterpretedOption.length)
                         for (var i = 0; i < message.uninterpretedOption.length; ++i)
                             $root.google.protobuf.UninterpretedOption.encode(message.uninterpretedOption[i], writer.uint32(/* id 999, wireType 2 =*/7994).fork()).ldelim();
-                    if (message[".google.api.resource"] != null && Object.hasOwnProperty.call(message, ".google.api.resource"))
+                    if (message[".google.api.resource"] != null && message.hasOwnProperty(".google.api.resource"))
                         $root.google.api.ResourceDescriptor.encode(message[".google.api.resource"], writer.uint32(/* id 1053, wireType 2 =*/8426).fork()).ldelim();
                     return writer;
                 };
@@ -34411,17 +34411,17 @@
                 FieldOptions.encode = function encode(message, writer) {
                     if (!writer)
                         writer = $Writer.create();
-                    if (message.ctype != null && Object.hasOwnProperty.call(message, "ctype"))
+                    if (message.ctype != null && message.hasOwnProperty("ctype"))
                         writer.uint32(/* id 1, wireType 0 =*/8).int32(message.ctype);
-                    if (message.packed != null && Object.hasOwnProperty.call(message, "packed"))
+                    if (message.packed != null && message.hasOwnProperty("packed"))
                         writer.uint32(/* id 2, wireType 0 =*/16).bool(message.packed);
-                    if (message.deprecated != null && Object.hasOwnProperty.call(message, "deprecated"))
+                    if (message.deprecated != null && message.hasOwnProperty("deprecated"))
                         writer.uint32(/* id 3, wireType 0 =*/24).bool(message.deprecated);
-                    if (message.lazy != null && Object.hasOwnProperty.call(message, "lazy"))
+                    if (message.lazy != null && message.hasOwnProperty("lazy"))
                         writer.uint32(/* id 5, wireType 0 =*/40).bool(message.lazy);
-                    if (message.jstype != null && Object.hasOwnProperty.call(message, "jstype"))
+                    if (message.jstype != null && message.hasOwnProperty("jstype"))
                         writer.uint32(/* id 6, wireType 0 =*/48).int32(message.jstype);
-                    if (message.weak != null && Object.hasOwnProperty.call(message, "weak"))
+                    if (message.weak != null && message.hasOwnProperty("weak"))
                         writer.uint32(/* id 10, wireType 0 =*/80).bool(message.weak);
                     if (message.uninterpretedOption != null && message.uninterpretedOption.length)
                         for (var i = 0; i < message.uninterpretedOption.length; ++i)
@@ -34432,7 +34432,7 @@
                             writer.int32(message[".google.api.fieldBehavior"][i]);
                         writer.ldelim();
                     }
-                    if (message[".google.api.resourceReference"] != null && Object.hasOwnProperty.call(message, ".google.api.resourceReference"))
+                    if (message[".google.api.resourceReference"] != null && message.hasOwnProperty(".google.api.resourceReference"))
                         $root.google.api.ResourceReference.encode(message[".google.api.resourceReference"], writer.uint32(/* id 1055, wireType 2 =*/8442).fork()).ldelim();
                     return writer;
                 };
@@ -34768,7 +34768,7 @@
                 /**
                  * CType enum.
                  * @name google.protobuf.FieldOptions.CType
-                 * @enum {number}
+                 * @enum {string}
                  * @property {number} STRING=0 STRING value
                  * @property {number} CORD=1 CORD value
                  * @property {number} STRING_PIECE=2 STRING_PIECE value
@@ -34784,7 +34784,7 @@
                 /**
                  * JSType enum.
                  * @name google.protobuf.FieldOptions.JSType
-                 * @enum {number}
+                 * @enum {string}
                  * @property {number} JS_NORMAL=0 JS_NORMAL value
                  * @property {number} JS_STRING=1 JS_STRING value
                  * @property {number} JS_NUMBER=2 JS_NUMBER value
@@ -35083,9 +35083,9 @@
                 EnumOptions.encode = function encode(message, writer) {
                     if (!writer)
                         writer = $Writer.create();
-                    if (message.allowAlias != null && Object.hasOwnProperty.call(message, "allowAlias"))
+                    if (message.allowAlias != null && message.hasOwnProperty("allowAlias"))
                         writer.uint32(/* id 2, wireType 0 =*/16).bool(message.allowAlias);
-                    if (message.deprecated != null && Object.hasOwnProperty.call(message, "deprecated"))
+                    if (message.deprecated != null && message.hasOwnProperty("deprecated"))
                         writer.uint32(/* id 3, wireType 0 =*/24).bool(message.deprecated);
                     if (message.uninterpretedOption != null && message.uninterpretedOption.length)
                         for (var i = 0; i < message.uninterpretedOption.length; ++i)
@@ -35328,7 +35328,7 @@
                 EnumValueOptions.encode = function encode(message, writer) {
                     if (!writer)
                         writer = $Writer.create();
-                    if (message.deprecated != null && Object.hasOwnProperty.call(message, "deprecated"))
+                    if (message.deprecated != null && message.hasOwnProperty("deprecated"))
                         writer.uint32(/* id 1, wireType 0 =*/8).bool(message.deprecated);
                     if (message.uninterpretedOption != null && message.uninterpretedOption.length)
                         for (var i = 0; i < message.uninterpretedOption.length; ++i)
@@ -35577,14 +35577,14 @@
                 ServiceOptions.encode = function encode(message, writer) {
                     if (!writer)
                         writer = $Writer.create();
-                    if (message.deprecated != null && Object.hasOwnProperty.call(message, "deprecated"))
+                    if (message.deprecated != null && message.hasOwnProperty("deprecated"))
                         writer.uint32(/* id 33, wireType 0 =*/264).bool(message.deprecated);
                     if (message.uninterpretedOption != null && message.uninterpretedOption.length)
                         for (var i = 0; i < message.uninterpretedOption.length; ++i)
                             $root.google.protobuf.UninterpretedOption.encode(message.uninterpretedOption[i], writer.uint32(/* id 999, wireType 2 =*/7994).fork()).ldelim();
-                    if (message[".google.api.defaultHost"] != null && Object.hasOwnProperty.call(message, ".google.api.defaultHost"))
+                    if (message[".google.api.defaultHost"] != null && message.hasOwnProperty(".google.api.defaultHost"))
                         writer.uint32(/* id 1049, wireType 2 =*/8394).string(message[".google.api.defaultHost"]);
-                    if (message[".google.api.oauthScopes"] != null && Object.hasOwnProperty.call(message, ".google.api.oauthScopes"))
+                    if (message[".google.api.oauthScopes"] != null && message.hasOwnProperty(".google.api.oauthScopes"))
                         writer.uint32(/* id 1050, wireType 2 =*/8402).string(message[".google.api.oauthScopes"]);
                     return writer;
                 };
@@ -35872,19 +35872,19 @@
                 MethodOptions.encode = function encode(message, writer) {
                     if (!writer)
                         writer = $Writer.create();
-                    if (message.deprecated != null && Object.hasOwnProperty.call(message, "deprecated"))
+                    if (message.deprecated != null && message.hasOwnProperty("deprecated"))
                         writer.uint32(/* id 33, wireType 0 =*/264).bool(message.deprecated);
-                    if (message.idempotencyLevel != null && Object.hasOwnProperty.call(message, "idempotencyLevel"))
+                    if (message.idempotencyLevel != null && message.hasOwnProperty("idempotencyLevel"))
                         writer.uint32(/* id 34, wireType 0 =*/272).int32(message.idempotencyLevel);
                     if (message.uninterpretedOption != null && message.uninterpretedOption.length)
                         for (var i = 0; i < message.uninterpretedOption.length; ++i)
                             $root.google.protobuf.UninterpretedOption.encode(message.uninterpretedOption[i], writer.uint32(/* id 999, wireType 2 =*/7994).fork()).ldelim();
-                    if (message[".google.longrunning.operationInfo"] != null && Object.hasOwnProperty.call(message, ".google.longrunning.operationInfo"))
+                    if (message[".google.longrunning.operationInfo"] != null && message.hasOwnProperty(".google.longrunning.operationInfo"))
                         $root.google.longrunning.OperationInfo.encode(message[".google.longrunning.operationInfo"], writer.uint32(/* id 1049, wireType 2 =*/8394).fork()).ldelim();
                     if (message[".google.api.methodSignature"] != null && message[".google.api.methodSignature"].length)
                         for (var i = 0; i < message[".google.api.methodSignature"].length; ++i)
                             writer.uint32(/* id 1051, wireType 2 =*/8410).string(message[".google.api.methodSignature"][i]);
-                    if (message[".google.api.http"] != null && Object.hasOwnProperty.call(message, ".google.api.http"))
+                    if (message[".google.api.http"] != null && message.hasOwnProperty(".google.api.http"))
                         $root.google.api.HttpRule.encode(message[".google.api.http"], writer.uint32(/* id 72295728, wireType 2 =*/578365826).fork()).ldelim();
                     return writer;
                 };
@@ -36134,7 +36134,7 @@
                 /**
                  * IdempotencyLevel enum.
                  * @name google.protobuf.MethodOptions.IdempotencyLevel
-                 * @enum {number}
+                 * @enum {string}
                  * @property {number} IDEMPOTENCY_UNKNOWN=0 IDEMPOTENCY_UNKNOWN value
                  * @property {number} NO_SIDE_EFFECTS=1 NO_SIDE_EFFECTS value
                  * @property {number} IDEMPOTENT=2 IDEMPOTENT value
@@ -36264,17 +36264,17 @@
                     if (message.name != null && message.name.length)
                         for (var i = 0; i < message.name.length; ++i)
                             $root.google.protobuf.UninterpretedOption.NamePart.encode(message.name[i], writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
-                    if (message.identifierValue != null && Object.hasOwnProperty.call(message, "identifierValue"))
+                    if (message.identifierValue != null && message.hasOwnProperty("identifierValue"))
                         writer.uint32(/* id 3, wireType 2 =*/26).string(message.identifierValue);
-                    if (message.positiveIntValue != null && Object.hasOwnProperty.call(message, "positiveIntValue"))
+                    if (message.positiveIntValue != null && message.hasOwnProperty("positiveIntValue"))
                         writer.uint32(/* id 4, wireType 0 =*/32).uint64(message.positiveIntValue);
-                    if (message.negativeIntValue != null && Object.hasOwnProperty.call(message, "negativeIntValue"))
+                    if (message.negativeIntValue != null && message.hasOwnProperty("negativeIntValue"))
                         writer.uint32(/* id 5, wireType 0 =*/40).int64(message.negativeIntValue);
-                    if (message.doubleValue != null && Object.hasOwnProperty.call(message, "doubleValue"))
+                    if (message.doubleValue != null && message.hasOwnProperty("doubleValue"))
                         writer.uint32(/* id 6, wireType 1 =*/49).double(message.doubleValue);
-                    if (message.stringValue != null && Object.hasOwnProperty.call(message, "stringValue"))
+                    if (message.stringValue != null && message.hasOwnProperty("stringValue"))
                         writer.uint32(/* id 7, wireType 2 =*/58).bytes(message.stringValue);
-                    if (message.aggregateValue != null && Object.hasOwnProperty.call(message, "aggregateValue"))
+                    if (message.aggregateValue != null && message.hasOwnProperty("aggregateValue"))
                         writer.uint32(/* id 8, wireType 2 =*/66).string(message.aggregateValue);
                     return writer;
                 };
@@ -37051,9 +37051,9 @@
                                 writer.int32(message.span[i]);
                             writer.ldelim();
                         }
-                        if (message.leadingComments != null && Object.hasOwnProperty.call(message, "leadingComments"))
+                        if (message.leadingComments != null && message.hasOwnProperty("leadingComments"))
                             writer.uint32(/* id 3, wireType 2 =*/26).string(message.leadingComments);
-                        if (message.trailingComments != null && Object.hasOwnProperty.call(message, "trailingComments"))
+                        if (message.trailingComments != null && message.hasOwnProperty("trailingComments"))
                             writer.uint32(/* id 4, wireType 2 =*/34).string(message.trailingComments);
                         if (message.leadingDetachedComments != null && message.leadingDetachedComments.length)
                             for (var i = 0; i < message.leadingDetachedComments.length; ++i)
@@ -37584,11 +37584,11 @@
                                 writer.int32(message.path[i]);
                             writer.ldelim();
                         }
-                        if (message.sourceFile != null && Object.hasOwnProperty.call(message, "sourceFile"))
+                        if (message.sourceFile != null && message.hasOwnProperty("sourceFile"))
                             writer.uint32(/* id 2, wireType 2 =*/18).string(message.sourceFile);
-                        if (message.begin != null && Object.hasOwnProperty.call(message, "begin"))
+                        if (message.begin != null && message.hasOwnProperty("begin"))
                             writer.uint32(/* id 3, wireType 0 =*/24).int32(message.begin);
-                        if (message.end != null && Object.hasOwnProperty.call(message, "end"))
+                        if (message.end != null && message.hasOwnProperty("end"))
                             writer.uint32(/* id 4, wireType 0 =*/32).int32(message.end);
                         return writer;
                     };
@@ -37841,9 +37841,9 @@
                 Timestamp.encode = function encode(message, writer) {
                     if (!writer)
                         writer = $Writer.create();
-                    if (message.seconds != null && Object.hasOwnProperty.call(message, "seconds"))
+                    if (message.seconds != null && message.hasOwnProperty("seconds"))
                         writer.uint32(/* id 1, wireType 0 =*/8).int64(message.seconds);
-                    if (message.nanos != null && Object.hasOwnProperty.call(message, "nanos"))
+                    if (message.nanos != null && message.hasOwnProperty("nanos"))
                         writer.uint32(/* id 2, wireType 0 =*/16).int32(message.nanos);
                     return writer;
                 };
@@ -38065,9 +38065,9 @@
                 Any.encode = function encode(message, writer) {
                     if (!writer)
                         writer = $Writer.create();
-                    if (message.type_url != null && Object.hasOwnProperty.call(message, "type_url"))
+                    if (message.type_url != null && message.hasOwnProperty("type_url"))
                         writer.uint32(/* id 1, wireType 2 =*/10).string(message.type_url);
-                    if (message.value != null && Object.hasOwnProperty.call(message, "value"))
+                    if (message.value != null && message.hasOwnProperty("value"))
                         writer.uint32(/* id 2, wireType 2 =*/18).bytes(message.value);
                     return writer;
                 };
@@ -38284,9 +38284,9 @@
                 Duration.encode = function encode(message, writer) {
                     if (!writer)
                         writer = $Writer.create();
-                    if (message.seconds != null && Object.hasOwnProperty.call(message, "seconds"))
+                    if (message.seconds != null && message.hasOwnProperty("seconds"))
                         writer.uint32(/* id 1, wireType 0 =*/8).int64(message.seconds);
-                    if (message.nanos != null && Object.hasOwnProperty.call(message, "nanos"))
+                    if (message.nanos != null && message.hasOwnProperty("nanos"))
                         writer.uint32(/* id 2, wireType 0 =*/16).int32(message.nanos);
                     return writer;
                 };
@@ -38862,7 +38862,7 @@
                 DoubleValue.encode = function encode(message, writer) {
                     if (!writer)
                         writer = $Writer.create();
-                    if (message.value != null && Object.hasOwnProperty.call(message, "value"))
+                    if (message.value != null && message.hasOwnProperty("value"))
                         writer.uint32(/* id 1, wireType 1 =*/9).double(message.value);
                     return writer;
                 };
@@ -39049,7 +39049,7 @@
                 FloatValue.encode = function encode(message, writer) {
                     if (!writer)
                         writer = $Writer.create();
-                    if (message.value != null && Object.hasOwnProperty.call(message, "value"))
+                    if (message.value != null && message.hasOwnProperty("value"))
                         writer.uint32(/* id 1, wireType 5 =*/13).float(message.value);
                     return writer;
                 };
@@ -39236,7 +39236,7 @@
                 Int64Value.encode = function encode(message, writer) {
                     if (!writer)
                         writer = $Writer.create();
-                    if (message.value != null && Object.hasOwnProperty.call(message, "value"))
+                    if (message.value != null && message.hasOwnProperty("value"))
                         writer.uint32(/* id 1, wireType 0 =*/8).int64(message.value);
                     return writer;
                 };
@@ -39437,7 +39437,7 @@
                 UInt64Value.encode = function encode(message, writer) {
                     if (!writer)
                         writer = $Writer.create();
-                    if (message.value != null && Object.hasOwnProperty.call(message, "value"))
+                    if (message.value != null && message.hasOwnProperty("value"))
                         writer.uint32(/* id 1, wireType 0 =*/8).uint64(message.value);
                     return writer;
                 };
@@ -39638,7 +39638,7 @@
                 Int32Value.encode = function encode(message, writer) {
                     if (!writer)
                         writer = $Writer.create();
-                    if (message.value != null && Object.hasOwnProperty.call(message, "value"))
+                    if (message.value != null && message.hasOwnProperty("value"))
                         writer.uint32(/* id 1, wireType 0 =*/8).int32(message.value);
                     return writer;
                 };
@@ -39825,7 +39825,7 @@
                 UInt32Value.encode = function encode(message, writer) {
                     if (!writer)
                         writer = $Writer.create();
-                    if (message.value != null && Object.hasOwnProperty.call(message, "value"))
+                    if (message.value != null && message.hasOwnProperty("value"))
                         writer.uint32(/* id 1, wireType 0 =*/8).uint32(message.value);
                     return writer;
                 };
@@ -40012,7 +40012,7 @@
                 BoolValue.encode = function encode(message, writer) {
                     if (!writer)
                         writer = $Writer.create();
-                    if (message.value != null && Object.hasOwnProperty.call(message, "value"))
+                    if (message.value != null && message.hasOwnProperty("value"))
                         writer.uint32(/* id 1, wireType 0 =*/8).bool(message.value);
                     return writer;
                 };
@@ -40199,7 +40199,7 @@
                 StringValue.encode = function encode(message, writer) {
                     if (!writer)
                         writer = $Writer.create();
-                    if (message.value != null && Object.hasOwnProperty.call(message, "value"))
+                    if (message.value != null && message.hasOwnProperty("value"))
                         writer.uint32(/* id 1, wireType 2 =*/10).string(message.value);
                     return writer;
                 };
@@ -40386,7 +40386,7 @@
                 BytesValue.encode = function encode(message, writer) {
                     if (!writer)
                         writer = $Writer.create();
-                    if (message.value != null && Object.hasOwnProperty.call(message, "value"))
+                    if (message.value != null && message.hasOwnProperty("value"))
                         writer.uint32(/* id 1, wireType 2 =*/10).bytes(message.value);
                     return writer;
                 };
@@ -40746,9 +40746,9 @@
                     SetIamPolicyRequest.encode = function encode(message, writer) {
                         if (!writer)
                             writer = $Writer.create();
-                        if (message.resource != null && Object.hasOwnProperty.call(message, "resource"))
+                        if (message.resource != null && message.hasOwnProperty("resource"))
                             writer.uint32(/* id 1, wireType 2 =*/10).string(message.resource);
-                        if (message.policy != null && Object.hasOwnProperty.call(message, "policy"))
+                        if (message.policy != null && message.hasOwnProperty("policy"))
                             $root.google.iam.v1.Policy.encode(message.policy, writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
                         return writer;
                     };
@@ -40961,9 +40961,9 @@
                     GetIamPolicyRequest.encode = function encode(message, writer) {
                         if (!writer)
                             writer = $Writer.create();
-                        if (message.resource != null && Object.hasOwnProperty.call(message, "resource"))
+                        if (message.resource != null && message.hasOwnProperty("resource"))
                             writer.uint32(/* id 1, wireType 2 =*/10).string(message.resource);
-                        if (message.options != null && Object.hasOwnProperty.call(message, "options"))
+                        if (message.options != null && message.hasOwnProperty("options"))
                             $root.google.iam.v1.GetPolicyOptions.encode(message.options, writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
                         return writer;
                     };
@@ -41177,7 +41177,7 @@
                     TestIamPermissionsRequest.encode = function encode(message, writer) {
                         if (!writer)
                             writer = $Writer.create();
-                        if (message.resource != null && Object.hasOwnProperty.call(message, "resource"))
+                        if (message.resource != null && message.hasOwnProperty("resource"))
                             writer.uint32(/* id 1, wireType 2 =*/10).string(message.resource);
                         if (message.permissions != null && message.permissions.length)
                             for (var i = 0; i < message.permissions.length; ++i)
@@ -41596,7 +41596,7 @@
                     GetPolicyOptions.encode = function encode(message, writer) {
                         if (!writer)
                             writer = $Writer.create();
-                        if (message.requestedPolicyVersion != null && Object.hasOwnProperty.call(message, "requestedPolicyVersion"))
+                        if (message.requestedPolicyVersion != null && message.hasOwnProperty("requestedPolicyVersion"))
                             writer.uint32(/* id 1, wireType 0 =*/8).int32(message.requestedPolicyVersion);
                         return writer;
                     };
@@ -41802,9 +41802,9 @@
                     Policy.encode = function encode(message, writer) {
                         if (!writer)
                             writer = $Writer.create();
-                        if (message.version != null && Object.hasOwnProperty.call(message, "version"))
+                        if (message.version != null && message.hasOwnProperty("version"))
                             writer.uint32(/* id 1, wireType 0 =*/8).int32(message.version);
-                        if (message.etag != null && Object.hasOwnProperty.call(message, "etag"))
+                        if (message.etag != null && message.hasOwnProperty("etag"))
                             writer.uint32(/* id 3, wireType 2 =*/26).bytes(message.etag);
                         if (message.bindings != null && message.bindings.length)
                             for (var i = 0; i < message.bindings.length; ++i)
@@ -42065,12 +42065,12 @@
                     Binding.encode = function encode(message, writer) {
                         if (!writer)
                             writer = $Writer.create();
-                        if (message.role != null && Object.hasOwnProperty.call(message, "role"))
+                        if (message.role != null && message.hasOwnProperty("role"))
                             writer.uint32(/* id 1, wireType 2 =*/10).string(message.role);
                         if (message.members != null && message.members.length)
                             for (var i = 0; i < message.members.length; ++i)
                                 writer.uint32(/* id 2, wireType 2 =*/18).string(message.members[i]);
-                        if (message.condition != null && Object.hasOwnProperty.call(message, "condition"))
+                        if (message.condition != null && message.hasOwnProperty("condition"))
                             $root.google.type.Expr.encode(message.condition, writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
                         return writer;
                     };
@@ -42579,13 +42579,13 @@
                     BindingDelta.encode = function encode(message, writer) {
                         if (!writer)
                             writer = $Writer.create();
-                        if (message.action != null && Object.hasOwnProperty.call(message, "action"))
+                        if (message.action != null && message.hasOwnProperty("action"))
                             writer.uint32(/* id 1, wireType 0 =*/8).int32(message.action);
-                        if (message.role != null && Object.hasOwnProperty.call(message, "role"))
+                        if (message.role != null && message.hasOwnProperty("role"))
                             writer.uint32(/* id 2, wireType 2 =*/18).string(message.role);
-                        if (message.member != null && Object.hasOwnProperty.call(message, "member"))
+                        if (message.member != null && message.hasOwnProperty("member"))
                             writer.uint32(/* id 3, wireType 2 =*/26).string(message.member);
-                        if (message.condition != null && Object.hasOwnProperty.call(message, "condition"))
+                        if (message.condition != null && message.hasOwnProperty("condition"))
                             $root.google.type.Expr.encode(message.condition, writer.uint32(/* id 4, wireType 2 =*/34).fork()).ldelim();
                         return writer;
                     };
@@ -42773,7 +42773,7 @@
                     /**
                      * Action enum.
                      * @name google.iam.v1.BindingDelta.Action
-                     * @enum {number}
+                     * @enum {string}
                      * @property {number} ACTION_UNSPECIFIED=0 ACTION_UNSPECIFIED value
                      * @property {number} ADD=1 ADD value
                      * @property {number} REMOVE=2 REMOVE value
@@ -42872,13 +42872,13 @@
                     AuditConfigDelta.encode = function encode(message, writer) {
                         if (!writer)
                             writer = $Writer.create();
-                        if (message.action != null && Object.hasOwnProperty.call(message, "action"))
+                        if (message.action != null && message.hasOwnProperty("action"))
                             writer.uint32(/* id 1, wireType 0 =*/8).int32(message.action);
-                        if (message.service != null && Object.hasOwnProperty.call(message, "service"))
+                        if (message.service != null && message.hasOwnProperty("service"))
                             writer.uint32(/* id 2, wireType 2 =*/18).string(message.service);
-                        if (message.exemptedMember != null && Object.hasOwnProperty.call(message, "exemptedMember"))
+                        if (message.exemptedMember != null && message.hasOwnProperty("exemptedMember"))
                             writer.uint32(/* id 3, wireType 2 =*/26).string(message.exemptedMember);
-                        if (message.logType != null && Object.hasOwnProperty.call(message, "logType"))
+                        if (message.logType != null && message.hasOwnProperty("logType"))
                             writer.uint32(/* id 4, wireType 2 =*/34).string(message.logType);
                         return writer;
                     };
@@ -43061,7 +43061,7 @@
                     /**
                      * Action enum.
                      * @name google.iam.v1.AuditConfigDelta.Action
-                     * @enum {number}
+                     * @enum {string}
                      * @property {number} ACTION_UNSPECIFIED=0 ACTION_UNSPECIFIED value
                      * @property {number} ADD=1 ADD value
                      * @property {number} REMOVE=2 REMOVE value
@@ -43175,13 +43175,13 @@
                 Expr.encode = function encode(message, writer) {
                     if (!writer)
                         writer = $Writer.create();
-                    if (message.expression != null && Object.hasOwnProperty.call(message, "expression"))
+                    if (message.expression != null && message.hasOwnProperty("expression"))
                         writer.uint32(/* id 1, wireType 2 =*/10).string(message.expression);
-                    if (message.title != null && Object.hasOwnProperty.call(message, "title"))
+                    if (message.title != null && message.hasOwnProperty("title"))
                         writer.uint32(/* id 2, wireType 2 =*/18).string(message.title);
-                    if (message.description != null && Object.hasOwnProperty.call(message, "description"))
+                    if (message.description != null && message.hasOwnProperty("description"))
                         writer.uint32(/* id 3, wireType 2 =*/26).string(message.description);
-                    if (message.location != null && Object.hasOwnProperty.call(message, "location"))
+                    if (message.location != null && message.hasOwnProperty("location"))
                         writer.uint32(/* id 4, wireType 2 =*/34).string(message.location);
                     return writer;
                 };
@@ -43664,15 +43664,15 @@
                 Operation.encode = function encode(message, writer) {
                     if (!writer)
                         writer = $Writer.create();
-                    if (message.name != null && Object.hasOwnProperty.call(message, "name"))
+                    if (message.name != null && message.hasOwnProperty("name"))
                         writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
-                    if (message.metadata != null && Object.hasOwnProperty.call(message, "metadata"))
+                    if (message.metadata != null && message.hasOwnProperty("metadata"))
                         $root.google.protobuf.Any.encode(message.metadata, writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
-                    if (message.done != null && Object.hasOwnProperty.call(message, "done"))
+                    if (message.done != null && message.hasOwnProperty("done"))
                         writer.uint32(/* id 3, wireType 0 =*/24).bool(message.done);
-                    if (message.error != null && Object.hasOwnProperty.call(message, "error"))
+                    if (message.error != null && message.hasOwnProperty("error"))
                         $root.google.rpc.Status.encode(message.error, writer.uint32(/* id 4, wireType 2 =*/34).fork()).ldelim();
-                    if (message.response != null && Object.hasOwnProperty.call(message, "response"))
+                    if (message.response != null && message.hasOwnProperty("response"))
                         $root.google.protobuf.Any.encode(message.response, writer.uint32(/* id 5, wireType 2 =*/42).fork()).ldelim();
                     return writer;
                 };
@@ -43932,7 +43932,7 @@
                 GetOperationRequest.encode = function encode(message, writer) {
                     if (!writer)
                         writer = $Writer.create();
-                    if (message.name != null && Object.hasOwnProperty.call(message, "name"))
+                    if (message.name != null && message.hasOwnProperty("name"))
                         writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
                     return writer;
                 };
@@ -44146,13 +44146,13 @@
                 ListOperationsRequest.encode = function encode(message, writer) {
                     if (!writer)
                         writer = $Writer.create();
-                    if (message.filter != null && Object.hasOwnProperty.call(message, "filter"))
+                    if (message.filter != null && message.hasOwnProperty("filter"))
                         writer.uint32(/* id 1, wireType 2 =*/10).string(message.filter);
-                    if (message.pageSize != null && Object.hasOwnProperty.call(message, "pageSize"))
+                    if (message.pageSize != null && message.hasOwnProperty("pageSize"))
                         writer.uint32(/* id 2, wireType 0 =*/16).int32(message.pageSize);
-                    if (message.pageToken != null && Object.hasOwnProperty.call(message, "pageToken"))
+                    if (message.pageToken != null && message.hasOwnProperty("pageToken"))
                         writer.uint32(/* id 3, wireType 2 =*/26).string(message.pageToken);
-                    if (message.name != null && Object.hasOwnProperty.call(message, "name"))
+                    if (message.name != null && message.hasOwnProperty("name"))
                         writer.uint32(/* id 4, wireType 2 =*/34).string(message.name);
                     return writer;
                 };
@@ -44386,7 +44386,7 @@
                     if (message.operations != null && message.operations.length)
                         for (var i = 0; i < message.operations.length; ++i)
                             $root.google.longrunning.Operation.encode(message.operations[i], writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
-                    if (message.nextPageToken != null && Object.hasOwnProperty.call(message, "nextPageToken"))
+                    if (message.nextPageToken != null && message.hasOwnProperty("nextPageToken"))
                         writer.uint32(/* id 2, wireType 2 =*/18).string(message.nextPageToken);
                     return writer;
                 };
@@ -44604,7 +44604,7 @@
                 CancelOperationRequest.encode = function encode(message, writer) {
                     if (!writer)
                         writer = $Writer.create();
-                    if (message.name != null && Object.hasOwnProperty.call(message, "name"))
+                    if (message.name != null && message.hasOwnProperty("name"))
                         writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
                     return writer;
                 };
@@ -44791,7 +44791,7 @@
                 DeleteOperationRequest.encode = function encode(message, writer) {
                     if (!writer)
                         writer = $Writer.create();
-                    if (message.name != null && Object.hasOwnProperty.call(message, "name"))
+                    if (message.name != null && message.hasOwnProperty("name"))
                         writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
                     return writer;
                 };
@@ -44987,9 +44987,9 @@
                 WaitOperationRequest.encode = function encode(message, writer) {
                     if (!writer)
                         writer = $Writer.create();
-                    if (message.name != null && Object.hasOwnProperty.call(message, "name"))
+                    if (message.name != null && message.hasOwnProperty("name"))
                         writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
-                    if (message.timeout != null && Object.hasOwnProperty.call(message, "timeout"))
+                    if (message.timeout != null && message.hasOwnProperty("timeout"))
                         $root.google.protobuf.Duration.encode(message.timeout, writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
                     return writer;
                 };
@@ -45202,9 +45202,9 @@
                 OperationInfo.encode = function encode(message, writer) {
                     if (!writer)
                         writer = $Writer.create();
-                    if (message.responseType != null && Object.hasOwnProperty.call(message, "responseType"))
+                    if (message.responseType != null && message.hasOwnProperty("responseType"))
                         writer.uint32(/* id 1, wireType 2 =*/10).string(message.responseType);
-                    if (message.metadataType != null && Object.hasOwnProperty.call(message, "metadataType"))
+                    if (message.metadataType != null && message.hasOwnProperty("metadataType"))
                         writer.uint32(/* id 2, wireType 2 =*/18).string(message.metadataType);
                     return writer;
                 };
@@ -45434,9 +45434,9 @@
                 Status.encode = function encode(message, writer) {
                     if (!writer)
                         writer = $Writer.create();
-                    if (message.code != null && Object.hasOwnProperty.call(message, "code"))
+                    if (message.code != null && message.hasOwnProperty("code"))
                         writer.uint32(/* id 1, wireType 0 =*/8).int32(message.code);
-                    if (message.message != null && Object.hasOwnProperty.call(message, "message"))
+                    if (message.message != null && message.hasOwnProperty("message"))
                         writer.uint32(/* id 2, wireType 2 =*/18).string(message.message);
                     if (message.details != null && message.details.length)
                         for (var i = 0; i < message.details.length; ++i)

--- a/src/v2/bigtable_instance_admin_client.ts
+++ b/src/v2/bigtable_instance_admin_client.ts
@@ -32,7 +32,7 @@ import {Transform} from 'stream';
 import {RequestType} from 'google-gax/build/src/apitypes';
 import * as protos from '../../protos/protos';
 import * as gapicConfig from './bigtable_instance_admin_client_config.json';
-
+import {operationsProtos} from 'google-gax';
 const version = require('../../../package.json').version;
 
 /**
@@ -1675,6 +1675,42 @@ export class BigtableInstanceAdminClient {
     this.initialize();
     return this.innerApiCalls.createInstance(request, options, callback);
   }
+  /**
+   * Check the status of the long running operation returned by the createInstance() method.
+   * @param {String} name
+   *   The operation name that will be passed.
+   * @returns {Promise} - The promise which resolves to an object.
+   *   The decoded operation object has result and metadata field to get information from.
+   *
+   * @example:
+   *   const decodedOperation = await checkCreateInstanceProgress(name);
+   *   console.log(decodedOperation.result);
+   *   console.log(decodedOperation.done);
+   *   console.log(decodedOperation.metadata);
+   *
+   */
+  async checkCreateInstanceProgress(
+    name: string
+  ): Promise<
+    LROperation<
+      protos.google.bigtable.admin.v2.Instance,
+      protos.google.bigtable.admin.v2.CreateInstanceMetadata
+    >
+  > {
+    const request = new operationsProtos.google.longrunning.GetOperationRequest(
+      {name}
+    );
+    const [operation] = await this.operationsClient.getOperation(request);
+    const decodeOperation = new gax.Operation(
+      operation,
+      this.descriptors.longrunning.createInstance,
+      gax.createDefaultBackoffSettings()
+    );
+    return decodeOperation as LROperation<
+      protos.google.bigtable.admin.v2.Instance,
+      protos.google.bigtable.admin.v2.CreateInstanceMetadata
+    >;
+  }
   partialUpdateInstance(
     request: protos.google.bigtable.admin.v2.IPartialUpdateInstanceRequest,
     options?: gax.CallOptions
@@ -1776,6 +1812,42 @@ export class BigtableInstanceAdminClient {
     });
     this.initialize();
     return this.innerApiCalls.partialUpdateInstance(request, options, callback);
+  }
+  /**
+   * Check the status of the long running operation returned by the partialUpdateInstance() method.
+   * @param {String} name
+   *   The operation name that will be passed.
+   * @returns {Promise} - The promise which resolves to an object.
+   *   The decoded operation object has result and metadata field to get information from.
+   *
+   * @example:
+   *   const decodedOperation = await checkPartialUpdateInstanceProgress(name);
+   *   console.log(decodedOperation.result);
+   *   console.log(decodedOperation.done);
+   *   console.log(decodedOperation.metadata);
+   *
+   */
+  async checkPartialUpdateInstanceProgress(
+    name: string
+  ): Promise<
+    LROperation<
+      protos.google.bigtable.admin.v2.Instance,
+      protos.google.bigtable.admin.v2.UpdateInstanceMetadata
+    >
+  > {
+    const request = new operationsProtos.google.longrunning.GetOperationRequest(
+      {name}
+    );
+    const [operation] = await this.operationsClient.getOperation(request);
+    const decodeOperation = new gax.Operation(
+      operation,
+      this.descriptors.longrunning.partialUpdateInstance,
+      gax.createDefaultBackoffSettings()
+    );
+    return decodeOperation as LROperation<
+      protos.google.bigtable.admin.v2.Instance,
+      protos.google.bigtable.admin.v2.UpdateInstanceMetadata
+    >;
   }
   createCluster(
     request: protos.google.bigtable.admin.v2.ICreateClusterRequest,
@@ -1883,6 +1955,42 @@ export class BigtableInstanceAdminClient {
     });
     this.initialize();
     return this.innerApiCalls.createCluster(request, options, callback);
+  }
+  /**
+   * Check the status of the long running operation returned by the createCluster() method.
+   * @param {String} name
+   *   The operation name that will be passed.
+   * @returns {Promise} - The promise which resolves to an object.
+   *   The decoded operation object has result and metadata field to get information from.
+   *
+   * @example:
+   *   const decodedOperation = await checkCreateClusterProgress(name);
+   *   console.log(decodedOperation.result);
+   *   console.log(decodedOperation.done);
+   *   console.log(decodedOperation.metadata);
+   *
+   */
+  async checkCreateClusterProgress(
+    name: string
+  ): Promise<
+    LROperation<
+      protos.google.bigtable.admin.v2.Cluster,
+      protos.google.bigtable.admin.v2.CreateClusterMetadata
+    >
+  > {
+    const request = new operationsProtos.google.longrunning.GetOperationRequest(
+      {name}
+    );
+    const [operation] = await this.operationsClient.getOperation(request);
+    const decodeOperation = new gax.Operation(
+      operation,
+      this.descriptors.longrunning.createCluster,
+      gax.createDefaultBackoffSettings()
+    );
+    return decodeOperation as LROperation<
+      protos.google.bigtable.admin.v2.Cluster,
+      protos.google.bigtable.admin.v2.CreateClusterMetadata
+    >;
   }
   updateCluster(
     request: protos.google.bigtable.admin.v2.ICluster,
@@ -1998,6 +2106,42 @@ export class BigtableInstanceAdminClient {
     this.initialize();
     return this.innerApiCalls.updateCluster(request, options, callback);
   }
+  /**
+   * Check the status of the long running operation returned by the updateCluster() method.
+   * @param {String} name
+   *   The operation name that will be passed.
+   * @returns {Promise} - The promise which resolves to an object.
+   *   The decoded operation object has result and metadata field to get information from.
+   *
+   * @example:
+   *   const decodedOperation = await checkUpdateClusterProgress(name);
+   *   console.log(decodedOperation.result);
+   *   console.log(decodedOperation.done);
+   *   console.log(decodedOperation.metadata);
+   *
+   */
+  async checkUpdateClusterProgress(
+    name: string
+  ): Promise<
+    LROperation<
+      protos.google.bigtable.admin.v2.Cluster,
+      protos.google.bigtable.admin.v2.UpdateClusterMetadata
+    >
+  > {
+    const request = new operationsProtos.google.longrunning.GetOperationRequest(
+      {name}
+    );
+    const [operation] = await this.operationsClient.getOperation(request);
+    const decodeOperation = new gax.Operation(
+      operation,
+      this.descriptors.longrunning.updateCluster,
+      gax.createDefaultBackoffSettings()
+    );
+    return decodeOperation as LROperation<
+      protos.google.bigtable.admin.v2.Cluster,
+      protos.google.bigtable.admin.v2.UpdateClusterMetadata
+    >;
+  }
   updateAppProfile(
     request: protos.google.bigtable.admin.v2.IUpdateAppProfileRequest,
     options?: gax.CallOptions
@@ -2100,6 +2244,42 @@ export class BigtableInstanceAdminClient {
     });
     this.initialize();
     return this.innerApiCalls.updateAppProfile(request, options, callback);
+  }
+  /**
+   * Check the status of the long running operation returned by the updateAppProfile() method.
+   * @param {String} name
+   *   The operation name that will be passed.
+   * @returns {Promise} - The promise which resolves to an object.
+   *   The decoded operation object has result and metadata field to get information from.
+   *
+   * @example:
+   *   const decodedOperation = await checkUpdateAppProfileProgress(name);
+   *   console.log(decodedOperation.result);
+   *   console.log(decodedOperation.done);
+   *   console.log(decodedOperation.metadata);
+   *
+   */
+  async checkUpdateAppProfileProgress(
+    name: string
+  ): Promise<
+    LROperation<
+      protos.google.bigtable.admin.v2.AppProfile,
+      protos.google.bigtable.admin.v2.UpdateAppProfileMetadata
+    >
+  > {
+    const request = new operationsProtos.google.longrunning.GetOperationRequest(
+      {name}
+    );
+    const [operation] = await this.operationsClient.getOperation(request);
+    const decodeOperation = new gax.Operation(
+      operation,
+      this.descriptors.longrunning.updateAppProfile,
+      gax.createDefaultBackoffSettings()
+    );
+    return decodeOperation as LROperation<
+      protos.google.bigtable.admin.v2.AppProfile,
+      protos.google.bigtable.admin.v2.UpdateAppProfileMetadata
+    >;
   }
   listAppProfiles(
     request: protos.google.bigtable.admin.v2.IListAppProfilesRequest,

--- a/src/v2/bigtable_table_admin_client.ts
+++ b/src/v2/bigtable_table_admin_client.ts
@@ -32,7 +32,7 @@ import {Transform} from 'stream';
 import {RequestType} from 'google-gax/build/src/apitypes';
 import * as protos from '../../protos/protos';
 import * as gapicConfig from './bigtable_table_admin_client_config.json';
-
+import {operationsProtos} from 'google-gax';
 const version = require('../../../package.json').version;
 
 /**
@@ -1903,6 +1903,42 @@ export class BigtableTableAdminClient {
       callback
     );
   }
+  /**
+   * Check the status of the long running operation returned by the createTableFromSnapshot() method.
+   * @param {String} name
+   *   The operation name that will be passed.
+   * @returns {Promise} - The promise which resolves to an object.
+   *   The decoded operation object has result and metadata field to get information from.
+   *
+   * @example:
+   *   const decodedOperation = await checkCreateTableFromSnapshotProgress(name);
+   *   console.log(decodedOperation.result);
+   *   console.log(decodedOperation.done);
+   *   console.log(decodedOperation.metadata);
+   *
+   */
+  async checkCreateTableFromSnapshotProgress(
+    name: string
+  ): Promise<
+    LROperation<
+      protos.google.bigtable.admin.v2.Table,
+      protos.google.bigtable.admin.v2.CreateTableFromSnapshotMetadata
+    >
+  > {
+    const request = new operationsProtos.google.longrunning.GetOperationRequest(
+      {name}
+    );
+    const [operation] = await this.operationsClient.getOperation(request);
+    const decodeOperation = new gax.Operation(
+      operation,
+      this.descriptors.longrunning.createTableFromSnapshot,
+      gax.createDefaultBackoffSettings()
+    );
+    return decodeOperation as LROperation<
+      protos.google.bigtable.admin.v2.Table,
+      protos.google.bigtable.admin.v2.CreateTableFromSnapshotMetadata
+    >;
+  }
   snapshotTable(
     request: protos.google.bigtable.admin.v2.ISnapshotTableRequest,
     options?: gax.CallOptions
@@ -2026,6 +2062,42 @@ export class BigtableTableAdminClient {
     this.initialize();
     return this.innerApiCalls.snapshotTable(request, options, callback);
   }
+  /**
+   * Check the status of the long running operation returned by the snapshotTable() method.
+   * @param {String} name
+   *   The operation name that will be passed.
+   * @returns {Promise} - The promise which resolves to an object.
+   *   The decoded operation object has result and metadata field to get information from.
+   *
+   * @example:
+   *   const decodedOperation = await checkSnapshotTableProgress(name);
+   *   console.log(decodedOperation.result);
+   *   console.log(decodedOperation.done);
+   *   console.log(decodedOperation.metadata);
+   *
+   */
+  async checkSnapshotTableProgress(
+    name: string
+  ): Promise<
+    LROperation<
+      protos.google.bigtable.admin.v2.Snapshot,
+      protos.google.bigtable.admin.v2.SnapshotTableMetadata
+    >
+  > {
+    const request = new operationsProtos.google.longrunning.GetOperationRequest(
+      {name}
+    );
+    const [operation] = await this.operationsClient.getOperation(request);
+    const decodeOperation = new gax.Operation(
+      operation,
+      this.descriptors.longrunning.snapshotTable,
+      gax.createDefaultBackoffSettings()
+    );
+    return decodeOperation as LROperation<
+      protos.google.bigtable.admin.v2.Snapshot,
+      protos.google.bigtable.admin.v2.SnapshotTableMetadata
+    >;
+  }
   createBackup(
     request: protos.google.bigtable.admin.v2.ICreateBackupRequest,
     options?: gax.CallOptions
@@ -2142,6 +2214,42 @@ export class BigtableTableAdminClient {
     this.initialize();
     return this.innerApiCalls.createBackup(request, options, callback);
   }
+  /**
+   * Check the status of the long running operation returned by the createBackup() method.
+   * @param {String} name
+   *   The operation name that will be passed.
+   * @returns {Promise} - The promise which resolves to an object.
+   *   The decoded operation object has result and metadata field to get information from.
+   *
+   * @example:
+   *   const decodedOperation = await checkCreateBackupProgress(name);
+   *   console.log(decodedOperation.result);
+   *   console.log(decodedOperation.done);
+   *   console.log(decodedOperation.metadata);
+   *
+   */
+  async checkCreateBackupProgress(
+    name: string
+  ): Promise<
+    LROperation<
+      protos.google.bigtable.admin.v2.Backup,
+      protos.google.bigtable.admin.v2.CreateBackupMetadata
+    >
+  > {
+    const request = new operationsProtos.google.longrunning.GetOperationRequest(
+      {name}
+    );
+    const [operation] = await this.operationsClient.getOperation(request);
+    const decodeOperation = new gax.Operation(
+      operation,
+      this.descriptors.longrunning.createBackup,
+      gax.createDefaultBackoffSettings()
+    );
+    return decodeOperation as LROperation<
+      protos.google.bigtable.admin.v2.Backup,
+      protos.google.bigtable.admin.v2.CreateBackupMetadata
+    >;
+  }
   restoreTable(
     request: protos.google.bigtable.admin.v2.IRestoreTableRequest,
     options?: gax.CallOptions
@@ -2256,6 +2364,42 @@ export class BigtableTableAdminClient {
     });
     this.initialize();
     return this.innerApiCalls.restoreTable(request, options, callback);
+  }
+  /**
+   * Check the status of the long running operation returned by the restoreTable() method.
+   * @param {String} name
+   *   The operation name that will be passed.
+   * @returns {Promise} - The promise which resolves to an object.
+   *   The decoded operation object has result and metadata field to get information from.
+   *
+   * @example:
+   *   const decodedOperation = await checkRestoreTableProgress(name);
+   *   console.log(decodedOperation.result);
+   *   console.log(decodedOperation.done);
+   *   console.log(decodedOperation.metadata);
+   *
+   */
+  async checkRestoreTableProgress(
+    name: string
+  ): Promise<
+    LROperation<
+      protos.google.bigtable.admin.v2.Table,
+      protos.google.bigtable.admin.v2.RestoreTableMetadata
+    >
+  > {
+    const request = new operationsProtos.google.longrunning.GetOperationRequest(
+      {name}
+    );
+    const [operation] = await this.operationsClient.getOperation(request);
+    const decodeOperation = new gax.Operation(
+      operation,
+      this.descriptors.longrunning.restoreTable,
+      gax.createDefaultBackoffSettings()
+    );
+    return decodeOperation as LROperation<
+      protos.google.bigtable.admin.v2.Table,
+      protos.google.bigtable.admin.v2.RestoreTableMetadata
+    >;
   }
   listTables(
     request: protos.google.bigtable.admin.v2.IListTablesRequest,

--- a/synth.metadata
+++ b/synth.metadata
@@ -3,23 +3,15 @@
     {
       "git": {
         "name": ".",
-        "remote": "https://github.com/googleapis/nodejs-bigtable.git",
-        "sha": "e08a191d12bd680576f7aa09f2d316f1418d49e1"
-      }
-    },
-    {
-      "git": {
-        "name": "googleapis",
-        "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "42ee97c1b93a0e3759bbba3013da309f670a90ab",
-        "internalRef": "307114445"
+        "remote": "git@github.com:googleapis/nodejs-bigtable.git",
+        "sha": "998ec842344dd2ca79736bc14dd4fa4c4b72eb25"
       }
     },
     {
       "git": {
         "name": "synthtool",
         "remote": "https://github.com/googleapis/synthtool.git",
-        "sha": "19465d3ec5e5acdb01521d8f3bddd311bcbee28d"
+        "sha": "ab883569eb0257bbf16a6d825fd018b3adde3912"
       }
     }
   ],

--- a/test/gapic_bigtable_instance_admin_v2.ts
+++ b/test/gapic_bigtable_instance_admin_v2.ts
@@ -25,7 +25,7 @@ import * as bigtableinstanceadminModule from '../src';
 
 import {PassThrough} from 'stream';
 
-import {protobuf, LROperation} from 'google-gax';
+import {protobuf, LROperation, operationsProtos} from 'google-gax';
 
 function generateSampleMessage<T extends object>(instance: T) {
   const filledObject = (instance.constructor as typeof protobuf.Message).toObject(
@@ -348,9 +348,7 @@ describe('v2.BigtableInstanceAdminClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.getInstance(request);
-      }, expectedError);
+      await assert.rejects(client.getInstance(request), expectedError);
       assert(
         (client.innerApiCalls.getInstance as SinonStub)
           .getCall(0)
@@ -468,9 +466,7 @@ describe('v2.BigtableInstanceAdminClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.listInstances(request);
-      }, expectedError);
+      await assert.rejects(client.listInstances(request), expectedError);
       assert(
         (client.innerApiCalls.listInstances as SinonStub)
           .getCall(0)
@@ -588,9 +584,7 @@ describe('v2.BigtableInstanceAdminClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.updateInstance(request);
-      }, expectedError);
+      await assert.rejects(client.updateInstance(request), expectedError);
       assert(
         (client.innerApiCalls.updateInstance as SinonStub)
           .getCall(0)
@@ -708,9 +702,7 @@ describe('v2.BigtableInstanceAdminClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.deleteInstance(request);
-      }, expectedError);
+      await assert.rejects(client.deleteInstance(request), expectedError);
       assert(
         (client.innerApiCalls.deleteInstance as SinonStub)
           .getCall(0)
@@ -828,9 +820,7 @@ describe('v2.BigtableInstanceAdminClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.getCluster(request);
-      }, expectedError);
+      await assert.rejects(client.getCluster(request), expectedError);
       assert(
         (client.innerApiCalls.getCluster as SinonStub)
           .getCall(0)
@@ -948,9 +938,7 @@ describe('v2.BigtableInstanceAdminClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.listClusters(request);
-      }, expectedError);
+      await assert.rejects(client.listClusters(request), expectedError);
       assert(
         (client.innerApiCalls.listClusters as SinonStub)
           .getCall(0)
@@ -1068,9 +1056,7 @@ describe('v2.BigtableInstanceAdminClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.deleteCluster(request);
-      }, expectedError);
+      await assert.rejects(client.deleteCluster(request), expectedError);
       assert(
         (client.innerApiCalls.deleteCluster as SinonStub)
           .getCall(0)
@@ -1188,9 +1174,7 @@ describe('v2.BigtableInstanceAdminClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.createAppProfile(request);
-      }, expectedError);
+      await assert.rejects(client.createAppProfile(request), expectedError);
       assert(
         (client.innerApiCalls.createAppProfile as SinonStub)
           .getCall(0)
@@ -1308,9 +1292,7 @@ describe('v2.BigtableInstanceAdminClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.getAppProfile(request);
-      }, expectedError);
+      await assert.rejects(client.getAppProfile(request), expectedError);
       assert(
         (client.innerApiCalls.getAppProfile as SinonStub)
           .getCall(0)
@@ -1428,9 +1410,7 @@ describe('v2.BigtableInstanceAdminClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.deleteAppProfile(request);
-      }, expectedError);
+      await assert.rejects(client.deleteAppProfile(request), expectedError);
       assert(
         (client.innerApiCalls.deleteAppProfile as SinonStub)
           .getCall(0)
@@ -1548,9 +1528,7 @@ describe('v2.BigtableInstanceAdminClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.getIamPolicy(request);
-      }, expectedError);
+      await assert.rejects(client.getIamPolicy(request), expectedError);
       assert(
         (client.innerApiCalls.getIamPolicy as SinonStub)
           .getCall(0)
@@ -1668,9 +1646,7 @@ describe('v2.BigtableInstanceAdminClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.setIamPolicy(request);
-      }, expectedError);
+      await assert.rejects(client.setIamPolicy(request), expectedError);
       assert(
         (client.innerApiCalls.setIamPolicy as SinonStub)
           .getCall(0)
@@ -1790,9 +1766,7 @@ describe('v2.BigtableInstanceAdminClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.testIamPermissions(request);
-      }, expectedError);
+      await assert.rejects(client.testIamPermissions(request), expectedError);
       assert(
         (client.innerApiCalls.testIamPermissions as SinonStub)
           .getCall(0)
@@ -1920,9 +1894,7 @@ describe('v2.BigtableInstanceAdminClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.createInstance(request);
-      }, expectedError);
+      await assert.rejects(client.createInstance(request), expectedError);
       assert(
         (client.innerApiCalls.createInstance as SinonStub)
           .getCall(0)
@@ -1957,14 +1929,57 @@ describe('v2.BigtableInstanceAdminClient', () => {
         expectedError
       );
       const [operation] = await client.createInstance(request);
-      await assert.rejects(async () => {
-        await operation.promise();
-      }, expectedError);
+      await assert.rejects(operation.promise(), expectedError);
       assert(
         (client.innerApiCalls.createInstance as SinonStub)
           .getCall(0)
           .calledWith(request, expectedOptions, undefined)
       );
+    });
+
+    it('invokes checkCreateInstanceProgress without error', async () => {
+      const client = new bigtableinstanceadminModule.v2.BigtableInstanceAdminClient(
+        {
+          credentials: {client_email: 'bogus', private_key: 'bogus'},
+          projectId: 'bogus',
+        }
+      );
+      client.initialize();
+      const expectedResponse = generateSampleMessage(
+        new operationsProtos.google.longrunning.Operation()
+      );
+      expectedResponse.name = 'test';
+      expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
+      expectedResponse.metadata = {type_url: 'url', value: Buffer.from('')};
+
+      client.operationsClient.getOperation = stubSimpleCall(expectedResponse);
+      const decodedOperation = await client.checkCreateInstanceProgress(
+        expectedResponse.name
+      );
+      assert.deepStrictEqual(decodedOperation.name, expectedResponse.name);
+      assert(decodedOperation.metadata);
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
+    });
+
+    it('invokes checkCreateInstanceProgress with error', async () => {
+      const client = new bigtableinstanceadminModule.v2.BigtableInstanceAdminClient(
+        {
+          credentials: {client_email: 'bogus', private_key: 'bogus'},
+          projectId: 'bogus',
+        }
+      );
+      client.initialize();
+      const expectedError = new Error('expected');
+
+      client.operationsClient.getOperation = stubSimpleCall(
+        undefined,
+        expectedError
+      );
+      await assert.rejects(
+        client.checkCreateInstanceProgress(''),
+        expectedError
+      );
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
     });
   });
 
@@ -2090,9 +2105,10 @@ describe('v2.BigtableInstanceAdminClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.partialUpdateInstance(request);
-      }, expectedError);
+      await assert.rejects(
+        client.partialUpdateInstance(request),
+        expectedError
+      );
       assert(
         (client.innerApiCalls.partialUpdateInstance as SinonStub)
           .getCall(0)
@@ -2128,14 +2144,57 @@ describe('v2.BigtableInstanceAdminClient', () => {
         expectedError
       );
       const [operation] = await client.partialUpdateInstance(request);
-      await assert.rejects(async () => {
-        await operation.promise();
-      }, expectedError);
+      await assert.rejects(operation.promise(), expectedError);
       assert(
         (client.innerApiCalls.partialUpdateInstance as SinonStub)
           .getCall(0)
           .calledWith(request, expectedOptions, undefined)
       );
+    });
+
+    it('invokes checkPartialUpdateInstanceProgress without error', async () => {
+      const client = new bigtableinstanceadminModule.v2.BigtableInstanceAdminClient(
+        {
+          credentials: {client_email: 'bogus', private_key: 'bogus'},
+          projectId: 'bogus',
+        }
+      );
+      client.initialize();
+      const expectedResponse = generateSampleMessage(
+        new operationsProtos.google.longrunning.Operation()
+      );
+      expectedResponse.name = 'test';
+      expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
+      expectedResponse.metadata = {type_url: 'url', value: Buffer.from('')};
+
+      client.operationsClient.getOperation = stubSimpleCall(expectedResponse);
+      const decodedOperation = await client.checkPartialUpdateInstanceProgress(
+        expectedResponse.name
+      );
+      assert.deepStrictEqual(decodedOperation.name, expectedResponse.name);
+      assert(decodedOperation.metadata);
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
+    });
+
+    it('invokes checkPartialUpdateInstanceProgress with error', async () => {
+      const client = new bigtableinstanceadminModule.v2.BigtableInstanceAdminClient(
+        {
+          credentials: {client_email: 'bogus', private_key: 'bogus'},
+          projectId: 'bogus',
+        }
+      );
+      client.initialize();
+      const expectedError = new Error('expected');
+
+      client.operationsClient.getOperation = stubSimpleCall(
+        undefined,
+        expectedError
+      );
+      await assert.rejects(
+        client.checkPartialUpdateInstanceProgress(''),
+        expectedError
+      );
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
     });
   });
 
@@ -2258,9 +2317,7 @@ describe('v2.BigtableInstanceAdminClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.createCluster(request);
-      }, expectedError);
+      await assert.rejects(client.createCluster(request), expectedError);
       assert(
         (client.innerApiCalls.createCluster as SinonStub)
           .getCall(0)
@@ -2295,14 +2352,57 @@ describe('v2.BigtableInstanceAdminClient', () => {
         expectedError
       );
       const [operation] = await client.createCluster(request);
-      await assert.rejects(async () => {
-        await operation.promise();
-      }, expectedError);
+      await assert.rejects(operation.promise(), expectedError);
       assert(
         (client.innerApiCalls.createCluster as SinonStub)
           .getCall(0)
           .calledWith(request, expectedOptions, undefined)
       );
+    });
+
+    it('invokes checkCreateClusterProgress without error', async () => {
+      const client = new bigtableinstanceadminModule.v2.BigtableInstanceAdminClient(
+        {
+          credentials: {client_email: 'bogus', private_key: 'bogus'},
+          projectId: 'bogus',
+        }
+      );
+      client.initialize();
+      const expectedResponse = generateSampleMessage(
+        new operationsProtos.google.longrunning.Operation()
+      );
+      expectedResponse.name = 'test';
+      expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
+      expectedResponse.metadata = {type_url: 'url', value: Buffer.from('')};
+
+      client.operationsClient.getOperation = stubSimpleCall(expectedResponse);
+      const decodedOperation = await client.checkCreateClusterProgress(
+        expectedResponse.name
+      );
+      assert.deepStrictEqual(decodedOperation.name, expectedResponse.name);
+      assert(decodedOperation.metadata);
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
+    });
+
+    it('invokes checkCreateClusterProgress with error', async () => {
+      const client = new bigtableinstanceadminModule.v2.BigtableInstanceAdminClient(
+        {
+          credentials: {client_email: 'bogus', private_key: 'bogus'},
+          projectId: 'bogus',
+        }
+      );
+      client.initialize();
+      const expectedError = new Error('expected');
+
+      client.operationsClient.getOperation = stubSimpleCall(
+        undefined,
+        expectedError
+      );
+      await assert.rejects(
+        client.checkCreateClusterProgress(''),
+        expectedError
+      );
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
     });
   });
 
@@ -2425,9 +2525,7 @@ describe('v2.BigtableInstanceAdminClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.updateCluster(request);
-      }, expectedError);
+      await assert.rejects(client.updateCluster(request), expectedError);
       assert(
         (client.innerApiCalls.updateCluster as SinonStub)
           .getCall(0)
@@ -2462,14 +2560,57 @@ describe('v2.BigtableInstanceAdminClient', () => {
         expectedError
       );
       const [operation] = await client.updateCluster(request);
-      await assert.rejects(async () => {
-        await operation.promise();
-      }, expectedError);
+      await assert.rejects(operation.promise(), expectedError);
       assert(
         (client.innerApiCalls.updateCluster as SinonStub)
           .getCall(0)
           .calledWith(request, expectedOptions, undefined)
       );
+    });
+
+    it('invokes checkUpdateClusterProgress without error', async () => {
+      const client = new bigtableinstanceadminModule.v2.BigtableInstanceAdminClient(
+        {
+          credentials: {client_email: 'bogus', private_key: 'bogus'},
+          projectId: 'bogus',
+        }
+      );
+      client.initialize();
+      const expectedResponse = generateSampleMessage(
+        new operationsProtos.google.longrunning.Operation()
+      );
+      expectedResponse.name = 'test';
+      expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
+      expectedResponse.metadata = {type_url: 'url', value: Buffer.from('')};
+
+      client.operationsClient.getOperation = stubSimpleCall(expectedResponse);
+      const decodedOperation = await client.checkUpdateClusterProgress(
+        expectedResponse.name
+      );
+      assert.deepStrictEqual(decodedOperation.name, expectedResponse.name);
+      assert(decodedOperation.metadata);
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
+    });
+
+    it('invokes checkUpdateClusterProgress with error', async () => {
+      const client = new bigtableinstanceadminModule.v2.BigtableInstanceAdminClient(
+        {
+          credentials: {client_email: 'bogus', private_key: 'bogus'},
+          projectId: 'bogus',
+        }
+      );
+      client.initialize();
+      const expectedError = new Error('expected');
+
+      client.operationsClient.getOperation = stubSimpleCall(
+        undefined,
+        expectedError
+      );
+      await assert.rejects(
+        client.checkUpdateClusterProgress(''),
+        expectedError
+      );
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
     });
   });
 
@@ -2595,9 +2736,7 @@ describe('v2.BigtableInstanceAdminClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.updateAppProfile(request);
-      }, expectedError);
+      await assert.rejects(client.updateAppProfile(request), expectedError);
       assert(
         (client.innerApiCalls.updateAppProfile as SinonStub)
           .getCall(0)
@@ -2633,14 +2772,57 @@ describe('v2.BigtableInstanceAdminClient', () => {
         expectedError
       );
       const [operation] = await client.updateAppProfile(request);
-      await assert.rejects(async () => {
-        await operation.promise();
-      }, expectedError);
+      await assert.rejects(operation.promise(), expectedError);
       assert(
         (client.innerApiCalls.updateAppProfile as SinonStub)
           .getCall(0)
           .calledWith(request, expectedOptions, undefined)
       );
+    });
+
+    it('invokes checkUpdateAppProfileProgress without error', async () => {
+      const client = new bigtableinstanceadminModule.v2.BigtableInstanceAdminClient(
+        {
+          credentials: {client_email: 'bogus', private_key: 'bogus'},
+          projectId: 'bogus',
+        }
+      );
+      client.initialize();
+      const expectedResponse = generateSampleMessage(
+        new operationsProtos.google.longrunning.Operation()
+      );
+      expectedResponse.name = 'test';
+      expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
+      expectedResponse.metadata = {type_url: 'url', value: Buffer.from('')};
+
+      client.operationsClient.getOperation = stubSimpleCall(expectedResponse);
+      const decodedOperation = await client.checkUpdateAppProfileProgress(
+        expectedResponse.name
+      );
+      assert.deepStrictEqual(decodedOperation.name, expectedResponse.name);
+      assert(decodedOperation.metadata);
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
+    });
+
+    it('invokes checkUpdateAppProfileProgress with error', async () => {
+      const client = new bigtableinstanceadminModule.v2.BigtableInstanceAdminClient(
+        {
+          credentials: {client_email: 'bogus', private_key: 'bogus'},
+          projectId: 'bogus',
+        }
+      );
+      client.initialize();
+      const expectedError = new Error('expected');
+
+      client.operationsClient.getOperation = stubSimpleCall(
+        undefined,
+        expectedError
+      );
+      await assert.rejects(
+        client.checkUpdateAppProfileProgress(''),
+        expectedError
+      );
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
     });
   });
 
@@ -2757,9 +2939,7 @@ describe('v2.BigtableInstanceAdminClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.listAppProfiles(request);
-      }, expectedError);
+      await assert.rejects(client.listAppProfiles(request), expectedError);
       assert(
         (client.innerApiCalls.listAppProfiles as SinonStub)
           .getCall(0)
@@ -2854,9 +3034,7 @@ describe('v2.BigtableInstanceAdminClient', () => {
           reject(err);
         });
       });
-      await assert.rejects(async () => {
-        await promise;
-      }, expectedError);
+      await assert.rejects(promise, expectedError);
       assert(
         (client.descriptors.page.listAppProfiles.createStream as SinonStub)
           .getCall(0)

--- a/test/gapic_bigtable_table_admin_v2.ts
+++ b/test/gapic_bigtable_table_admin_v2.ts
@@ -25,7 +25,7 @@ import * as bigtabletableadminModule from '../src';
 
 import {PassThrough} from 'stream';
 
-import {protobuf, LROperation} from 'google-gax';
+import {protobuf, LROperation, operationsProtos} from 'google-gax';
 
 function generateSampleMessage<T extends object>(instance: T) {
   const filledObject = (instance.constructor as typeof protobuf.Message).toObject(
@@ -331,9 +331,7 @@ describe('v2.BigtableTableAdminClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.createTable(request);
-      }, expectedError);
+      await assert.rejects(client.createTable(request), expectedError);
       assert(
         (client.innerApiCalls.createTable as SinonStub)
           .getCall(0)
@@ -442,9 +440,7 @@ describe('v2.BigtableTableAdminClient', () => {
       };
       const expectedError = new Error('expected');
       client.innerApiCalls.getTable = stubSimpleCall(undefined, expectedError);
-      await assert.rejects(async () => {
-        await client.getTable(request);
-      }, expectedError);
+      await assert.rejects(client.getTable(request), expectedError);
       assert(
         (client.innerApiCalls.getTable as SinonStub)
           .getCall(0)
@@ -556,9 +552,7 @@ describe('v2.BigtableTableAdminClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.deleteTable(request);
-      }, expectedError);
+      await assert.rejects(client.deleteTable(request), expectedError);
       assert(
         (client.innerApiCalls.deleteTable as SinonStub)
           .getCall(0)
@@ -672,9 +666,7 @@ describe('v2.BigtableTableAdminClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.modifyColumnFamilies(request);
-      }, expectedError);
+      await assert.rejects(client.modifyColumnFamilies(request), expectedError);
       assert(
         (client.innerApiCalls.modifyColumnFamilies as SinonStub)
           .getCall(0)
@@ -786,9 +778,7 @@ describe('v2.BigtableTableAdminClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.dropRowRange(request);
-      }, expectedError);
+      await assert.rejects(client.dropRowRange(request), expectedError);
       assert(
         (client.innerApiCalls.dropRowRange as SinonStub)
           .getCall(0)
@@ -902,9 +892,10 @@ describe('v2.BigtableTableAdminClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.generateConsistencyToken(request);
-      }, expectedError);
+      await assert.rejects(
+        client.generateConsistencyToken(request),
+        expectedError
+      );
       assert(
         (client.innerApiCalls.generateConsistencyToken as SinonStub)
           .getCall(0)
@@ -1016,9 +1007,7 @@ describe('v2.BigtableTableAdminClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.checkConsistency(request);
-      }, expectedError);
+      await assert.rejects(client.checkConsistency(request), expectedError);
       assert(
         (client.innerApiCalls.checkConsistency as SinonStub)
           .getCall(0)
@@ -1130,9 +1119,7 @@ describe('v2.BigtableTableAdminClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.getSnapshot(request);
-      }, expectedError);
+      await assert.rejects(client.getSnapshot(request), expectedError);
       assert(
         (client.innerApiCalls.getSnapshot as SinonStub)
           .getCall(0)
@@ -1244,9 +1231,7 @@ describe('v2.BigtableTableAdminClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.deleteSnapshot(request);
-      }, expectedError);
+      await assert.rejects(client.deleteSnapshot(request), expectedError);
       assert(
         (client.innerApiCalls.deleteSnapshot as SinonStub)
           .getCall(0)
@@ -1355,9 +1340,7 @@ describe('v2.BigtableTableAdminClient', () => {
       };
       const expectedError = new Error('expected');
       client.innerApiCalls.getBackup = stubSimpleCall(undefined, expectedError);
-      await assert.rejects(async () => {
-        await client.getBackup(request);
-      }, expectedError);
+      await assert.rejects(client.getBackup(request), expectedError);
       assert(
         (client.innerApiCalls.getBackup as SinonStub)
           .getCall(0)
@@ -1472,9 +1455,7 @@ describe('v2.BigtableTableAdminClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.updateBackup(request);
-      }, expectedError);
+      await assert.rejects(client.updateBackup(request), expectedError);
       assert(
         (client.innerApiCalls.updateBackup as SinonStub)
           .getCall(0)
@@ -1586,9 +1567,7 @@ describe('v2.BigtableTableAdminClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.deleteBackup(request);
-      }, expectedError);
+      await assert.rejects(client.deleteBackup(request), expectedError);
       assert(
         (client.innerApiCalls.deleteBackup as SinonStub)
           .getCall(0)
@@ -1700,9 +1679,7 @@ describe('v2.BigtableTableAdminClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.getIamPolicy(request);
-      }, expectedError);
+      await assert.rejects(client.getIamPolicy(request), expectedError);
       assert(
         (client.innerApiCalls.getIamPolicy as SinonStub)
           .getCall(0)
@@ -1814,9 +1791,7 @@ describe('v2.BigtableTableAdminClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.setIamPolicy(request);
-      }, expectedError);
+      await assert.rejects(client.setIamPolicy(request), expectedError);
       assert(
         (client.innerApiCalls.setIamPolicy as SinonStub)
           .getCall(0)
@@ -1930,9 +1905,7 @@ describe('v2.BigtableTableAdminClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.testIamPermissions(request);
-      }, expectedError);
+      await assert.rejects(client.testIamPermissions(request), expectedError);
       assert(
         (client.innerApiCalls.testIamPermissions as SinonStub)
           .getCall(0)
@@ -2054,9 +2027,10 @@ describe('v2.BigtableTableAdminClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.createTableFromSnapshot(request);
-      }, expectedError);
+      await assert.rejects(
+        client.createTableFromSnapshot(request),
+        expectedError
+      );
       assert(
         (client.innerApiCalls.createTableFromSnapshot as SinonStub)
           .getCall(0)
@@ -2089,14 +2063,53 @@ describe('v2.BigtableTableAdminClient', () => {
         expectedError
       );
       const [operation] = await client.createTableFromSnapshot(request);
-      await assert.rejects(async () => {
-        await operation.promise();
-      }, expectedError);
+      await assert.rejects(operation.promise(), expectedError);
       assert(
         (client.innerApiCalls.createTableFromSnapshot as SinonStub)
           .getCall(0)
           .calledWith(request, expectedOptions, undefined)
       );
+    });
+
+    it('invokes checkCreateTableFromSnapshotProgress without error', async () => {
+      const client = new bigtabletableadminModule.v2.BigtableTableAdminClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedResponse = generateSampleMessage(
+        new operationsProtos.google.longrunning.Operation()
+      );
+      expectedResponse.name = 'test';
+      expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
+      expectedResponse.metadata = {type_url: 'url', value: Buffer.from('')};
+
+      client.operationsClient.getOperation = stubSimpleCall(expectedResponse);
+      const decodedOperation = await client.checkCreateTableFromSnapshotProgress(
+        expectedResponse.name
+      );
+      assert.deepStrictEqual(decodedOperation.name, expectedResponse.name);
+      assert(decodedOperation.metadata);
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
+    });
+
+    it('invokes checkCreateTableFromSnapshotProgress with error', async () => {
+      const client = new bigtabletableadminModule.v2.BigtableTableAdminClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedError = new Error('expected');
+
+      client.operationsClient.getOperation = stubSimpleCall(
+        undefined,
+        expectedError
+      );
+      await assert.rejects(
+        client.checkCreateTableFromSnapshotProgress(''),
+        expectedError
+      );
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
     });
   });
 
@@ -2213,9 +2226,7 @@ describe('v2.BigtableTableAdminClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.snapshotTable(request);
-      }, expectedError);
+      await assert.rejects(client.snapshotTable(request), expectedError);
       assert(
         (client.innerApiCalls.snapshotTable as SinonStub)
           .getCall(0)
@@ -2248,14 +2259,53 @@ describe('v2.BigtableTableAdminClient', () => {
         expectedError
       );
       const [operation] = await client.snapshotTable(request);
-      await assert.rejects(async () => {
-        await operation.promise();
-      }, expectedError);
+      await assert.rejects(operation.promise(), expectedError);
       assert(
         (client.innerApiCalls.snapshotTable as SinonStub)
           .getCall(0)
           .calledWith(request, expectedOptions, undefined)
       );
+    });
+
+    it('invokes checkSnapshotTableProgress without error', async () => {
+      const client = new bigtabletableadminModule.v2.BigtableTableAdminClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedResponse = generateSampleMessage(
+        new operationsProtos.google.longrunning.Operation()
+      );
+      expectedResponse.name = 'test';
+      expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
+      expectedResponse.metadata = {type_url: 'url', value: Buffer.from('')};
+
+      client.operationsClient.getOperation = stubSimpleCall(expectedResponse);
+      const decodedOperation = await client.checkSnapshotTableProgress(
+        expectedResponse.name
+      );
+      assert.deepStrictEqual(decodedOperation.name, expectedResponse.name);
+      assert(decodedOperation.metadata);
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
+    });
+
+    it('invokes checkSnapshotTableProgress with error', async () => {
+      const client = new bigtabletableadminModule.v2.BigtableTableAdminClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedError = new Error('expected');
+
+      client.operationsClient.getOperation = stubSimpleCall(
+        undefined,
+        expectedError
+      );
+      await assert.rejects(
+        client.checkSnapshotTableProgress(''),
+        expectedError
+      );
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
     });
   });
 
@@ -2370,9 +2420,7 @@ describe('v2.BigtableTableAdminClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.createBackup(request);
-      }, expectedError);
+      await assert.rejects(client.createBackup(request), expectedError);
       assert(
         (client.innerApiCalls.createBackup as SinonStub)
           .getCall(0)
@@ -2405,14 +2453,50 @@ describe('v2.BigtableTableAdminClient', () => {
         expectedError
       );
       const [operation] = await client.createBackup(request);
-      await assert.rejects(async () => {
-        await operation.promise();
-      }, expectedError);
+      await assert.rejects(operation.promise(), expectedError);
       assert(
         (client.innerApiCalls.createBackup as SinonStub)
           .getCall(0)
           .calledWith(request, expectedOptions, undefined)
       );
+    });
+
+    it('invokes checkCreateBackupProgress without error', async () => {
+      const client = new bigtabletableadminModule.v2.BigtableTableAdminClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedResponse = generateSampleMessage(
+        new operationsProtos.google.longrunning.Operation()
+      );
+      expectedResponse.name = 'test';
+      expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
+      expectedResponse.metadata = {type_url: 'url', value: Buffer.from('')};
+
+      client.operationsClient.getOperation = stubSimpleCall(expectedResponse);
+      const decodedOperation = await client.checkCreateBackupProgress(
+        expectedResponse.name
+      );
+      assert.deepStrictEqual(decodedOperation.name, expectedResponse.name);
+      assert(decodedOperation.metadata);
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
+    });
+
+    it('invokes checkCreateBackupProgress with error', async () => {
+      const client = new bigtabletableadminModule.v2.BigtableTableAdminClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedError = new Error('expected');
+
+      client.operationsClient.getOperation = stubSimpleCall(
+        undefined,
+        expectedError
+      );
+      await assert.rejects(client.checkCreateBackupProgress(''), expectedError);
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
     });
   });
 
@@ -2527,9 +2611,7 @@ describe('v2.BigtableTableAdminClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.restoreTable(request);
-      }, expectedError);
+      await assert.rejects(client.restoreTable(request), expectedError);
       assert(
         (client.innerApiCalls.restoreTable as SinonStub)
           .getCall(0)
@@ -2562,14 +2644,50 @@ describe('v2.BigtableTableAdminClient', () => {
         expectedError
       );
       const [operation] = await client.restoreTable(request);
-      await assert.rejects(async () => {
-        await operation.promise();
-      }, expectedError);
+      await assert.rejects(operation.promise(), expectedError);
       assert(
         (client.innerApiCalls.restoreTable as SinonStub)
           .getCall(0)
           .calledWith(request, expectedOptions, undefined)
       );
+    });
+
+    it('invokes checkRestoreTableProgress without error', async () => {
+      const client = new bigtabletableadminModule.v2.BigtableTableAdminClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedResponse = generateSampleMessage(
+        new operationsProtos.google.longrunning.Operation()
+      );
+      expectedResponse.name = 'test';
+      expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
+      expectedResponse.metadata = {type_url: 'url', value: Buffer.from('')};
+
+      client.operationsClient.getOperation = stubSimpleCall(expectedResponse);
+      const decodedOperation = await client.checkRestoreTableProgress(
+        expectedResponse.name
+      );
+      assert.deepStrictEqual(decodedOperation.name, expectedResponse.name);
+      assert(decodedOperation.metadata);
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
+    });
+
+    it('invokes checkRestoreTableProgress with error', async () => {
+      const client = new bigtabletableadminModule.v2.BigtableTableAdminClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const expectedError = new Error('expected');
+
+      client.operationsClient.getOperation = stubSimpleCall(
+        undefined,
+        expectedError
+      );
+      await assert.rejects(client.checkRestoreTableProgress(''), expectedError);
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
     });
   });
 
@@ -2680,9 +2798,7 @@ describe('v2.BigtableTableAdminClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.listTables(request);
-      }, expectedError);
+      await assert.rejects(client.listTables(request), expectedError);
       assert(
         (client.innerApiCalls.listTables as SinonStub)
           .getCall(0)
@@ -2766,9 +2882,7 @@ describe('v2.BigtableTableAdminClient', () => {
           reject(err);
         });
       });
-      await assert.rejects(async () => {
-        await promise;
-      }, expectedError);
+      await assert.rejects(promise, expectedError);
       assert(
         (client.descriptors.page.listTables.createStream as SinonStub)
           .getCall(0)
@@ -2966,9 +3080,7 @@ describe('v2.BigtableTableAdminClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.listSnapshots(request);
-      }, expectedError);
+      await assert.rejects(client.listSnapshots(request), expectedError);
       assert(
         (client.innerApiCalls.listSnapshots as SinonStub)
           .getCall(0)
@@ -3059,9 +3171,7 @@ describe('v2.BigtableTableAdminClient', () => {
           reject(err);
         });
       });
-      await assert.rejects(async () => {
-        await promise;
-      }, expectedError);
+      await assert.rejects(promise, expectedError);
       assert(
         (client.descriptors.page.listSnapshots.createStream as SinonStub)
           .getCall(0)
@@ -3260,9 +3370,7 @@ describe('v2.BigtableTableAdminClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.listBackups(request);
-      }, expectedError);
+      await assert.rejects(client.listBackups(request), expectedError);
       assert(
         (client.innerApiCalls.listBackups as SinonStub)
           .getCall(0)
@@ -3352,9 +3460,7 @@ describe('v2.BigtableTableAdminClient', () => {
           reject(err);
         });
       });
-      await assert.rejects(async () => {
-        await promise;
-      }, expectedError);
+      await assert.rejects(promise, expectedError);
       assert(
         (client.descriptors.page.listBackups.createStream as SinonStub)
           .getCall(0)

--- a/test/gapic_bigtable_v2.ts
+++ b/test/gapic_bigtable_v2.ts
@@ -254,9 +254,7 @@ describe('v2.BigtableClient', () => {
       };
       const expectedError = new Error('expected');
       client.innerApiCalls.mutateRow = stubSimpleCall(undefined, expectedError);
-      await assert.rejects(async () => {
-        await client.mutateRow(request);
-      }, expectedError);
+      await assert.rejects(client.mutateRow(request), expectedError);
       assert(
         (client.innerApiCalls.mutateRow as SinonStub)
           .getCall(0)
@@ -368,9 +366,7 @@ describe('v2.BigtableClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.checkAndMutateRow(request);
-      }, expectedError);
+      await assert.rejects(client.checkAndMutateRow(request), expectedError);
       assert(
         (client.innerApiCalls.checkAndMutateRow as SinonStub)
           .getCall(0)
@@ -484,9 +480,7 @@ describe('v2.BigtableClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.readModifyWriteRow(request);
-      }, expectedError);
+      await assert.rejects(client.readModifyWriteRow(request), expectedError);
       assert(
         (client.innerApiCalls.readModifyWriteRow as SinonStub)
           .getCall(0)
@@ -574,9 +568,7 @@ describe('v2.BigtableClient', () => {
           reject(err);
         });
       });
-      await assert.rejects(async () => {
-        await promise;
-      }, expectedError);
+      await assert.rejects(promise, expectedError);
       assert(
         (client.innerApiCalls.readRows as SinonStub)
           .getCall(0)
@@ -666,9 +658,7 @@ describe('v2.BigtableClient', () => {
           reject(err);
         });
       });
-      await assert.rejects(async () => {
-        await promise;
-      }, expectedError);
+      await assert.rejects(promise, expectedError);
       assert(
         (client.innerApiCalls.sampleRowKeys as SinonStub)
           .getCall(0)
@@ -758,9 +748,7 @@ describe('v2.BigtableClient', () => {
           reject(err);
         });
       });
-      await assert.rejects(async () => {
-        await promise;
-      }, expectedError);
+      await assert.rejects(promise, expectedError);
       assert(
         (client.innerApiCalls.mutateRows as SinonStub)
           .getCall(0)


### PR DESCRIPTION
For each client method returning a long running operation, a separate method to check its status is added.

Added methods: `checkCreateBackupProgress`, `checkCreateClusterProgress`, `checkCreateInstanceProgress`, `checkCreateTableFromSnapshotProgress`, `checkPartialUpdateInstanceProgress`, `checkRestoreTableProgress`, `checkSnapshotTableProgress`, `checkUpdateAppProfileProgress`, `checkUpdateClusterProgress`.