### PR TITLE
Create CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,10 @@
+# Code owners file.
+# This file controls who is tagged for review for any given pull request.
+#
+# For syntax help see:
+# https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
+
+
+# The bigtable-dpe team is the default owner for anything not
+# explicitly taken by someone else.
+*                               @GoogleCloudPlatform/bigtable-dpe


### PR DESCRIPTION
Simplifying team repo triage/access via a GitHub team
