### PR TITLE
feature: idiomatic table backup management implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,8 @@
     "api-documenter": "api-documenter yaml --input-folder=temp"
   },
   "dependencies": {
+    "@google-cloud/paginator": "^3.0.0",
+    "@google-cloud/precise-date": "^2.0.1",
     "@google-cloud/projectify": "^2.0.0",
     "@google-cloud/promisify": "^2.0.0",
     "arrify": "^2.0.0",

--- a/samples/backups.js
+++ b/samples/backups.js
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 // Imports the Google Cloud client library
-const {Bigtable} = require('@google-cloud/bigtable');
+const {Bigtable, Backup} = require('@google-cloud/bigtable');
 const uuid = require('uuid');
 const {inspect} = require('util');
 
@@ -151,8 +151,7 @@ async function runBackupOperations(
   // [END bigtable_delete_backup]
 
   // need to delete that other backup example
-  // await new Backup(backupFromTable).delete();
-  await cluster.deleteBackup(`${backupID}-2`, {
+  await new Backup(bigtable, backupFromTable).delete({
     gaxOptions: {
       timeout: 50 * 1000,
     },

--- a/samples/backups.js
+++ b/samples/backups.js
@@ -1,0 +1,114 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Imports the Google Cloud client library
+const {Bigtable} = require('@google-cloud/bigtable');
+const {inspect} = require('util');
+
+async function runBackupOperations(
+  instanceID,
+  clusterID,
+  tableID,
+  optionalBackupID
+) {
+  const bigtable = new Bigtable();
+  const instance = bigtable.instance(instanceID);
+  const cluster = instance.cluster(clusterID);
+
+  const backupID = optionalBackupID || generateBackupId(cluster, tableID);
+
+  // [START bigtable_create_backup]
+  const table = instance.table(tableID);
+  const [backupOperation] = await cluster.createBackup(table, backupID, {
+    expireTime: new Date(Date.now() + 24 * 60 * 60 * 1000), // in 1 day from now
+  });
+  console.log(
+    'Started a table backup operation:',
+    inspect(backupOperation.latestResponse.name, {depth: null, colors: true})
+  );
+
+  // The long running operation (LRO) "backupOperation" provides an EventEmitter interface
+  // or a promise to wait for completion.
+  // The backup cannot be interacted with (restore, update, delete) until it is ready.
+  await backupOperation.promise();
+  console.log('Backup is now "READY" (available).');
+  // [END bigtable_create_backup]
+
+  // [START bigtable_list_backups]
+  const [existingBackups] = await cluster.listBackups();
+  console.log(
+    'These backups exist:',
+    inspect(existingBackups, {depth: null, colors: true})
+  );
+  // [END bigtable_list_backups]
+
+  // [START bigtable_get_backup]
+  // Get information about a backup, like when it will expire or how big it is.
+  // NOTE: No need to poll with this RPC to get backup ready status,
+  //  instead use the EventEmitter or promise interface of the LRO.
+
+  // Convert GCPs Timestamp into a JavaScript Date, this will be used below...
+  function timestampToDate(timestamp) {
+    return new Date(
+      Number(timestamp.seconds) * 1000 + Math.floor(timestamp.nanos / 1000000)
+    );
+  }
+
+  const [backupInfo] = await cluster.getBackup(backupID);
+  console.log('The backup is %s bytes in size.', backupInfo.sizeBytes);
+
+  const expireDate = timestampToDate(backupInfo.expireTime);
+  console.log('The backup will auto delete at', expireDate.toISOString());
+
+  const endDate = timestampToDate(backupInfo.endTime);
+  console.log('The backup finished being created at', endDate.toISOString());
+  // [END bigtable_get_backup]
+
+  // [START bigtable_delete_backup]
+  await cluster.deleteBackup(backupID);
+  console.log('Deleted backup with ID %s, no response is returned.', backupID);
+  // [END bigtable_delete_backup]
+}
+
+function generateBackupId(cluster, table) {
+  return [cluster.id, table.id || table, Date.now()].join('-').slice(-50); // truncate to max backup id length of 50
+}
+
+require('yargs')
+  .demand(1)
+  .command(
+    'run',
+    'Create a backup of a table, restore it, and finally delete it.',
+    {},
+    argv =>
+      runBackupOperations(argv.instance, argv.cluster, argv.table, argv.backup)
+  )
+  .example(
+    'node $0 run --instance [instanceID] --cluster [clusterID] --table [tableID] [--backup [backupID]]',
+    'Create a backup, restore it, and finally delete it.'
+  )
+  .wrap(120)
+  .nargs('instance', 1)
+  .nargs('cluster', 1)
+  .nargs('table', 1)
+  .nargs('backup', 1)
+  .describe('instance', 'Cloud Bigtable Instance ID')
+  .describe('cluster', 'Cloud Bigtable Cluster ID')
+  .describe('table', 'Cloud Bigtable Table ID')
+  .describe('backup', 'A unique Cloud Bigtable Backup ID')
+  .demandOption(['instance', 'cluster', 'table'])
+  .recommendCommands()
+  .epilogue('For more information, see https://cloud.google.com/bigtable/docs')
+  .help()
+  .strict().argv;

--- a/samples/document-snippets/cluster.js
+++ b/samples/document-snippets/cluster.js
@@ -129,6 +129,86 @@ const snippets = {
       });
     // [END bigtable_cluster_set_meta]
   },
+
+  createBackup: (instanceId, clusterId, tableId, backupId) => {
+    // [START bigtable_cluster_create_backup]
+    const {Bigtable} = require('@google-cloud/bigtable');
+    const bigtable = new Bigtable();
+    const instance = bigtable.instance(instanceId);
+    const cluster = instance.cluster(clusterId);
+    const table = instance.table(tableId);
+
+    const expireTime = new Date(Date.now() + 24 * 60 * 60 * 1000); // accepts either a Date or an ITimestamp
+    table
+      .create() // need a table to backup first
+      .then(() => cluster.createBackup(table, backupId, expireTime)) // create the backup
+      .then(([backupOperation]) => backupOperation.promise()) // wait for backup to finish
+      .then(result => {
+        const backup = result[0];
+      })
+      .catch(err => {
+        // Handle the error.
+      });
+    // [END bigtable_cluster_create_backup]
+  },
+
+  listBackups: (instanceId, clusterId) => {
+    // [START bigtable_cluster_list_backups]
+    const {Bigtable} = require('@google-cloud/bigtable');
+    const bigtable = new Bigtable();
+    const instance = bigtable.instance(instanceId);
+    const cluster = instance.cluster(clusterId);
+
+    cluster
+      .listBackups()
+      .then(result => {
+        const backups = result[0];
+      })
+      .catch(err => {
+        // Handle the error.
+      });
+    // [END bigtable_cluster_list_backups]
+  },
+
+  getBackup: (instanceId, clusterId, backupId) => {
+    // [START bigtable_cluster_get_backup]
+    const {Bigtable} = require('@google-cloud/bigtable');
+    const bigtable = new Bigtable();
+    const instance = bigtable.instance(instanceId);
+    const cluster = instance.cluster(clusterId);
+
+    cluster
+      .getBackup(backupId)
+      .then(result => {
+        const backup = result[0];
+      })
+      .catch(err => {
+        // Handle the error.
+      });
+    // [END bigtable_cluster_get_backup]
+  },
+
+  deleteBackup: (instanceId, clusterId, backupId) => {
+    // [START bigtable_cluster_delete_backup]
+    const {Bigtable} = require('@google-cloud/bigtable');
+    const bigtable = new Bigtable();
+    const instance = bigtable.instance(instanceId);
+    const cluster = instance.cluster(clusterId);
+
+    cluster
+      .deleteBackup(backupId, {
+        gaxOptions: {
+          timeout: 50 * 1000, // this op takes a good 30-40 seconds
+        },
+      })
+      .then(() => {
+        // empty response, backup was deleted
+      })
+      .catch(err => {
+        // Handle the error.
+      });
+    // [END bigtable_cluster_delete_backup]
+  },
 };
 
 module.exports = snippets;

--- a/samples/document-snippets/cluster.js
+++ b/samples/document-snippets/cluster.js
@@ -141,7 +141,7 @@ const snippets = {
     const expireTime = new Date(Date.now() + 24 * 60 * 60 * 1000); // accepts either a Date or an ITimestamp
     table
       .create() // need a table to backup first
-      .then(() => cluster.createBackup(table, backupId, expireTime)) // create the backup
+      .then(() => cluster.createBackup(table, backupId, {expireTime})) // create the backup
       .then(([backupOperation]) => backupOperation.promise()) // wait for backup to finish
       .then(result => {
         const backup = result[0];

--- a/samples/document-snippets/table.js
+++ b/samples/document-snippets/table.js
@@ -375,6 +375,24 @@ const snippets = {
     // [END bigtable_del_rows]
   },
 
+  backup: (instanceId, tableId, backupId) => {
+    const instance = bigtable.instance(instanceId);
+    const table = instance.table(tableId);
+
+    // [START bigtable_backup_table]
+    const expireInThirtyMinutes = new Date(Date.now() + 30 * 60 * 1000);
+    table
+      .backup(backupId, expireInThirtyMinutes)
+      .then(([backupOperation]) => backupOperation.promise())
+      .then(result => {
+        const backup = result[0];
+      })
+      .catch(err => {
+        // Handle the error.
+      });
+    // [END bigtable_backup_table]
+  },
+
   delTable: (instanceId, tableId) => {
     const instance = bigtable.instance(instanceId);
     const table = instance.table(tableId);

--- a/samples/document-snippets/table.js
+++ b/samples/document-snippets/table.js
@@ -382,7 +382,7 @@ const snippets = {
     // [START bigtable_backup_table]
     const expireInThirtyMinutes = new Date(Date.now() + 30 * 60 * 1000);
     table
-      .backup(backupId, expireInThirtyMinutes)
+      .backup(backupId, {expireTime: expireInThirtyMinutes})
       .then(([backupOperation]) => backupOperation.promise())
       .then(result => {
         const backup = result[0];

--- a/samples/test/backups.test.js
+++ b/samples/test/backups.test.js
@@ -71,7 +71,7 @@ describe('backups', () => {
     const output = exec(
       `node backups.js run --instance ${instanceId} --cluster ${clusterId} --table ${tableId} --backup ${backupId}`
     );
-    assert.include(output, 'Backup is now "READY" (available).');
+    assert.include(output, 'The backup finished being created');
     assert.include(output, backupId);
     assert.include(output, `Deleted backup with ID ${backupId}`);
   }).timeout(120 * 1000); // deleting backups is slow, the script does it twice, give it time.

--- a/samples/test/backups.test.js
+++ b/samples/test/backups.test.js
@@ -1,0 +1,78 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const {assert} = require('chai');
+const {describe, it, before, after} = require('mocha');
+const uuid = require('uuid');
+const {execSync} = require('child_process');
+const {Bigtable} = require('@google-cloud/bigtable');
+
+const exec = cmd => execSync(cmd, {encoding: 'utf8'});
+
+const bigtable = new Bigtable();
+
+const instanceId = `gcloud-tests-${uuid.v4()}`.substr(0, 30); // Bigtable naming rules
+const clusterId = `gcloud-tests-${uuid.v4()}`.substr(0, 30); // Bigtable naming rules
+const tableId = `gcloud-tests-${uuid.v4()}`.substr(0, 30); // Bigtable naming rules
+const backupId = `gcloud-tests-${uuid.v4()}`.substr(0, 30); // Bigtable naming rules
+const instance = bigtable.instance(instanceId);
+
+describe('backups', () => {
+  before(async () => {
+    await instance.create({
+      clusters: [
+        {
+          id: clusterId,
+          location: 'us-central1-c',
+          nodes: 3,
+        },
+      ],
+    });
+
+    const table = instance.table(tableId);
+    await table.create();
+    await table.createFamily('follows');
+    await table.insert([
+      {
+        key: 'alincoln',
+        data: {
+          follows: {
+            gwashington: 1,
+          },
+        },
+      },
+      {
+        key: 'gwashington',
+        data: {
+          follows: {
+            alincoln: 1,
+          },
+        },
+      },
+    ]);
+  });
+
+  after(() => instance.delete());
+
+  it('should backup, restore, and delete the backup', () => {
+    const output = exec(
+      `node backups.js run --instance ${instanceId} --cluster ${clusterId} --table ${tableId} --backup ${backupId}`
+    );
+    assert.include(output, 'Backup is now "READY" (available).');
+    assert.include(output, backupId);
+    assert.include(output, `Deleted backup with ID ${backupId}`);
+  });
+});

--- a/samples/test/backups.test.js
+++ b/samples/test/backups.test.js
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -74,5 +74,5 @@ describe('backups', () => {
     assert.include(output, 'Backup is now "READY" (available).');
     assert.include(output, backupId);
     assert.include(output, `Deleted backup with ID ${backupId}`);
-  });
+  }).timeout(120 * 1000); // deleting backups is slow, the script does it twice, give it time.
 });

--- a/samples/test/cluster.js
+++ b/samples/test/cluster.js
@@ -21,6 +21,8 @@ const bigtable = new Bigtable();
 
 const INSTANCE_ID = `gcloud-tests-${uuid.v4()}`.substr(0, 30); // Bigtable naming rules
 const CLUSTER_ID = `gcloud-tests-${uuid.v4()}`.substr(0, 30); // Bigtable naming rules
+const TABLE_ID = `gcloud-tests-${uuid.v4()}`.substr(0, 30); // Bigtable naming rules
+const BACKUP_ID = `gcloud-tests-${uuid.v4()}`.substr(0, 30); // Bigtable naming rules
 
 const clusterSnippets = require('./cluster.js');
 
@@ -73,6 +75,22 @@ describe.skip('Cluster Snippets', () => {
 
   it('should set cluster metadata', () => {
     clusterSnippets.setMeta(INSTANCE_ID, CLUSTER_ID);
+  });
+
+  it('should create a backup of a table', () => {
+    clusterSnippets.createBackup(INSTANCE_ID, CLUSTER_ID, TABLE_ID, BACKUP_ID);
+  });
+
+  it('should list backups', () => {
+    clusterSnippets.listBackups(INSTANCE_ID, CLUSTER_ID);
+  });
+
+  it('should get backup metadata', () => {
+    clusterSnippets.getBackup(INSTANCE_ID, CLUSTER_ID, BACKUP_ID);
+  });
+
+  it('should delete a backup', () => {
+    clusterSnippets.deleteBackup(INSTANCE_ID, CLUSTER_ID, BACKUP_ID);
   });
 
   it('should delete a cluster', () => {

--- a/samples/test/table.js
+++ b/samples/test/table.js
@@ -22,6 +22,7 @@ const bigtable = new Bigtable();
 const INSTANCE_ID = `gcloud-tests-${uuid.v4()}`.substr(0, 30); // Bigtable naming rules
 const CLUSTER_ID = `gcloud-tests-${uuid.v4()}`.substr(0, 30); // Bigtable naming rules
 const TABLE_ID = `gcloud-tests-${uuid.v4()}`.substr(0, 30); // Bigtable naming rules
+const BACKUP_ID = `gcloud-tests-${uuid.v4()}`.substr(0, 30); // Bigtable naming rules
 
 const tableSnippets = require('./table.js');
 
@@ -91,6 +92,10 @@ describe.skip('Table Snippets', () => {
 
   it('should create sample row-keys', () => {
     tableSnippets.sampleRowKeys(INSTANCE_ID, TABLE_ID);
+  });
+
+  it('should backup table', () => {
+    tableSnippets.backup(INSTANCE_ID, TABLE_ID, BACKUP_ID);
   });
 
   // it('should delete rows', () => {

--- a/src/backup.ts
+++ b/src/backup.ts
@@ -1,0 +1,301 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {PreciseDate} from '@google-cloud/precise-date';
+import {google} from '../protos/protos';
+import {Bigtable} from './';
+import {BigtableTableAdminClient} from './v2';
+import {
+  DeleteBackupOptions,
+  DeleteBackupResponse,
+  GetBackupOptions,
+  GetBackupResponse,
+  ModifiableBackupFields,
+  UpdateBackupOptions,
+  UpdateBackupResponse,
+} from './cluster';
+import {RestoreTableOptions, RestoreTableResponse} from './instance';
+import * as Long from 'long';
+
+export class Backup implements google.bigtable.admin.v2.IBackup {
+  name?: string | null;
+  sourceTable?: string | null;
+  expireTime?: google.protobuf.ITimestamp | null;
+  startTime?: google.protobuf.ITimestamp | null;
+  endTime?: google.protobuf.ITimestamp | null;
+  sizeBytes?: number | Long | string | null;
+  state?:
+    | google.bigtable.admin.v2.Backup.State
+    | keyof typeof google.bigtable.admin.v2.Backup.State
+    | null;
+
+  private readonly _backup: google.bigtable.admin.v2.IBackup;
+  private _bigtable: Bigtable;
+  private _tableAdminClient: BigtableTableAdminClient;
+
+  /**
+   * @param {Bigtable} bigtable
+   * @param {google.bigtable.admin.v2.IBackup} backup A Backup or
+   */
+  constructor(bigtable: Bigtable, backup: google.bigtable.admin.v2.IBackup) {
+    Object.assign(this, backup);
+
+    this._backup = backup.valueOf();
+    this._bigtable = bigtable;
+    this._tableAdminClient = this._bigtable.api[
+      'BigtableTableAdminClient'
+    ] as BigtableTableAdminClient;
+  }
+
+  /**
+   * The parent path of this backup, i.e. the cluster.
+   * @readonly
+   * @return {string}
+   */
+  get parent(): string {
+    return this._tableAdminClient.clusterPath(
+      this.projectId,
+      this.instanceId,
+      this.clusterId
+    );
+  }
+
+  /**
+   * The project to which this backup belongs.
+   * @readonly
+   * @return {string}
+   */
+  get projectId(): string {
+    if (!this.name) {
+      throw new TypeError(
+        'A backup name is required to determine the projectId.'
+      );
+    }
+    return this._tableAdminClient
+      .matchProjectFromBackupName(this.name)
+      .toString();
+  }
+
+  /**
+   * The instance to which this backup belongs.
+   * @readonly
+   * @return {string}
+   */
+  get instanceId(): string {
+    if (!this.name) {
+      throw new TypeError(
+        'A backup name is required to determine the instanceId.'
+      );
+    }
+    return this._tableAdminClient
+      .matchInstanceFromBackupName(this.name)
+      .toString();
+  }
+
+  /**
+   * The cluster to which this backup belongs.
+   * @readonly
+   * @return {string}
+   */
+  get clusterId(): string {
+    if (!this.name) {
+      throw new TypeError(
+        'A backup name is required to determine the clusterId.'
+      );
+    }
+    return this._tableAdminClient
+      .matchClusterFromBackupName(this.name)
+      .toString();
+  }
+
+  /**
+   * This backup's identifier.
+   * @readonly
+   * @return {string}
+   */
+  get backupId(): string {
+    if (!this.name) {
+      throw new TypeError(
+        'A backup name is required to determine the backupId.'
+      );
+    }
+    return this._tableAdminClient
+      .matchBackupFromBackupName(this.name)
+      .toString();
+  }
+
+  /**
+   * A Date-compatible PreciseDate representation of `expireTime`.
+   * @readonly
+   * @return {PreciseDate}
+   */
+  get expireDate(): PreciseDate {
+    if (!this.expireTime) {
+      throw new TypeError('An expireTime is required to convert to Date.');
+    }
+    return new PreciseDate({
+      seconds: this.expireTime.seconds!,
+      nanos: this.expireTime.nanos!,
+    });
+  }
+
+  /**
+   * A Date-compatible PreciseDate representation of `startTime`.
+   * @readonly
+   * @return {PreciseDate}
+   */
+  get startDate(): PreciseDate {
+    if (!this.startTime) {
+      throw new TypeError('A startTime is required to convert to Date.');
+    }
+    return new PreciseDate({
+      seconds: this.startTime.seconds!,
+      nanos: this.startTime.nanos!,
+    });
+  }
+
+  /**
+   * A Date-compatible PreciseDate representation of `endTime`.
+   * @readonly
+   * @return {PreciseDate}
+   */
+  get endDate(): PreciseDate {
+    if (!this.endTime) {
+      throw new TypeError('An endTime is required to convert to Date.');
+    }
+    return new PreciseDate({
+      seconds: this.endTime.seconds!,
+      nanos: this.endTime.nanos!,
+    });
+  }
+
+  /**
+   * Deletes this pending or completed Cloud Bigtable backup.
+   *
+   * @param {DeleteBackupOptions} [options]
+   * @return {Promise<DeleteBackupResponse>}
+   * @see {Cluster#deleteBackup}
+   *
+   * @example <caption>include:samples/document-snippets/cluster.js</caption>
+   * region_tag:bigtable_cluster_delete_backup
+   */
+  delete(options?: DeleteBackupOptions): Promise<DeleteBackupResponse> {
+    if (!this.name) {
+      return Promise.reject(
+        new TypeError('A backup name is required to delete a backup.')
+      );
+    }
+
+    return this._bigtable
+      .instance(this.instanceId)
+      .cluster(this.clusterId)
+      .deleteBackup(this.backupId, options);
+  }
+
+  /**
+   * Gets fresh metadata for this Cloud Bigtable Backup.
+   *
+   * @param {GetBackupOptions} [options]
+   * @return {Promise<GetBackupResponse>}
+   * @see {Cluster#getBackup}
+   *
+   * @example <caption>include:samples/document-snippets/cluster.js</caption>
+   * region_tag:bigtable_cluster_get_backup
+   */
+  get(options?: GetBackupOptions): Promise<GetBackupResponse> {
+    if (!this.name) {
+      return Promise.reject(
+        new TypeError('A backup name is required to get a backup.')
+      );
+    }
+
+    return this._bigtable
+      .instance(this.instanceId)
+      .cluster(this.clusterId)
+      .getBackup(this.backupId, options);
+  }
+
+  /**
+   * Create a new table by restoring from this completed backup.
+   *
+   * The new table must be in the same instance as the instance containing
+   * the backup. The returned table
+   * {@link google.longrunning.Operation|long-running operation} can be used
+   * to track the progress of the operation, and to cancel it.
+   *
+   * @param {string} tableId
+   *   Required. The id of the table to create and restore to. This
+   *   table must not already exist. The `table_id` appended to
+   *   `parent` forms the full table name of the form
+   *   `projects/<project>/instances/<instance>/tables/<table_id>`.
+   * @param {RestoreTableOptions} [options]
+   * @return {Promise<RestoreTableResponse>}
+   * @see {Instance#restoreTable}
+   */
+  restore(
+    tableId: string,
+    options?: RestoreTableOptions
+  ): Promise<RestoreTableResponse> {
+    if (!this.name) {
+      return Promise.reject(
+        new TypeError('A backup name is required to restore a backup.')
+      );
+    }
+
+    return this._bigtable
+      .instance(this.instanceId)
+      .restoreTable(this.backupId, this.clusterId, tableId, options);
+  }
+
+  /**
+   * Updates this pending or completed Cloud Bigtable Backup.
+   *
+   * @param {ModifiableBackupFields} fields
+   *   Required. The fields to be updated.
+   * @param {BackupTimestamp} fields.expireTime
+   *   Required. This is currently the only supported field.
+   * @param {UpdateBackupOptions} [options]
+   * @return {Promise<UpdateBackupResponse>}
+   * @see {Cluster#updateBackup}
+   */
+  update(
+    fields: ModifiableBackupFields,
+    options?: UpdateBackupOptions
+  ): Promise<UpdateBackupResponse> {
+    if (!this.name) {
+      return Promise.reject(
+        new TypeError('A backup name is required to update a backup.')
+      );
+    }
+
+    return this._bigtable
+      .instance(this.instanceId)
+      .cluster(this.clusterId)
+      .updateBackup(this.backupId, fields, options);
+  }
+
+  /**
+   * A plain-old-javascript-object representation of this backup.
+   * @return {google.bigtable.admin.v2.IBackup}
+   */
+  valueOf(): google.bigtable.admin.v2.IBackup {
+    return {...this._backup};
+  }
+}
+
+/**
+ * Reference to the {@link Backup} class.
+ * @name module:@google-cloud/bigtable.Backup
+ * @see Backup
+ */

--- a/src/backup.ts
+++ b/src/backup.ts
@@ -40,7 +40,7 @@ export class Backup implements google.bigtable.admin.v2.IBackup {
     | keyof typeof google.bigtable.admin.v2.Backup.State
     | null;
 
-  private readonly _backup: google.bigtable.admin.v2.IBackup;
+  metadata: google.bigtable.admin.v2.IBackup;
   private _bigtable: Bigtable;
   private _tableAdminClient: BigtableTableAdminClient;
 
@@ -51,7 +51,7 @@ export class Backup implements google.bigtable.admin.v2.IBackup {
   constructor(bigtable: Bigtable, backup: google.bigtable.admin.v2.IBackup) {
     Object.assign(this, backup);
 
-    this._backup = backup.valueOf();
+    this.metadata = backup.valueOf();
     this._bigtable = bigtable;
     this._tableAdminClient = this._bigtable.api[
       'BigtableTableAdminClient'
@@ -290,7 +290,7 @@ export class Backup implements google.bigtable.admin.v2.IBackup {
    * @return {google.bigtable.admin.v2.IBackup}
    */
   valueOf(): google.bigtable.admin.v2.IBackup {
-    return {...this._backup};
+    return {...this.metadata};
   }
 }
 

--- a/src/backup.ts
+++ b/src/backup.ts
@@ -13,127 +13,176 @@
 // limitations under the License.
 
 import {PreciseDate} from '@google-cloud/precise-date';
+import {promisifyAll} from '@google-cloud/promisify';
+import snakeCase = require('lodash.snakecase');
 import {google} from '../protos/protos';
-import {Bigtable} from './';
+import {Bigtable, Cluster, Table} from './';
 import {BigtableTableAdminClient} from './v2';
-import {
-  DeleteBackupOptions,
-  DeleteBackupResponse,
-  GetBackupOptions,
-  GetBackupResponse,
-  ModifiableBackupFields,
-  UpdateBackupOptions,
-  UpdateBackupResponse,
-} from './cluster';
-import {RestoreTableOptions, RestoreTableResponse} from './instance';
-import * as Long from 'long';
+import {CallOptions, LROperation, ServiceError} from 'google-gax';
 
-export class Backup implements google.bigtable.admin.v2.IBackup {
-  name?: string | null;
-  sourceTable?: string | null;
-  expireTime?: google.protobuf.ITimestamp | null;
-  startTime?: google.protobuf.ITimestamp | null;
-  endTime?: google.protobuf.ITimestamp | null;
-  sizeBytes?: number | Long | string | null;
-  state?:
-    | google.bigtable.admin.v2.Backup.State
-    | keyof typeof google.bigtable.admin.v2.Backup.State
-    | null;
+type IEmpty = google.protobuf.IEmpty;
+export type IBackup = google.bigtable.admin.v2.IBackup;
 
-  metadata: google.bigtable.admin.v2.IBackup;
+export type BackupTimestamp = google.protobuf.ITimestamp | PreciseDate | Date;
+export interface ModifiableBackupFields {
+  /**
+   * The ITimestamp (Date or PreciseDate will be converted) representing
+   * when the backup will automatically be deleted. This must be at a
+   * minimum 6 hours from the time of the backup request and a maximum of 30
+   * days.
+   */
+  expireTime?: BackupTimestamp;
+}
 
-  private _bigtable: Bigtable;
-  private _tableAdminClient: BigtableTableAdminClient;
+export interface GenericBackupCallback<T> {
+  (err: ServiceError | null, backup: Backup, apiResponse?: T): void;
+}
+
+export type DeleteBackupCallback = GenericBackupCallback<IEmpty>;
+export type DeleteBackupResponse = [Backup, IEmpty];
+export type GetBackupCallback = GenericBackupCallback<IBackup>;
+export type GetBackupResponse = [Backup, IBackup];
+export type UpdateBackupCallback = GenericBackupCallback<IBackup>;
+export type UpdateBackupResponse = [Backup, IBackup];
+
+export type CreateBackupCallback = (
+  err: ServiceError | null,
+  apiResponse?: LROperation<
+    google.bigtable.admin.v2.IBackup,
+    google.bigtable.admin.v2.ICreateBackupMetadata
+  >
+) => void;
+export type CreateBackupResponse = [
+  LROperation<
+    google.bigtable.admin.v2.IBackup,
+    google.bigtable.admin.v2.ICreateBackupMetadata
+  >
+];
+
+export type RestoreTableCallback = (
+  err: ServiceError | null,
+  table: Table | null,
+  apiResponse?: LROperation<
+    google.bigtable.admin.v2.ITable,
+    google.bigtable.admin.v2.IRestoreTableMetadata
+  >
+) => void;
+export type RestoreTableResponse = [
+  Table,
+  LROperation<
+    google.bigtable.admin.v2.ITable,
+    google.bigtable.admin.v2.IRestoreTableMetadata
+  >
+];
+
+export interface GetBackupsOptions {
+  /**
+   * A filter expression that filters backups listed in the response.
+   *   The expression must specify the field name, a comparison operator,
+   *   and the value that you want to use for filtering. The value must be a
+   *   string, a number, or a boolean. The comparison operator must be
+   *   <, >, <=, >=, !=, =, or :. Colon ‘:’ represents a HAS operator which is
+   *   roughly synonymous with equality. Filter rules are case insensitive.
+   */
+  filter?: string;
 
   /**
-   * @param {Bigtable} bigtable
-   * @param {google.bigtable.admin.v2.IBackup} backup A Backup or
+   * An expression for specifying the sort order of the results of the request.
+   *   The string value should specify one or more fields in
+   *   {@link google.bigtable.admin.v2.Backup|Backup}. The full syntax is
+   *   described at https://aip.dev/132#ordering.
    */
-  constructor(bigtable: Bigtable, backup: google.bigtable.admin.v2.IBackup) {
-    Object.assign(this, backup);
+  orderBy?: string;
 
-    this.metadata = backup.valueOf();
-    this._bigtable = bigtable;
-    this._tableAdminClient = this._bigtable.api[
+  gaxOptions?: CallOptions;
+}
+
+export type GetBackupsResponse = [Backup[], IBackup[]];
+export type GetBackupsCallback = (
+  err: ServiceError | null,
+  backups?: Backup[],
+  apiResponse?: IBackup[]
+) => void;
+
+/**
+ * Interact with backups like get detailed information from BigTable, create
+ * a backup, or restore a backup to a table.
+ *
+ * @class
+ * @param {Cluster} cluster The parent instance of this backup.
+ * @param {string} name Name of the backup.
+ *
+ * @example
+ * const {Bigtable} = require('@google-cloud/bigtable');
+ * const bigtable = new Bigtable();
+ * const instance = bigtable.instance('my-instance');
+ * const backup = instance.backup('my-backup', 'my-cluster');
+ */
+export class Backup {
+  bigtable: Bigtable;
+  cluster: Cluster;
+
+  /**
+   * A unique backup string, e.g. "my-backup".
+   * This string must be between 1 and 50 characters in length and match the
+   * regex {@link -_.a-zA-Z0-9|_a-zA-Z0-9}*.
+   */
+  id: string;
+
+  /**
+   * The full path of the backup which is in the form of:
+   *  `projects/{project}/instances/{instance}/clusters/{cluster}/backups/{backup}`.
+   *
+   * The "backup" portion must be between 1 and 50 characters in length and
+   * match the regex {@link -_.a-zA-Z0-9|_a-zA-Z0-9}*.
+   */
+  name: string;
+  metadata: IBackup;
+
+  /**
+   * @param {Cluster} cluster
+   * @param {string} idOrName The backup name or id.
+   * @param {ModifiableBackupFields} [fields]
+   */
+  constructor(
+    cluster: Cluster,
+    idOrName: string,
+    fields?: ModifiableBackupFields
+  ) {
+    this.bigtable = cluster.bigtable;
+    this.cluster = cluster;
+    this.metadata = {};
+
+    if (fields && fields.expireTime) {
+      if (fields.expireTime instanceof Date) {
+        this.metadata.expireTime = new PreciseDate(
+          fields.expireTime
+        ).toStruct();
+      } else if (fields.expireTime.seconds) {
+        this.metadata.expireTime = fields.expireTime;
+      }
+    }
+
+    const tableAdminClient = this.bigtable.api[
       'BigtableTableAdminClient'
     ] as BigtableTableAdminClient;
-  }
 
-  /**
-   * The parent path of this backup, i.e. the cluster.
-   * @readonly
-   * @return {string}
-   */
-  get parent(): string {
-    return this._tableAdminClient.clusterPath(
-      this.projectId,
-      this.instanceId,
-      this.clusterId
-    );
-  }
-
-  /**
-   * The project to which this backup belongs.
-   * @readonly
-   * @return {string}
-   */
-  get projectId(): string {
-    if (!this.name) {
-      throw new TypeError(
-        'A backup name is required to determine the projectId.'
+    if (idOrName.includes('/')) {
+      this.name = idOrName;
+      this.id = tableAdminClient.matchBackupFromBackupName(idOrName).toString();
+      if (!this.id) {
+        throw new Error(`Backup id '${idOrName}' is not formatted correctly.
+        Please use the format 'projects/{project}/instances/{instance}/clusters/{cluster}/backups/{backup}.`);
+      }
+    } else {
+      this.id = idOrName;
+      this.name = tableAdminClient.backupPath(
+        this.bigtable.projectId,
+        this.cluster.instance.id,
+        this.cluster.id,
+        this.id
       );
     }
-    return this._tableAdminClient
-      .matchProjectFromBackupName(this.name)
-      .toString();
-  }
-
-  /**
-   * The instance to which this backup belongs.
-   * @readonly
-   * @return {string}
-   */
-  get instanceId(): string {
-    if (!this.name) {
-      throw new TypeError(
-        'A backup name is required to determine the instanceId.'
-      );
-    }
-    return this._tableAdminClient
-      .matchInstanceFromBackupName(this.name)
-      .toString();
-  }
-
-  /**
-   * The cluster to which this backup belongs.
-   * @readonly
-   * @return {string}
-   */
-  get clusterId(): string {
-    if (!this.name) {
-      throw new TypeError(
-        'A backup name is required to determine the clusterId.'
-      );
-    }
-    return this._tableAdminClient
-      .matchClusterFromBackupName(this.name)
-      .toString();
-  }
-
-  /**
-   * This backup's identifier.
-   * @readonly
-   * @return {string}
-   */
-  get backupId(): string {
-    if (!this.name) {
-      throw new TypeError(
-        'A backup name is required to determine the backupId.'
-      );
-    }
-    return this._tableAdminClient
-      .matchBackupFromBackupName(this.name)
-      .toString();
   }
 
   /**
@@ -142,12 +191,12 @@ export class Backup implements google.bigtable.admin.v2.IBackup {
    * @return {PreciseDate}
    */
   get expireDate(): PreciseDate {
-    if (!this.expireTime) {
+    if (!this.metadata || !this.metadata.expireTime) {
       throw new TypeError('An expireTime is required to convert to Date.');
     }
     return new PreciseDate({
-      seconds: this.expireTime.seconds!,
-      nanos: this.expireTime.nanos!,
+      seconds: this.metadata.expireTime.seconds!,
+      nanos: this.metadata.expireTime.nanos!,
     });
   }
 
@@ -157,12 +206,12 @@ export class Backup implements google.bigtable.admin.v2.IBackup {
    * @return {PreciseDate}
    */
   get startDate(): PreciseDate {
-    if (!this.startTime) {
+    if (!this.metadata || !this.metadata.startTime) {
       throw new TypeError('A startTime is required to convert to Date.');
     }
     return new PreciseDate({
-      seconds: this.startTime.seconds!,
-      nanos: this.startTime.nanos!,
+      seconds: this.metadata.startTime.seconds!,
+      nanos: this.metadata.startTime.nanos!,
     });
   }
 
@@ -172,61 +221,203 @@ export class Backup implements google.bigtable.admin.v2.IBackup {
    * @return {PreciseDate}
    */
   get endDate(): PreciseDate {
-    if (!this.endTime) {
+    if (!this.metadata || !this.metadata.endTime) {
       throw new TypeError('An endTime is required to convert to Date.');
     }
     return new PreciseDate({
-      seconds: this.endTime.seconds!,
-      nanos: this.endTime.nanos!,
+      seconds: this.metadata.endTime.seconds!,
+      nanos: this.metadata.endTime.nanos!,
     });
   }
 
+  create(
+    table: Table | string,
+    fields?: Required<ModifiableBackupFields>
+  ): Promise<CreateBackupResponse>;
+  create(
+    table: Table | string,
+    fields: Required<ModifiableBackupFields>,
+    gaxOptions?: CallOptions
+  ): Promise<CreateBackupResponse>;
+  create(
+    table: Table | string,
+    fields: Required<ModifiableBackupFields>,
+    gaxOptions: CallOptions,
+    callback: CreateBackupCallback
+  ): void;
+  create(
+    table: Table | string,
+    fields: Required<ModifiableBackupFields>,
+    callback: CreateBackupCallback
+  ): void;
+  /**
+   * Starts creating a new Cloud Bigtable Backup.
+   *
+   * The returned backup
+   * {@link google.longrunning.Operation|long-running operation} can be used to
+   * track creation of the backup. Cancelling the returned operation will
+   * stop the creation and delete the backup.
+   *
+   * @param {Table|string} table A reference to the Table to backup, or the full
+   *   table path in the form:
+   *   `projects/{project}/instances/{instance}/tables/{table}`.
+   * @param {ModifiableBackupFields} [fields] Fields to be specified, otherwise
+   *   use the data originally provided to the constructor.
+   * @param {BackupTimestamp} [fields.expireTime] When the backup will be
+   *   automatically deleted.
+   * @param {CallOptions | CreateBackupCallback} [gaxOptionsOrCallback]
+   * @param {CreateBackupCallback} [cb]
+   * @return {void | Promise<CreateBackupResponse>}
+   *
+   * @example <caption>include:samples/document-snippets/cluster.js</caption>
+   * region_tag:bigtable_cluster_create_backup
+   */
+  create(
+    table: Table | string,
+    fields?: Required<ModifiableBackupFields>,
+    gaxOptionsOrCallback?: CallOptions | CreateBackupCallback,
+    cb?: CreateBackupCallback
+  ): void | Promise<CreateBackupResponse> {
+    const options =
+      typeof gaxOptionsOrCallback === 'object' ? gaxOptionsOrCallback : {};
+    const callback =
+      typeof gaxOptionsOrCallback === 'function' ? gaxOptionsOrCallback : cb!;
+
+    if (
+      !table ||
+      (typeof table === 'object' && !table.name) ||
+      typeof table === 'function'
+    ) {
+      throw new TypeError(
+        'A reference to a table is required to create a backup.'
+      );
+    }
+
+    const {expireTime, ...restFields} = fields || {};
+    this.metadata = {
+      sourceTable: typeof table === 'string' ? table : table.name,
+      ...restFields,
+    };
+
+    if (expireTime instanceof Date) {
+      this.metadata.expireTime = new PreciseDate(expireTime).toStruct();
+    } else if (expireTime && expireTime.seconds) {
+      this.metadata.expireTime = expireTime;
+    }
+
+    if (!this.metadata.expireTime) {
+      throw new TypeError('The expireTime field is invalid.');
+    }
+
+    const reqOpts: google.bigtable.admin.v2.ICreateBackupRequest = {
+      parent: this.cluster.name,
+      backupId: this.id,
+      backup: this.metadata,
+    };
+
+    this.bigtable.request<
+      LROperation<IBackup, google.bigtable.admin.v2.ICreateBackupMetadata>
+    >(
+      {
+        client: 'BigtableTableAdminClient',
+        method: 'createBackup',
+        reqOpts,
+        gaxOpts: options,
+      },
+      callback
+    );
+  }
+
+  delete(gaxOptions?: CallOptions): Promise<DeleteBackupResponse>;
+  delete(callback: DeleteBackupCallback): void;
+  delete(gaxOptions: CallOptions, callback: DeleteBackupCallback): void;
   /**
    * Deletes this pending or completed Cloud Bigtable backup.
    *
-   * @param {DeleteBackupOptions} [options]
-   * @return {Promise<DeleteBackupResponse>}
-   * @see {Cluster#deleteBackup}
+   * @param {CallOptions | DeleteBackupCallback} [gaxOptionsOrCallback]
+   * @param {DeleteBackupCallback} [cb]
+   * @return {void | Promise<DeleteBackupResponse>}
    *
    * @example <caption>include:samples/document-snippets/cluster.js</caption>
    * region_tag:bigtable_cluster_delete_backup
    */
-  delete(options?: DeleteBackupOptions): Promise<DeleteBackupResponse> {
-    if (!this.name) {
-      return Promise.reject(
-        new TypeError('A backup name is required to delete a backup.')
-      );
-    }
+  delete(
+    gaxOptionsOrCallback?: CallOptions | DeleteBackupCallback,
+    cb?: DeleteBackupCallback
+  ): void | Promise<DeleteBackupResponse> {
+    const options =
+      typeof gaxOptionsOrCallback === 'object' ? gaxOptionsOrCallback : {};
+    const callback =
+      typeof gaxOptionsOrCallback === 'function' ? gaxOptionsOrCallback : cb!;
 
-    return this._bigtable
-      .instance(this.instanceId)
-      .cluster(this.clusterId)
-      .deleteBackup(this.backupId, options);
+    const reqOpts: google.bigtable.admin.v2.IDeleteBackupRequest = {
+      name: this.name,
+    };
+
+    this.bigtable.request<google.protobuf.IEmpty>(
+      {
+        client: 'BigtableTableAdminClient',
+        method: 'deleteBackup',
+        reqOpts,
+        gaxOpts: options,
+      },
+      (err, resp) => callback(err, this, resp)
+    );
   }
 
+  get(gaxOptions?: CallOptions): Promise<GetBackupResponse>;
+  get(callback: GetBackupCallback): void;
+  get(gaxOptions: CallOptions, callback: GetBackupCallback): void;
   /**
    * Gets fresh metadata for this Cloud Bigtable Backup.
    *
-   * @param {GetBackupOptions} [options]
-   * @return {Promise<GetBackupResponse>}
-   * @see {Cluster#getBackup}
+   * @param {CallOptions | GetBackupCallback} [gaxOptionsOrCallback]
+   * @param {GetBackupCallback} [cb]
+   * @return {void | Promise<GetBackupResponse>}
    *
    * @example <caption>include:samples/document-snippets/cluster.js</caption>
    * region_tag:bigtable_cluster_get_backup
    */
-  get(options?: GetBackupOptions): Promise<GetBackupResponse> {
-    if (!this.name) {
-      return Promise.reject(
-        new TypeError('A backup name is required to get a backup.')
-      );
-    }
+  get(
+    gaxOptionsOrCallback?: CallOptions | GetBackupCallback,
+    cb?: GetBackupCallback
+  ): void | Promise<GetBackupResponse> {
+    const options =
+      typeof gaxOptionsOrCallback === 'object' ? gaxOptionsOrCallback : {};
+    const callback =
+      typeof gaxOptionsOrCallback === 'function' ? gaxOptionsOrCallback : cb!;
 
-    return this._bigtable
-      .instance(this.instanceId)
-      .cluster(this.clusterId)
-      .getBackup(this.backupId, options);
+    const reqOpts: google.bigtable.admin.v2.IGetBackupRequest = {
+      name: this.name,
+    };
+
+    this.bigtable.request<IBackup>(
+      {
+        client: 'BigtableTableAdminClient',
+        method: 'getBackup',
+        reqOpts,
+        gaxOpts: options,
+      },
+      (err, resp) => {
+        if (resp) {
+          this.metadata = resp;
+        }
+
+        callback(err, this, this.metadata);
+      }
+    );
   }
 
+  restore(
+    tableId: string,
+    gaxOptions?: CallOptions
+  ): Promise<RestoreTableResponse>;
+  restore(
+    tableId: string,
+    gaxOptions: CallOptions,
+    callback: RestoreTableCallback
+  ): void;
+  restore(tableId: string, callback: RestoreTableCallback): void;
   /**
    * Create a new table by restoring from this completed backup.
    *
@@ -240,25 +431,58 @@ export class Backup implements google.bigtable.admin.v2.IBackup {
    *   table must not already exist. The `table_id` appended to
    *   `parent` forms the full table name of the form
    *   `projects/<project>/instances/<instance>/tables/<table_id>`.
-   * @param {RestoreTableOptions} [options]
-   * @return {Promise<RestoreTableResponse>}
-   * @see {Instance#restoreTable}
+   * @param {CallOptions | RestoreTableCallback} [gaxOptionsOrCallback]
+   * @param {RestoreTableCallback} [cb]
+   * @return {void | Promise<RestoreTableResponse>}
    */
   restore(
     tableId: string,
-    options?: RestoreTableOptions
-  ): Promise<RestoreTableResponse> {
-    if (!this.name) {
-      return Promise.reject(
-        new TypeError('A backup name is required to restore a backup.')
-      );
-    }
+    gaxOptionsOrCallback?: CallOptions | RestoreTableCallback,
+    cb?: RestoreTableCallback
+  ): void | Promise<RestoreTableResponse> {
+    const options =
+      typeof gaxOptionsOrCallback === 'object' ? gaxOptionsOrCallback : {};
+    const callback =
+      typeof gaxOptionsOrCallback === 'function' ? gaxOptionsOrCallback : cb!;
 
-    return this._bigtable
-      .instance(this.instanceId)
-      .restoreTable(this.backupId, this.clusterId, tableId, options);
+    const reqOpts: google.bigtable.admin.v2.IRestoreTableRequest = {
+      parent: this.cluster.name,
+      tableId,
+      backup: this.name,
+    };
+
+    this.bigtable.request<
+      LROperation<
+        google.bigtable.admin.v2.ITable,
+        google.bigtable.admin.v2.IRestoreTableMetadata
+      >
+    >(
+      {
+        client: 'BigtableTableAdminClient',
+        method: 'restoreTable',
+        reqOpts,
+        gaxOpts: options,
+      },
+      (err, operation) => {
+        let table: Table | null = null;
+        if (!err) {
+          table = new Table(this.cluster.instance, tableId);
+        }
+        callback(err, table, operation);
+      }
+    );
   }
 
+  update(
+    fields: ModifiableBackupFields,
+    gaxOptions?: CallOptions
+  ): Promise<UpdateBackupResponse>;
+  update(fields: ModifiableBackupFields, callback: UpdateBackupCallback): void;
+  update(
+    fields: ModifiableBackupFields,
+    gaxOptions: CallOptions,
+    callback: UpdateBackupCallback
+  ): void;
   /**
    * Updates this pending or completed Cloud Bigtable Backup.
    *
@@ -266,34 +490,81 @@ export class Backup implements google.bigtable.admin.v2.IBackup {
    *   Required. The fields to be updated.
    * @param {BackupTimestamp} fields.expireTime
    *   Required. This is currently the only supported field.
-   * @param {UpdateBackupOptions} [options]
-   * @return {Promise<UpdateBackupResponse>}
-   * @see {Cluster#updateBackup}
+   * @param {CallOptions | UpdateBackupCallback} [gaxOptionsOrCallback]
+   * @param {UpdateBackupCallback} [cb]
+   * @return {void | Promise<UpdateBackupResponse>}
    */
   update(
     fields: ModifiableBackupFields,
-    options?: UpdateBackupOptions
-  ): Promise<UpdateBackupResponse> {
-    if (!this.name) {
-      return Promise.reject(
-        new TypeError('A backup name is required to update a backup.')
+    gaxOptionsOrCallback?: CallOptions | UpdateBackupCallback,
+    cb?: UpdateBackupCallback
+  ): void | Promise<UpdateBackupResponse> {
+    const options =
+      typeof gaxOptionsOrCallback === 'object' ? gaxOptionsOrCallback : {};
+    const callback =
+      typeof gaxOptionsOrCallback === 'function' ? gaxOptionsOrCallback : cb!;
+
+    if (!fields || !fields.expireTime) {
+      throw new TypeError(
+        'Must specify at least one field to update (e.g. expireTime).'
       );
     }
 
-    return this._bigtable
-      .instance(this.instanceId)
-      .cluster(this.clusterId)
-      .updateBackup(this.backupId, fields, options);
-  }
+    const {expireTime, ...restFields} = fields;
 
-  /**
-   * A plain-old-javascript-object representation of this backup.
-   * @return {google.bigtable.admin.v2.IBackup}
-   */
-  valueOf(): google.bigtable.admin.v2.IBackup {
-    return {...this.metadata};
+    const backup: IBackup = {
+      name: this.name,
+      ...restFields,
+    };
+
+    if (expireTime) {
+      if (expireTime instanceof Date) {
+        backup.expireTime = new PreciseDate(expireTime).toStruct();
+      } else if (expireTime.seconds) {
+        backup.expireTime = expireTime;
+      } else {
+        throw new TypeError('The expireTime field is invalid.');
+      }
+    }
+
+    const reqOpts: google.bigtable.admin.v2.IUpdateBackupRequest = {
+      backup,
+      updateMask: {
+        paths: [],
+      },
+    };
+
+    const fieldsForMask = ['expireTime'];
+    fieldsForMask.forEach(field => {
+      if (field in fields) {
+        reqOpts.updateMask!.paths!.push(snakeCase(field));
+      }
+    });
+
+    this.bigtable.request<IBackup>(
+      {
+        client: 'BigtableTableAdminClient',
+        method: 'updateBackup',
+        reqOpts,
+        gaxOpts: options,
+      },
+      (err, resp) => {
+        if (resp) {
+          this.metadata = resp;
+        }
+
+        callback(err, this, this.metadata);
+      }
+    );
   }
 }
+
+/*! Developer Documentation
+ *
+ * All async methods (except for streams) will return a Promise in the event
+ * that a callback is omitted.
+ */
+promisifyAll(Backup, {exclude: ['expireDate', 'startDate', 'endDate']});
 
 /**
  * Reference to the {@link Backup} class.

--- a/src/backup.ts
+++ b/src/backup.ts
@@ -41,6 +41,7 @@ export class Backup implements google.bigtable.admin.v2.IBackup {
     | null;
 
   metadata: google.bigtable.admin.v2.IBackup;
+
   private _bigtable: Bigtable;
   private _tableAdminClient: BigtableTableAdminClient;
 

--- a/src/cluster.ts
+++ b/src/cluster.ts
@@ -90,7 +90,7 @@ export type GetClusterMetadataCallback = (
   apiResponse?: IOperation | null
 ) => void;
 
-export type BackupTimestamp = google.protobuf.ITimestamp | PreciseDate;
+export type BackupTimestamp = google.protobuf.ITimestamp | PreciseDate | Date;
 export interface ModifiableBackupFields {
   /**
    * The ITimestamp (Date or PreciseDate will be converted) representing

--- a/src/cluster.ts
+++ b/src/cluster.ts
@@ -616,11 +616,11 @@ Please use the format 'my-cluster' or '${instance.name}/clusters/my-cluster'.`);
     const callback =
       typeof optionsOrCallback === 'function' ? optionsOrCallback : cb!;
 
-    if (!table) {
+    if (!table || typeof table === 'function') {
       throw new Error('A reference to a table is required to create a backup.');
     }
 
-    if (!id) {
+    if (!id || typeof table === 'function') {
       throw new Error('An id is required to create a backup.');
     }
 
@@ -696,7 +696,7 @@ Please use the format 'my-cluster' or '${instance.name}/clusters/my-cluster'.`);
     const callback =
       typeof optionsOrCallback === 'function' ? optionsOrCallback : cb!;
 
-    if (!id) {
+    if (!id || typeof id === 'function') {
       throw new Error('The backup id/name is required.');
     }
 
@@ -748,7 +748,7 @@ Please use the format 'my-cluster' or '${instance.name}/clusters/my-cluster'.`);
     const callback =
       typeof optionsOrCallback === 'function' ? optionsOrCallback : cb!;
 
-    if (!id) {
+    if (!id || typeof id === 'function') {
       throw new Error('The backup id/name is required.');
     }
 
@@ -866,7 +866,7 @@ Please use the format 'my-cluster' or '${instance.name}/clusters/my-cluster'.`);
     const callback =
       typeof optionsOrCallback === 'function' ? optionsOrCallback : cb!;
 
-    if (!id) {
+    if (!id || typeof id === 'function') {
       throw new Error('The backup id/name is required.');
     }
 

--- a/src/cluster.ts
+++ b/src/cluster.ts
@@ -1,4 +1,4 @@
-// Copyright 2016 Google LLC
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -547,6 +547,27 @@ Please use the format 'my-cluster' or '${instance.name}/clusters/my-cluster'.`);
     );
   }
 
+  /**
+   * Convert a full or partial object (with at least `name`) to a Backup
+   * instance. If defining statically, `backup.get()` should be called to
+   * pull the full state from the remote.
+   *
+   * @example
+   * const name = 'projects/p/instances/i/clusters/c/backups/b';
+   * const backupPartial = cluster.asBackup({name});
+   * const [backup] = await backupLocal.get();
+   * assert(backup instanceof Backup);
+   * assert.strictEqual(backup.name, name);
+   *
+   * @param {google.bigtable.admin.v2.IBackup} backup A full or partial
+   *   object that implements `IBackup`. While any empty object will work,
+   *   `name` should be supplied to be useful in most cases.
+   * @return {Backup}
+   */
+  asBackup(backup: google.bigtable.admin.v2.IBackup): Backup {
+    return new Backup(this.bigtable, backup);
+  }
+
   createBackup(
     table: Table | string,
     id: string,
@@ -765,7 +786,7 @@ Please use the format 'my-cluster' or '${instance.name}/clusters/my-cluster'.`);
       (err, resp) => {
         let backup;
         if (resp) {
-          backup = new Backup(this.bigtable, resp);
+          backup = this.asBackup(resp);
         }
 
         callback(err, backup);
@@ -812,7 +833,7 @@ Please use the format 'my-cluster' or '${instance.name}/clusters/my-cluster'.`);
       },
       (...args) => {
         if (args[1]) {
-          args[1] = args[1].map(backup => new Backup(this.bigtable, backup));
+          args[1] = args[1].map(backup => this.asBackup(backup));
         }
 
         callback(...args);
@@ -913,7 +934,7 @@ Please use the format 'my-cluster' or '${instance.name}/clusters/my-cluster'.`);
       (err, resp) => {
         let backup;
         if (resp) {
-          backup = new Backup(this.bigtable, resp);
+          backup = this.asBackup(resp);
         }
 
         callback(err, backup);
@@ -969,7 +990,7 @@ paginator.extend(Cluster, ['listBackups']);
  * All async methods (except for streams) will return a Promise in the event
  * that a callback is omitted.
  */
-promisifyAll(Cluster);
+promisifyAll(Cluster, {exclude: ['asBackup']});
 
 /**
  * Reference to the {@link Cluster} class.

--- a/src/cluster.ts
+++ b/src/cluster.ts
@@ -620,7 +620,7 @@ Please use the format 'my-cluster' or '${instance.name}/clusters/my-cluster'.`);
       throw new Error('A reference to a table is required to create a backup.');
     }
 
-    if (!id || typeof table === 'function') {
+    if (!id || typeof id === 'function') {
       throw new Error('An id is required to create a backup.');
     }
 
@@ -629,7 +629,6 @@ Please use the format 'my-cluster' or '${instance.name}/clusters/my-cluster'.`);
     }
 
     const {expireTime, ...restFields} = fields;
-
     const backup: google.bigtable.admin.v2.IBackup = {
       sourceTable: table.name,
       ...restFields,
@@ -701,7 +700,6 @@ Please use the format 'my-cluster' or '${instance.name}/clusters/my-cluster'.`);
     }
 
     const name = `${this.name}/backups/${id}`;
-
     const reqOpts: google.bigtable.admin.v2.IDeleteBackupRequest = {
       name,
     };
@@ -753,7 +751,6 @@ Please use the format 'my-cluster' or '${instance.name}/clusters/my-cluster'.`);
     }
 
     const name = `${this.name}/backups/${id}`;
-
     const reqOpts: google.bigtable.admin.v2.IGetBackupRequest = {
       name,
     };

--- a/src/index.ts
+++ b/src/index.ts
@@ -955,6 +955,7 @@ export {
   SetAppProfileMetadataCallback,
   SetAppProfileMetadataResponse,
 } from './app-profile';
+export {Backup} from './backup';
 export {
   Chunk,
   ChunkTransformer,
@@ -987,6 +988,24 @@ export {
   IEmpty,
   SetClusterMetadataCallback,
   SetClusterMetadataResponse,
+  BackupTimestamp,
+  ModifiableBackupFields,
+  CreateBackupOptions,
+  CreateBackupCallback,
+  CreateBackupResponse,
+  DeleteBackupOptions,
+  DeleteBackupCallback,
+  DeleteBackupResponse,
+  GetBackupOptions,
+  GetBackupCallback,
+  GetBackupResponse,
+  ListBackupsOptions,
+  ListBackupsStreamOptions,
+  ListBackupsCallback,
+  ListBackupsResponse,
+  UpdateBackupOptions,
+  UpdateBackupCallback,
+  UpdateBackupResponse,
 } from './cluster';
 export {
   CreateFamilyCallback,
@@ -1040,6 +1059,9 @@ export {
   InstanceExistsResponse,
   SetInstanceMetadataCallback,
   SetInstanceMetadataResponse,
+  RestoreTableOptions,
+  RestoreTableCallback,
+  RestoreTableResponse,
 } from './instance';
 export {
   IMutation,

--- a/src/index.ts
+++ b/src/index.ts
@@ -955,7 +955,26 @@ export {
   SetAppProfileMetadataCallback,
   SetAppProfileMetadataResponse,
 } from './app-profile';
-export {Backup} from './backup';
+export {
+  Backup,
+  BackupTimestamp,
+  CreateBackupCallback,
+  CreateBackupResponse,
+  DeleteBackupCallback,
+  DeleteBackupResponse,
+  GenericBackupCallback,
+  GetBackupCallback,
+  GetBackupResponse,
+  GetBackupsCallback,
+  GetBackupsOptions,
+  GetBackupsResponse,
+  IBackup,
+  ModifiableBackupFields,
+  RestoreTableCallback,
+  RestoreTableResponse,
+  UpdateBackupCallback,
+  UpdateBackupResponse,
+} from './backup';
 export {
   Chunk,
   ChunkTransformer,
@@ -988,24 +1007,6 @@ export {
   IEmpty,
   SetClusterMetadataCallback,
   SetClusterMetadataResponse,
-  BackupTimestamp,
-  ModifiableBackupFields,
-  CreateBackupOptions,
-  CreateBackupCallback,
-  CreateBackupResponse,
-  DeleteBackupOptions,
-  DeleteBackupCallback,
-  DeleteBackupResponse,
-  GetBackupOptions,
-  GetBackupCallback,
-  GetBackupResponse,
-  ListBackupsOptions,
-  ListBackupsStreamOptions,
-  ListBackupsCallback,
-  ListBackupsResponse,
-  UpdateBackupOptions,
-  UpdateBackupCallback,
-  UpdateBackupResponse,
 } from './cluster';
 export {
   CreateFamilyCallback,
@@ -1059,9 +1060,6 @@ export {
   InstanceExistsResponse,
   SetInstanceMetadataCallback,
   SetInstanceMetadataResponse,
-  RestoreTableOptions,
-  RestoreTableCallback,
-  RestoreTableResponse,
 } from './instance';
 export {
   IMutation,

--- a/src/instance.ts
+++ b/src/instance.ts
@@ -465,7 +465,7 @@ Please use the format 'my-instance' or '${bigtable.projectName}/instances/my-ins
     optionsOrCallback?: CreateTableOptions | CreateTableCallback,
     cb?: CreateTableCallback
   ): void | Promise<CreateTableResponse> {
-    if (!id) {
+    if (!id || typeof id === 'function') {
       throw new Error('An id is required to create a table.');
     }
 
@@ -1097,28 +1097,26 @@ Please use the format 'my-instance' or '${bigtable.projectName}/instances/my-ins
     optionsOrCallback?: RestoreTableOptions | RestoreTableCallback,
     cb?: RestoreTableCallback
   ): void | Promise<RestoreTableResponse> {
-    if (!backupId) {
-      throw new Error('A backup id is required for what to restore.');
-    }
-
-    if (!clusterId) {
-      throw new Error(
-        'A cluster id is required from where the backup resides.'
-      );
-    }
-
-    if (!tableId) {
-      throw new Error('An table id is required to restore from a backup.');
-    }
-
     const options =
       typeof optionsOrCallback === 'object' ? optionsOrCallback : {};
     const callback =
       typeof optionsOrCallback === 'function' ? optionsOrCallback : cb!;
 
-    const backupName = `${this.name}/clusters/${clusterId}/backups/${backupId}`;
-    // const tableName = `${this.name}/tables/${tableId}`;
+    if (!backupId || typeof backupId === 'function') {
+      throw new Error('A backup id is required for what to restore.');
+    }
 
+    if (!clusterId || typeof clusterId === 'function') {
+      throw new Error(
+        'A cluster id is required from where the backup resides.'
+      );
+    }
+
+    if (!tableId || typeof tableId === 'function') {
+      throw new Error('An table id is required to restore from a backup.');
+    }
+
+    const backupName = `${this.name}/clusters/${clusterId}/backups/${backupId}`;
     const reqOpts: google.bigtable.admin.v2.IRestoreTableRequest = {
       parent: this.name,
       tableId,

--- a/src/instance.ts
+++ b/src/instance.ts
@@ -60,7 +60,6 @@ import {CallOptions, LROperation, Operation} from 'google-gax';
 import {ServiceError} from 'google-gax';
 import {Bigtable} from '.';
 import {google} from '../protos/protos';
-import * as protos from '../protos/protos';
 
 export interface ClusterInfo extends BasicClusterConfig {
   id: string;
@@ -146,14 +145,14 @@ export interface RestoreTableOptions {
 export type RestoreTableCallback = (
   err: ServiceError | null,
   apiResponse?: LROperation<
-    protos.google.bigtable.admin.v2.ITable,
-    protos.google.bigtable.admin.v2.IRestoreTableMetadata
+    google.bigtable.admin.v2.ITable,
+    google.bigtable.admin.v2.IRestoreTableMetadata
   >
 ) => void;
 export type RestoreTableResponse = [
   LROperation<
-    protos.google.bigtable.admin.v2.ITable,
-    protos.google.bigtable.admin.v2.IRestoreTableMetadata
+    google.bigtable.admin.v2.ITable,
+    google.bigtable.admin.v2.IRestoreTableMetadata
   >
 ];
 
@@ -1128,8 +1127,8 @@ Please use the format 'my-instance' or '${bigtable.projectName}/instances/my-ins
 
     this.bigtable.request<
       LROperation<
-        protos.google.bigtable.admin.v2.ITable,
-        protos.google.bigtable.admin.v2.IRestoreTableMetadata
+        google.bigtable.admin.v2.ITable,
+        google.bigtable.admin.v2.IRestoreTableMetadata
       >
     >(
       {

--- a/src/instance.ts
+++ b/src/instance.ts
@@ -1138,7 +1138,7 @@ Please use the format 'my-instance' or '${bigtable.projectName}/instances/my-ins
         reqOpts,
         gaxOpts: options.gaxOptions,
       },
-      callback
+      callback // TODO cast as Table
     );
   }
 

--- a/src/instance.ts
+++ b/src/instance.ts
@@ -56,10 +56,16 @@ import {
   GetTablesCallback,
   GetTablesResponse,
 } from './table';
-import {CallOptions, LROperation, Operation} from 'google-gax';
+import {CallOptions, Operation} from 'google-gax';
 import {ServiceError} from 'google-gax';
-import {Bigtable} from '.';
+import {Backup, Bigtable} from '.';
 import {google} from '../protos/protos';
+import {
+  ModifiableBackupFields,
+  RestoreTableCallback,
+  RestoreTableResponse,
+} from './backup';
+import {BigtableTableAdminClient} from './v2';
 
 export interface ClusterInfo extends BasicClusterConfig {
   id: string;
@@ -139,23 +145,6 @@ export type SetInstanceMetadataCallback = (
 ) => void;
 export type SetInstanceMetadataResponse = [google.protobuf.Empty];
 
-export interface RestoreTableOptions {
-  gaxOptions?: CallOptions;
-}
-export type RestoreTableCallback = (
-  err: ServiceError | null,
-  apiResponse?: LROperation<
-    google.bigtable.admin.v2.ITable,
-    google.bigtable.admin.v2.IRestoreTableMetadata
-  >
-) => void;
-export type RestoreTableResponse = [
-  LROperation<
-    google.bigtable.admin.v2.ITable,
-    google.bigtable.admin.v2.IRestoreTableMetadata
-  >
-];
-
 /**
  * Create an Instance object to interact with a Cloud Bigtable instance.
  *
@@ -226,6 +215,38 @@ Please use the format 'my-instance' or '${bigtable.projectName}/instances/my-ins
    */
   appProfile(name: string): AppProfile {
     return new AppProfile(this, name);
+  }
+
+  /**
+   * Get a reference to a Bigtable Backup.
+   *
+   * @example
+   * const id = 'my-backup';
+   * const backup = instance.backup(id, 'my-cluster');
+   * const expiresAt = new Date(Date.now() * 1000 * 60 * 60 * 6);
+   * const [operation] = await backup.create({expireTime: expiresAt});
+   * await operation.promise();
+   * const [fetchedBackup] = await backup.get();
+   * assert(backup instanceof Backup);
+   * assert.strictEqual(backup.id, id);
+   * assert.strictEqual(backup, fetchedBackup);
+   *
+   * @param {string} idOrName The backup name or id.
+   * @param {string | Cluster} cluster The id of the cluster this back is
+   * related to, or an instance of a Cluster.
+   * @param {ModifiableBackupFields} [fields] Declare things like
+   * `expireTime` at the point of instantiation. This can always be supplied
+   * later when creating the backup, or can be fetched using `backup.get()`.
+   * @returns {Backup}
+   */
+  backup(
+    idOrName: string,
+    cluster: string | Cluster,
+    fields?: ModifiableBackupFields
+  ): Backup {
+    const clusterInstance =
+      typeof cluster === 'string' ? this.cluster(cluster) : cluster;
+    return new Backup(clusterInstance, idOrName, fields);
   }
 
   create(options: InstanceOptions): Promise<CreateInstanceResponse>;
@@ -1045,23 +1066,20 @@ Please use the format 'my-instance' or '${bigtable.projectName}/instances/my-ins
     ]);
   }
 
-  restoreTable(
-    backupId: string,
-    clusterId: string,
+  createTableFromBackup(
     tableId: string,
-    options?: RestoreTableOptions
+    backup: Backup | string,
+    gaxOptions: CallOptions
   ): Promise<RestoreTableResponse>;
-  restoreTable(
-    backupId: string,
-    clusterId: string,
+  createTableFromBackup(
     tableId: string,
-    options: RestoreTableOptions,
+    backup: Backup | string,
+    gaxOptions: CallOptions,
     callback: RestoreTableCallback
   ): void;
-  restoreTable(
-    backupId: string,
-    clusterId: string,
+  createTableFromBackup(
     tableId: string,
+    backup: Backup | string,
     callback: RestoreTableCallback
   ): void;
   /**
@@ -1072,71 +1090,52 @@ Please use the format 'my-instance' or '${bigtable.projectName}/instances/my-ins
    * {@link google.longrunning.Operation|long-running operation} can be used
    * to track the progress of the operation, and to cancel it.
    *
-   * @param {string} backupId
-   *   The id of the backup from which to restore. The `backupId` appended to
-   *   `parent` forms the full backup name of the form
-   *   `projects/<project>/instances/<instance>/clusters/<cluster>/backups/<backup>`.
-   * @param {string} clusterId
-   *   The id of the cluster from where the backup resides. The `clusterId`
-   *   appended to `parent` in conjunction with the `backupId` forms the full
-   *   backup name of the form
-   *   `projects/<project>/instances/<instance>/clusters/<cluster>/backups/<backup>`.
    * @param {string} tableId
    *   Required. The id of the table to create and restore to. This
    *   table must not already exist. The `table_id` appended to
    *   `parent` forms the full table name of the form
    *   `projects/<project>/instances/<instance>/tables/<table_id>`.
-   * @param {RestoreTableOptions | RestoreTableCallback} [optionsOrCallback]
+   * @param {Backup | string} backup
+   *   The name of the backup from which to restore of the form
+   *  `projects/<project>/instances/<instance>/clusters/<cluster>/backups/<backup>`,
+   *  or a Backup instance.
+   * @param {CallOptions | RestoreTableCallback} [gaxOptionsOrCallback]
    * @param {RestoreTableCallback} [cb]
    * @return {void | Promise<RestoreTableResponse>}
    */
-  restoreTable(
-    backupId: string,
-    clusterId: string,
+  createTableFromBackup(
     tableId: string,
-    optionsOrCallback?: RestoreTableOptions | RestoreTableCallback,
+    backup: Backup | string,
+    gaxOptionsOrCallback?: CallOptions | RestoreTableCallback,
     cb?: RestoreTableCallback
   ): void | Promise<RestoreTableResponse> {
     const options =
-      typeof optionsOrCallback === 'object' ? optionsOrCallback : {};
+      typeof gaxOptionsOrCallback === 'object' ? gaxOptionsOrCallback : {};
     const callback =
-      typeof optionsOrCallback === 'function' ? optionsOrCallback : cb!;
-
-    if (!backupId || typeof backupId === 'function') {
-      throw new Error('A backup id is required for what to restore.');
-    }
-
-    if (!clusterId || typeof clusterId === 'function') {
-      throw new Error(
-        'A cluster id is required from where the backup resides.'
-      );
-    }
+      typeof gaxOptionsOrCallback === 'function' ? gaxOptionsOrCallback : cb!;
 
     if (!tableId || typeof tableId === 'function') {
       throw new Error('An table id is required to restore from a backup.');
     }
 
-    const backupName = `${this.name}/clusters/${clusterId}/backups/${backupId}`;
-    const reqOpts: google.bigtable.admin.v2.IRestoreTableRequest = {
-      parent: this.name,
-      tableId,
-      backup: backupName,
-    };
+    const tableAdminClient = this.bigtable.api[
+      'BigtableTableAdminClient'
+    ] as BigtableTableAdminClient;
 
-    this.bigtable.request<
-      LROperation<
-        google.bigtable.admin.v2.ITable,
-        google.bigtable.admin.v2.IRestoreTableMetadata
-      >
-    >(
-      {
-        client: 'BigtableTableAdminClient',
-        method: 'restoreTable',
-        reqOpts,
-        gaxOpts: options.gaxOptions,
-      },
-      callback // TODO cast as Table
-    );
+    let backupFrom: Backup;
+    if (backup instanceof Backup) {
+      backupFrom = backup;
+    } else {
+      const clusterId = tableAdminClient
+        .matchClusterFromBackupName(backup)
+        .toString();
+      if (!clusterId) {
+        throw new Error('A complete backup name (path) is required.');
+      }
+      backupFrom = new Backup(this.cluster(clusterId), backup);
+    }
+
+    backupFrom.restore(tableId, options, callback);
   }
 
   setIamPolicy(

--- a/src/table.ts
+++ b/src/table.ts
@@ -44,6 +44,7 @@ import {
   CreateBackupCallback,
   CreateBackupOptions,
   CreateBackupResponse,
+  ModifiableBackupFields,
 } from './cluster';
 
 // See protos/google/rpc/code.proto
@@ -489,18 +490,18 @@ Please use the format 'prezzy' or '${instance.name}/tables/prezzy'.`);
 
   backup(
     id: string,
-    expireTime: google.protobuf.ITimestamp | Date,
+    fields: Required<ModifiableBackupFields>,
     options?: CreateBackupOptions
   ): Promise<CreateBackupResponse>;
   backup(
     id: string,
-    expireTime: google.protobuf.ITimestamp | Date,
+    fields: Required<ModifiableBackupFields>,
     options: CreateBackupOptions,
     callback: CreateBackupCallback
   ): void;
   backup(
     id: string,
-    expireTime: google.protobuf.ITimestamp | Date,
+    fields: Required<ModifiableBackupFields>,
     callback: CreateBackupCallback
   ): void;
   /**
@@ -511,7 +512,9 @@ Please use the format 'prezzy' or '${instance.name}/tables/prezzy'.`);
    * cluster from which a backup can be performed.
    *
    * @param {string} id A unique ID for the backup.
-   * @param {google.protobuf.ITimestamp | Date} expireTime
+   * @param {ModifiableBackupFields} fields Fields to be specified.
+   * @param {BackupTimestamp} fields.expireTime When the backup will be
+   *   automatically deleted.
    * @param {CreateBackupOptions | CreateBackupCallback} [optionsOrCallback]
    * @param {CreateBackupCallback} [cb]
    * @return {void | Promise<CreateBackupResponse>}
@@ -521,7 +524,7 @@ Please use the format 'prezzy' or '${instance.name}/tables/prezzy'.`);
    */
   backup(
     id: string,
-    expireTime: google.protobuf.ITimestamp | Date,
+    fields: Required<ModifiableBackupFields>,
     optionsOrCallback?: CreateBackupOptions | CreateBackupCallback,
     cb?: CreateBackupCallback
   ): void | Promise<CreateBackupResponse> {
@@ -548,7 +551,7 @@ Please use the format 'prezzy' or '${instance.name}/tables/prezzy'.`);
       .then(clusterId => {
         this.instance
           .cluster(clusterId)
-          .createBackup(this, id, expireTime, options, callback);
+          .createBackup(this, id, fields, options, callback);
       })
       .catch(err => callback(err));
   }

--- a/src/table.ts
+++ b/src/table.ts
@@ -550,11 +550,10 @@ Please use the format 'prezzy' or '${instance.name}/tables/prezzy'.`);
         }
         return clusterId;
       })
-      .then(clusterId => {
-        this.instance
-          .cluster(clusterId)
-          .createBackup(this, id, fields, options, callback);
-      })
+      .then(clusterId =>
+        this.instance.cluster(clusterId).createBackup(this, id, fields, options)
+      )
+      .then(([resp]) => callback(null, resp))
       .catch(err => callback(err));
   }
 

--- a/src/table.ts
+++ b/src/table.ts
@@ -528,14 +528,14 @@ Please use the format 'prezzy' or '${instance.name}/tables/prezzy'.`);
     optionsOrCallback?: CreateBackupOptions | CreateBackupCallback,
     cb?: CreateBackupCallback
   ): void | Promise<CreateBackupResponse> {
-    if (!id) {
-      throw new TypeError('An id is required to create a backup.');
-    }
-
     const options =
       typeof optionsOrCallback === 'object' ? optionsOrCallback : {};
     const callback =
       typeof optionsOrCallback === 'function' ? optionsOrCallback : cb!;
+
+    if (!id || typeof id === 'function') {
+      throw new TypeError('An id is required to create a backup.');
+    }
 
     this.getReplicationStates({...options.gaxOptions})
       .then(([stateMap]) => {
@@ -639,7 +639,7 @@ Please use the format 'prezzy' or '${instance.name}/tables/prezzy'.`);
     const options =
       typeof optionsOrCallback === 'object' ? optionsOrCallback : {};
 
-    if (!id) {
+    if (!id || typeof id === 'function') {
       throw new Error('An id is required to create a family.');
     }
 

--- a/src/table.ts
+++ b/src/table.ts
@@ -529,7 +529,7 @@ Please use the format 'prezzy' or '${instance.name}/tables/prezzy'.`);
     cb?: CreateBackupCallback
   ): void | Promise<CreateBackupResponse> {
     if (!id) {
-      throw new Error('An id is required to create a backup.');
+      throw new TypeError('An id is required to create a backup.');
     }
 
     const options =
@@ -537,11 +537,13 @@ Please use the format 'prezzy' or '${instance.name}/tables/prezzy'.`);
     const callback =
       typeof optionsOrCallback === 'function' ? optionsOrCallback : cb!;
 
-    this.getReplicationStates(options.gaxOptions)
+    this.getReplicationStates({...options.gaxOptions})
       .then(([stateMap]) => {
         const [clusterId] =
           [...stateMap.entries()].find(
-            ([, clusterState]) => clusterState.replicationState === 'READY'
+            ([, clusterState]) =>
+              clusterState.replicationState === 'READY' ||
+              clusterState.replicationState === 'READY_OPTIMIZING'
           ) || [];
         if (!clusterId) {
           throw new Error('No ready clusters eligible for backup.');

--- a/src/table.ts
+++ b/src/table.ts
@@ -40,6 +40,11 @@ import {Bigtable, AbortableDuplex} from '.';
 import {Instance} from './instance';
 import {google} from '../protos/protos';
 import {Duplex} from 'stream';
+import {
+  CreateBackupCallback,
+  CreateBackupOptions,
+  CreateBackupResponse,
+} from './cluster';
 
 // See protos/google/rpc/code.proto
 // (4=DEADLINE_EXCEEDED, 10=ABORTED, 14=UNAVAILABLE)
@@ -480,6 +485,72 @@ Please use the format 'prezzy' or '${instance.name}/tables/prezzy'.`);
         inclusive: !endKey,
       },
     };
+  }
+
+  backup(
+    id: string,
+    expireTime: google.protobuf.ITimestamp | Date,
+    options?: CreateBackupOptions
+  ): Promise<CreateBackupResponse>;
+  backup(
+    id: string,
+    expireTime: google.protobuf.ITimestamp | Date,
+    options: CreateBackupOptions,
+    callback: CreateBackupCallback
+  ): void;
+  backup(
+    id: string,
+    expireTime: google.protobuf.ITimestamp | Date,
+    callback: CreateBackupCallback
+  ): void;
+  /**
+   * Backup a table with cluster auto selection.
+   *
+   * Backups of tables originate from a specific cluster. This is a helper
+   * around Cluster.createBackup that automatically selects the first ready
+   * cluster from which a backup can be performed.
+   *
+   * @param {string} id A unique ID for the backup.
+   * @param {google.protobuf.ITimestamp | Date} expireTime
+   * @param {CreateBackupOptions | CreateBackupCallback} [optionsOrCallback]
+   * @param {CreateBackupCallback} [cb]
+   * @return {void | Promise<CreateBackupResponse>}
+   *
+   * @example <caption>include:samples/document-snippets/table.js</caption>
+   * region_tag:bigtable_create_table
+   */
+  backup(
+    id: string,
+    expireTime: google.protobuf.ITimestamp | Date,
+    optionsOrCallback?: CreateBackupOptions | CreateBackupCallback,
+    cb?: CreateBackupCallback
+  ): void | Promise<CreateBackupResponse> {
+    if (!id) {
+      throw new Error('An id is required to create a backup.');
+    }
+
+    const options =
+      typeof optionsOrCallback === 'object' ? optionsOrCallback : {};
+    const callback =
+      typeof optionsOrCallback === 'function' ? optionsOrCallback : cb!;
+
+    this.getReplicationStates(options.gaxOptions)
+      .then(([stateMap]) => {
+        const [clusterId] =
+          [...stateMap.entries()].find(
+            ([, clusterState]) => clusterState.replicationState === 'READY'
+          ) || [];
+        if (!clusterId) {
+          throw new Error('No ready clusters eligible for backup.');
+        }
+        return clusterId;
+      })
+      .then(clusterId => {
+        this.instance
+          .cluster(clusterId)
+          .createBackup(this, id, expireTime, options, callback);
+      })
+      .catch(err => callback(err));
   }
 
   create(options?: CreateTableOptions): Promise<CreateTableResponse>;

--- a/src/table.ts
+++ b/src/table.ts
@@ -38,14 +38,14 @@ import {ChunkTransformer} from './chunktransformer';
 import {CallOptions} from 'google-gax';
 import {Bigtable, AbortableDuplex} from '.';
 import {Instance} from './instance';
-import {google} from '../protos/protos';
-import {Duplex} from 'stream';
 import {
   CreateBackupCallback,
   CreateBackupOptions,
   CreateBackupResponse,
   ModifiableBackupFields,
 } from './cluster';
+import {google} from '../protos/protos';
+import {Duplex} from 'stream';
 
 // See protos/google/rpc/code.proto
 // (4=DEADLINE_EXCEEDED, 10=ABORTED, 14=UNAVAILABLE)

--- a/system-test/bigtable.ts
+++ b/system-test/bigtable.ts
@@ -1,4 +1,4 @@
-// Copyright 2016 Google LLC
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,12 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import {PreciseDate} from '@google-cloud/precise-date';
 import * as assert from 'assert';
 import {beforeEach, afterEach, describe, it, before, after} from 'mocha';
 import Q from 'p-queue';
 import * as uuid from 'uuid';
 
-import {Bigtable} from '../src';
+import {Backup, Bigtable, Instance} from '../src';
 import {AppProfile} from '../src/app-profile.js';
 import {Cluster} from '../src/cluster.js';
 import {Family} from '../src/family.js';
@@ -35,6 +36,20 @@ describe('Bigtable', () => {
   const APP_PROFILE = INSTANCE.appProfile(APP_PROFILE_ID);
   const CLUSTER_ID = generateId('cluster');
 
+  async function reapBackups(instance: Instance) {
+    const [clusters] = await instance.getClusters();
+    return Promise.all(
+      clusters.map(async cluster => {
+        const [backups] = await cluster.listBackups();
+        return Promise.all(
+          backups.map(backup =>
+            backup.delete({gaxOptions: {timeout: 50 * 1000}})
+          )
+        );
+      })
+    );
+  }
+
   async function reapInstances() {
     const [instances] = await bigtable.getInstances();
     const testInstances = instances
@@ -46,6 +61,8 @@ describe('Bigtable', () => {
         return !timeCreated || timeCreated <= oneHourAgo;
       });
     const q = new Q({concurrency: 5});
+    // need to delete backups first due to instance deletion precondition
+    await Promise.all(testInstances.map(instance => reapBackups(instance)));
     await Promise.all(
       testInstances.map(instance => {
         q.add(() => instance.delete());
@@ -1111,8 +1128,202 @@ describe('Bigtable', () => {
       assert.strictEqual(rows.length, 0);
     });
   });
+
+  describe('backups', () => {
+    const CLUSTER = INSTANCE.cluster(CLUSTER_ID);
+
+    // For these tests, two backups are needed. The backups are labeled for what
+    // they are intended to originate/interact from/with, but this is just for
+    // testing and the naming convention used here does not actually influence
+    // the real functionality - it is just a way to keep things organized!
+    const backupIdFromCluster = generateId('backup');
+    const backupNameFromCluster = `${CLUSTER.name}/backups/${backupIdFromCluster}`;
+    const restoreTableIdFromCluster = generateId('table');
+
+    const backupIdFromTable = generateId('backup');
+    const backupNameFromTable = `${CLUSTER.name}/backups/${backupIdFromTable}`;
+    const restoreTableIdFromTable = generateId('table');
+
+    // The minimum backup expiry time is 6 hours. The times here each have a 2
+    // hour padding to tolerate latency and clock drift. Also, while the time
+    // implementation for backups in this client accepts any of a Timestamp
+    // Struct, Date, or PreciseDate, to keep things easy this uses PreciseDate.
+    const expireTime = new PreciseDate(PreciseDate.now() + 8 * 60 * 60 * 1000);
+    const updateExpireTime = new PreciseDate(
+      expireTime.getTime() + 2 + 60 * 60 * 1000
+    );
+
+    it('should create backup of a table (from cluster)', async () => {
+      const [op] = await CLUSTER.createBackup(TABLE, backupIdFromCluster, {
+        expireTime,
+      });
+      const name = replaceProjectId(bigtable, backupNameFromCluster);
+      assert(op.latestResponse.name.indexOf(`operations/${name}`) === 0);
+
+      const [backup] = await op.promise();
+      assert.strictEqual(backup.state, 2);
+      assert.strictEqual(backup.name, name);
+
+      const expectedTime = expireTime.toStruct();
+      assert.deepStrictEqual(
+        backup.expireTime?.seconds?.toString(),
+        expectedTime.seconds.toString()
+      );
+      assert.deepStrictEqual(
+        backup.expireTime?.nanos?.toString(),
+        expectedTime.nanos.toString()
+      );
+    });
+
+    it('should create backup of a table (from table)', async () => {
+      const [op] = await TABLE.backup(backupIdFromTable, {expireTime});
+      const name = replaceProjectId(bigtable, backupNameFromTable);
+      assert(op.latestResponse.name.indexOf(`operations/${name}`) === 0);
+
+      const [backup] = await op.promise();
+      assert.strictEqual(backup.state, 2);
+      assert.strictEqual(backup.name, name);
+
+      const expectedTime = expireTime.toStruct();
+      assert.deepStrictEqual(
+        backup.expireTime?.seconds?.toString(),
+        expectedTime.seconds.toString()
+      );
+      assert.deepStrictEqual(
+        backup.expireTime?.nanos?.toString(),
+        expectedTime.nanos.toString()
+      );
+    });
+
+    it('should get a specific backup (cluster)', async () => {
+      const [backup] = await CLUSTER.getBackup(backupIdFromCluster);
+      const name = replaceProjectId(bigtable, backupNameFromCluster);
+      assert.strictEqual(backup.name, name);
+      assert.strictEqual(backup.backupId, backupIdFromCluster);
+      assert.strictEqual(backup.state, 'READY');
+    });
+
+    it('should get a specific backup (self)', async () => {
+      const unfetchedBackup = CLUSTER.asBackup({
+        name: backupNameFromTable, // still has {{projectId}}
+      });
+      const [backup] = await unfetchedBackup.get();
+      const name = replaceProjectId(bigtable, backupNameFromTable);
+      assert.strictEqual(backup.name, name);
+      assert.strictEqual(backup.backupId, backupIdFromTable);
+      assert.strictEqual(backup.state, 'READY');
+    });
+
+    it('should list backups (await)', async () => {
+      const [backups] = await CLUSTER.listBackups();
+      assert(Array.isArray(backups));
+      assert(backups.length > 0);
+      assert(backups.every(backup => backup.metadata.name === backup.name));
+      assert(backups.some(backup => backup.backupId === backupIdFromCluster));
+      assert(backups.some(backup => backup.backupId === backupIdFromTable));
+    });
+
+    it('should list backups (stream)', done => {
+      const backups: Backup[] = [];
+      CLUSTER.listBackupsStream()
+        .on('error', done)
+        .on('data', backup => {
+          assert(backup.metadata.name === backup.name);
+          backups.push(backup);
+        })
+        .on('end', () => {
+          assert(backups.length > 0);
+          done();
+        });
+    });
+
+    it('should restore a backup (cluster)', async () => {
+      const [op] = await INSTANCE.restoreTable(
+        backupIdFromCluster,
+        CLUSTER_ID,
+        restoreTableIdFromCluster
+      );
+
+      const [table, meta] = await op.promise();
+      const restoredTableId = table.name?.split('/').pop();
+      const name = replaceProjectId(bigtable, backupNameFromCluster);
+      assert.strictEqual(restoredTableId, restoreTableIdFromCluster);
+      assert.strictEqual(meta.backupInfo?.backup, name);
+    });
+
+    it('should restore a backup (self)', async () => {
+      const [backup] = await CLUSTER.getBackup(backupIdFromTable);
+      const [op] = await backup.restore(restoreTableIdFromTable);
+
+      const [table, meta] = await op.promise();
+      const restoredTableId = table.name?.split('/').pop();
+      const name = replaceProjectId(bigtable, backupNameFromTable);
+      assert.strictEqual(restoredTableId, restoreTableIdFromTable);
+      assert.strictEqual(meta.backupInfo?.backup, name);
+    });
+
+    it('should update a backup (cluster)', async () => {
+      const [updated] = await CLUSTER.updateBackup(backupIdFromCluster, {
+        expireTime: updateExpireTime,
+      });
+
+      const name = replaceProjectId(bigtable, backupNameFromCluster);
+      assert.strictEqual(updated.name, name);
+
+      const expectedTime = updateExpireTime.toStruct();
+      assert.deepStrictEqual(
+        updated.expireTime?.seconds?.toString(),
+        expectedTime.seconds.toString()
+      );
+      assert.deepStrictEqual(
+        updated.expireTime?.nanos?.toString(),
+        expectedTime.nanos.toString()
+      );
+    });
+
+    it('should update a backup (self)', async () => {
+      const unfetchedBackup = CLUSTER.asBackup({
+        name: backupNameFromTable,
+      });
+      const [updated] = await unfetchedBackup.update({
+        expireTime: updateExpireTime,
+      });
+
+      const name = replaceProjectId(bigtable, backupNameFromTable);
+      assert.strictEqual(updated.name, name);
+
+      const expectedTime = updateExpireTime.toStruct();
+      assert.deepStrictEqual(
+        updated.expireTime?.seconds?.toString(),
+        expectedTime.seconds.toString()
+      );
+      assert.deepStrictEqual(
+        updated.expireTime?.nanos?.toString(),
+        expectedTime.nanos.toString()
+      );
+    });
+
+    it('should delete a backup (cluster)', async () => {
+      await CLUSTER.deleteBackup(backupIdFromCluster, {
+        // deleting a backup takes a good 30-40 seconds
+        gaxOptions: {timeout: 50 * 1000},
+      });
+    });
+
+    it('should delete a backup (self)', async () => {
+      const [backup] = await CLUSTER.getBackup(backupIdFromTable);
+      await backup.delete({
+        // deleting a backup takes a good 30-40 seconds
+        gaxOptions: {timeout: 50 * 1000},
+      });
+    });
+  });
 });
 
 function generateId(resourceType: string) {
   return PREFIX + resourceType + '-' + uuid.v1().substr(0, 8);
+}
+
+function replaceProjectId(bigtable: Bigtable, resourcePath: string): string {
+  return resourcePath.replace('{{projectId}}', bigtable.projectId);
 }

--- a/test/app-profile.ts
+++ b/test/app-profile.ts
@@ -20,10 +20,11 @@ import {CallOptions} from 'google-gax';
 
 let promisified = false;
 const fakePromisify = Object.assign({}, promisify, {
-  promisifyAll(klass: Function) {
+  promisifyAll(klass: Function, options: any) {
     if (klass.name === 'AppProfile') {
       promisified = true;
     }
+    promisify.promisifyAll(klass, options);
   },
 });
 

--- a/test/backup.ts
+++ b/test/backup.ts
@@ -1,0 +1,448 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {PreciseDate} from '@google-cloud/precise-date';
+import * as assert from 'assert';
+import {afterEach, beforeEach, describe, it} from 'mocha';
+import * as sinon from 'sinon';
+import {Backup} from '../src/backup';
+import {google} from '../protos/protos';
+import {Bigtable, ModifiableBackupFields} from '../src';
+
+import IBackup = google.bigtable.admin.v2.IBackup;
+
+const sandbox = sinon.createSandbox();
+
+describe('Bigtable/Backup', () => {
+  const PROJECT_ID = 'my-project';
+  const INSTANCE_ID = 'my-instance';
+  const CLUSTER_ID = 'my-cluster';
+  const BACKUP_ID = 'my-backup';
+  const TABLE_ID = 'my-table';
+
+  const INSTANCE_NAME = `projects/${PROJECT_ID}/instances/${INSTANCE_ID}`;
+  const CLUSTER_NAME = `${INSTANCE_NAME}/clusters/${CLUSTER_ID}`;
+  const BACKUP_NAME = `${CLUSTER_NAME}/backups/${BACKUP_ID};`;
+  const TABLE_NAME = `${INSTANCE_NAME}/tables/${TABLE_ID}`;
+
+  const now = Date.now();
+  const aMinuteInMillis = 60 * 1000;
+  const aDayInMillis = 24 * 60 * aMinuteInMillis;
+
+  let bigtableMock: unknown;
+  let backupStruct: IBackup;
+  let instanceStub: sinon.SinonStub;
+  let clusterStub: sinon.SinonStub;
+  let clusterPathStub: sinon.SinonStub;
+  let matchProjectStub: sinon.SinonStub;
+  let matchInstanceStub: sinon.SinonStub;
+  let matchClusterStub: sinon.SinonStub;
+  let matchBackupStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    instanceStub = sandbox.stub();
+    clusterStub = sandbox.stub();
+    clusterPathStub = sandbox.stub().returns(CLUSTER_NAME);
+    matchProjectStub = sandbox.stub().returns(PROJECT_ID);
+    matchInstanceStub = sandbox.stub().returns(INSTANCE_ID);
+    matchClusterStub = sandbox.stub().returns(CLUSTER_ID);
+    matchBackupStub = sandbox.stub().returns(BACKUP_ID);
+
+    const instanceMock = {
+      cluster: clusterStub,
+    };
+    instanceStub.returns(instanceMock);
+
+    bigtableMock = {
+      api: {
+        BigtableTableAdminClient: {
+          clusterPath: clusterPathStub,
+          matchProjectFromBackupName: matchProjectStub,
+          matchInstanceFromBackupName: matchInstanceStub,
+          matchClusterFromBackupName: matchClusterStub,
+          matchBackupFromBackupName: matchBackupStub,
+        },
+      },
+      instance: instanceStub,
+    };
+
+    backupStruct = Object.freeze({
+      name: BACKUP_NAME,
+      sourceTable: TABLE_NAME,
+      expireTime: new PreciseDate(now + aDayInMillis).toStruct(),
+      startTime: new PreciseDate(now).toStruct(),
+      endTime: new PreciseDate(now + aMinuteInMillis).toStruct(),
+      sizeBytes: 42,
+      state: 'READY',
+    });
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('instantiation', () => {
+    it('should create backup from response data', () => {
+      assert.doesNotThrow(
+        () => new Backup(bigtableMock as Bigtable, backupStruct)
+      );
+    });
+
+    it('should copy all properties to maintain the interface', () => {
+      const backup = new Backup(bigtableMock as Bigtable, backupStruct);
+      assert.strictEqual(backup.name, backupStruct.name);
+      assert.strictEqual(backup.sourceTable, backupStruct.sourceTable);
+      assert.deepStrictEqual(backup.expireTime, backupStruct.expireTime);
+      assert.deepStrictEqual(backup.startTime, backupStruct.startTime);
+      assert.deepStrictEqual(backup.endTime, backupStruct.endTime);
+      assert.strictEqual(backup.sizeBytes, backupStruct.sizeBytes);
+      assert.strictEqual(backup.state, backupStruct.state);
+    });
+
+    it('should keep the original struct as metadata', () => {
+      const backup = new Backup(bigtableMock as Bigtable, backupStruct);
+      assert.strictEqual(backup.metadata, backupStruct);
+    });
+
+    it('should keep a copy of original instance primitive as metadata', () => {
+      const backup = new Backup(bigtableMock as Bigtable, backupStruct);
+      const copy = new Backup(bigtableMock as Bigtable, backup);
+      assert.notStrictEqual(copy.metadata, backup);
+      assert.deepStrictEqual(copy.metadata, backupStruct);
+    });
+  });
+
+  describe('parent', () => {
+    it('should return inferred parent (cluster)', () => {
+      const backup = new Backup(bigtableMock as Bigtable, backupStruct);
+      assert.strictEqual(backup.parent, CLUSTER_NAME);
+      assert(clusterPathStub.calledOnce);
+      assert.deepStrictEqual(clusterPathStub.firstCall.args, [
+        PROJECT_ID,
+        INSTANCE_ID,
+        CLUSTER_ID,
+      ]);
+    });
+
+    it('should throw if missing backup name', () => {
+      const backup = new Backup(bigtableMock as Bigtable, backupStruct);
+      backup.name = null;
+      assert.throws(() => backup.parent, TypeError);
+      assert(clusterPathStub.notCalled);
+    });
+  });
+
+  describe('projectId', () => {
+    it('should return inferred projectId', () => {
+      const backup = new Backup(bigtableMock as Bigtable, backupStruct);
+      assert.strictEqual(backup.projectId, PROJECT_ID);
+      assert(matchProjectStub.calledOnce);
+      assert.deepStrictEqual(matchProjectStub.firstCall.args, [BACKUP_NAME]);
+    });
+
+    it('should throw if missing backup name', () => {
+      const backup = new Backup(bigtableMock as Bigtable, backupStruct);
+      backup.name = null;
+      assert.throws(() => backup.projectId, TypeError);
+      assert(matchProjectStub.notCalled);
+    });
+  });
+
+  describe('instanceId', () => {
+    it('should return inferred instanceId', () => {
+      const backup = new Backup(bigtableMock as Bigtable, backupStruct);
+      assert.strictEqual(backup.instanceId, INSTANCE_ID);
+      assert(matchInstanceStub.calledOnce);
+      assert.deepStrictEqual(matchInstanceStub.firstCall.args, [BACKUP_NAME]);
+    });
+
+    it('should throw if missing backup name', () => {
+      const backup = new Backup(bigtableMock as Bigtable, backupStruct);
+      backup.name = null;
+      assert.throws(() => backup.instanceId, TypeError);
+      assert(matchInstanceStub.notCalled);
+    });
+  });
+
+  describe('clusterId', () => {
+    it('should return inferred clusterId', () => {
+      const backup = new Backup(bigtableMock as Bigtable, backupStruct);
+      assert.strictEqual(backup.clusterId, CLUSTER_ID);
+      assert(matchClusterStub.calledOnce);
+      assert.deepStrictEqual(matchClusterStub.firstCall.args, [BACKUP_NAME]);
+    });
+
+    it('should throw if missing backup name', () => {
+      const backup = new Backup(bigtableMock as Bigtable, backupStruct);
+      backup.name = null;
+      assert.throws(() => backup.clusterId, TypeError);
+      assert(matchClusterStub.notCalled);
+    });
+  });
+
+  describe('backupId', () => {
+    it('should return inferred backupId', () => {
+      const backup = new Backup(bigtableMock as Bigtable, backupStruct);
+      assert.strictEqual(backup.backupId, BACKUP_ID);
+      assert(matchBackupStub.calledOnce);
+      assert.deepStrictEqual(matchBackupStub.firstCall.args, [BACKUP_NAME]);
+    });
+
+    it('should throw if missing backup name', () => {
+      const backup = new Backup(bigtableMock as Bigtable, backupStruct);
+      backup.name = null;
+      assert.throws(() => backup.backupId, TypeError);
+      assert(matchBackupStub.notCalled);
+    });
+  });
+
+  describe('expireDate', () => {
+    it('should return expireTime as expireDate', () => {
+      const backup = new Backup(bigtableMock as Bigtable, backupStruct);
+      const {expireDate} = backup;
+      assert(expireDate instanceof PreciseDate);
+      assert.deepStrictEqual(expireDate.toStruct(), backupStruct.expireTime);
+    });
+
+    it('should throw if missing expireTime', () => {
+      const backup = new Backup(bigtableMock as Bigtable, backupStruct);
+      backup.expireTime = null;
+      assert.throws(() => backup.expireDate, TypeError);
+    });
+  });
+
+  describe('startDate', () => {
+    it('should return startTime as startDate', () => {
+      const backup = new Backup(bigtableMock as Bigtable, backupStruct);
+      const {startDate} = backup;
+      assert(startDate instanceof PreciseDate);
+      assert.deepStrictEqual(startDate.toStruct(), backupStruct.startTime);
+    });
+
+    it('should throw if missing startTime', () => {
+      const backup = new Backup(bigtableMock as Bigtable, backupStruct);
+      backup.startTime = null;
+      assert.throws(() => backup.startDate, TypeError);
+    });
+  });
+
+  describe('endDate', () => {
+    it('should return endTime as endDate', () => {
+      const backup = new Backup(bigtableMock as Bigtable, backupStruct);
+      const {endDate} = backup;
+      assert(endDate instanceof PreciseDate);
+      assert.deepStrictEqual(endDate.toStruct(), backupStruct.endTime);
+    });
+
+    it('should throw if missing endTime', () => {
+      const backup = new Backup(bigtableMock as Bigtable, backupStruct);
+      backup.endTime = null;
+      assert.throws(() => backup.endDate, TypeError);
+    });
+  });
+
+  describe('delete', () => {
+    let deleteStub: sinon.SinonStub;
+
+    beforeEach(() => {
+      deleteStub = sandbox.stub().resolves('ok');
+      clusterStub.returns({deleteBackup: deleteStub});
+    });
+
+    it('should delete backup via cluster interface', async () => {
+      const backup = new Backup(bigtableMock as Bigtable, backupStruct);
+      await backup.delete();
+      assert(instanceStub.calledOnceWithExactly(INSTANCE_ID), 'instance');
+      assert(clusterStub.calledOnceWithExactly(CLUSTER_ID), 'cluster');
+      assert(deleteStub.calledOnce, 'deleteBackup');
+      assert.deepStrictEqual(deleteStub.firstCall.args, [BACKUP_ID, undefined]);
+    });
+
+    it('should pass through options', async () => {
+      const backup = new Backup(bigtableMock as Bigtable, backupStruct);
+      const opts = Object.freeze({gaxOptions: {timeout: 9000}});
+      await backup.delete(opts);
+      assert(deleteStub.calledOnce, 'deleteBackup');
+      assert.deepStrictEqual(deleteStub.firstCall.args, [BACKUP_ID, opts]);
+    });
+
+    it('should reject if missing backup name', async () => {
+      const backup = new Backup(bigtableMock as Bigtable, backupStruct);
+      backup.name = null;
+      await assert.rejects(async () => await backup.delete(), TypeError);
+      assert(deleteStub.notCalled);
+    });
+
+    it('should resolve the original value from api', async () => {
+      const backup = new Backup(bigtableMock as Bigtable, backupStruct);
+      const result = await backup.delete();
+      assert.strictEqual(result, 'ok');
+    });
+  });
+
+  describe('get', () => {
+    let getStub: sinon.SinonStub;
+
+    beforeEach(() => {
+      getStub = sandbox.stub().resolves('ok');
+      clusterStub.returns({getBackup: getStub});
+    });
+
+    it('should get backup via cluster interface', async () => {
+      const backup = new Backup(bigtableMock as Bigtable, backupStruct);
+      await backup.get();
+      assert(instanceStub.calledOnceWithExactly(INSTANCE_ID), 'instance');
+      assert(clusterStub.calledOnceWithExactly(CLUSTER_ID), 'cluster');
+      assert(getStub.calledOnce, 'getBackup');
+      assert.deepStrictEqual(getStub.firstCall.args, [BACKUP_ID, undefined]);
+    });
+
+    it('should pass through options', async () => {
+      const backup = new Backup(bigtableMock as Bigtable, backupStruct);
+      const opts = Object.freeze({gaxOptions: {timeout: 9000}});
+      await backup.get(opts);
+      assert(getStub.calledOnce, 'getBackup');
+      assert.deepStrictEqual(getStub.firstCall.args, [BACKUP_ID, opts]);
+    });
+
+    it('should reject if missing backup name', async () => {
+      const backup = new Backup(bigtableMock as Bigtable, backupStruct);
+      backup.name = null;
+      await assert.rejects(async () => await backup.get(), TypeError);
+      assert(getStub.notCalled);
+    });
+
+    it('should resolve the original value from api', async () => {
+      const backup = new Backup(bigtableMock as Bigtable, backupStruct);
+      const result = await backup.get();
+      assert.strictEqual(result, 'ok');
+    });
+  });
+
+  describe('restore', () => {
+    let restoreStub: sinon.SinonStub;
+
+    beforeEach(() => {
+      restoreStub = sandbox.stub().resolves('ok');
+      instanceStub.returns({restoreTable: restoreStub});
+    });
+
+    it('should restore backup via cluster interface', async () => {
+      const backup = new Backup(bigtableMock as Bigtable, backupStruct);
+      await backup.restore(TABLE_ID);
+      assert(instanceStub.calledOnceWithExactly(INSTANCE_ID), 'instance');
+      assert(clusterStub.notCalled, 'avoid cluster invocation mistake');
+      assert(restoreStub.calledOnce, 'restoreBackup');
+      assert.deepStrictEqual(restoreStub.firstCall.args, [
+        BACKUP_ID,
+        CLUSTER_ID,
+        TABLE_ID,
+        undefined,
+      ]);
+    });
+
+    it('should pass through options', async () => {
+      const backup = new Backup(bigtableMock as Bigtable, backupStruct);
+      const opts = Object.freeze({gaxOptions: {timeout: 9000}});
+      await backup.restore(TABLE_ID, opts);
+      assert(restoreStub.calledOnce, 'restoreBackup');
+      assert.deepStrictEqual(restoreStub.firstCall.args, [
+        BACKUP_ID,
+        CLUSTER_ID,
+        TABLE_ID,
+        opts,
+      ]);
+    });
+
+    it('should reject if missing backup name', async () => {
+      const backup = new Backup(bigtableMock as Bigtable, backupStruct);
+      backup.name = null;
+      await assert.rejects(
+        async () => await backup.restore(TABLE_ID),
+        TypeError
+      );
+      assert(restoreStub.notCalled);
+    });
+
+    it('should resolve the original value from api', async () => {
+      const backup = new Backup(bigtableMock as Bigtable, backupStruct);
+      const result = await backup.restore(TABLE_ID);
+      assert.strictEqual(result, 'ok');
+    });
+  });
+
+  describe('update', () => {
+    let updateStub: sinon.SinonStub;
+    let fields: ModifiableBackupFields;
+
+    beforeEach(() => {
+      updateStub = sandbox.stub().resolves('ok');
+      clusterStub.returns({updateBackup: updateStub});
+      fields = {
+        expireTime: new Date(),
+      };
+    });
+
+    it('should update backup via cluster interface', async () => {
+      const backup = new Backup(bigtableMock as Bigtable, backupStruct);
+      await backup.update(fields);
+      assert(instanceStub.calledOnceWithExactly(INSTANCE_ID), 'instance');
+      assert(clusterStub.calledOnceWithExactly(CLUSTER_ID), 'cluster');
+      assert(updateStub.calledOnce, 'updateBackup');
+      assert.deepStrictEqual(updateStub.firstCall.args, [
+        BACKUP_ID,
+        fields,
+        undefined,
+      ]);
+    });
+
+    it('should pass through options', async () => {
+      const backup = new Backup(bigtableMock as Bigtable, backupStruct);
+      const opts = Object.freeze({gaxOptions: {timeout: 9000}});
+      await backup.update(fields, opts);
+      assert(updateStub.calledOnce, 'updateBackup');
+      assert.deepStrictEqual(updateStub.firstCall.args, [
+        BACKUP_ID,
+        fields,
+        opts,
+      ]);
+    });
+
+    it('should reject if missing backup name', async () => {
+      const backup = new Backup(bigtableMock as Bigtable, backupStruct);
+      backup.name = null;
+      await assert.rejects(async () => await backup.update(fields), TypeError);
+      assert(updateStub.notCalled);
+    });
+
+    it('should resolve the original value from api', async () => {
+      const backup = new Backup(bigtableMock as Bigtable, backupStruct);
+      const result = await backup.update(fields);
+      assert.strictEqual(result, 'ok');
+    });
+  });
+
+  describe('valueOf', () => {
+    it('should implement valueOf which clones from metadata', () => {
+      const backup = new Backup(bigtableMock as Bigtable, backupStruct);
+      const cloned = backup.valueOf();
+
+      assert.deepStrictEqual(cloned, backupStruct);
+      assert.notStrictEqual(cloned, backupStruct);
+
+      assert.deepStrictEqual(cloned, backup.metadata);
+      assert.notStrictEqual(cloned, backup.metadata);
+    });
+  });
+});

--- a/test/cluster.ts
+++ b/test/cluster.ts
@@ -28,6 +28,7 @@ const fakePromisify = Object.assign({}, promisify, {
     if (klass.name === 'Cluster') {
       promisified = true;
     }
+    assert.deepStrictEqual(options.exclude, ['asBackup']);
     promisify.promisifyAll(klass, options);
   },
 });
@@ -460,6 +461,18 @@ describe('Bigtable/Cluster', () => {
         assert.deepStrictEqual([].slice.call(argsies), args);
         done();
       });
+    });
+  });
+
+  describe('asBackup', () => {
+    it('should return a Backup instance', () => {
+      const backup = cluster.asBackup({name: 'foo'});
+      assert(BackupClassStub.calledOnce, 'Backup constructor called');
+      assert.deepStrictEqual(BackupClassStub.firstCall.args, [
+        {...INSTANCE.bigtable},
+        {name: 'foo'},
+      ]);
+      assert(backup instanceof BackupClassStub, 'is a Backup');
     });
   });
 

--- a/test/cluster.ts
+++ b/test/cluster.ts
@@ -20,10 +20,11 @@ import {CallOptions} from 'google-gax';
 
 let promisified = false;
 const fakePromisify = Object.assign({}, promisify, {
-  promisifyAll(klass: Function) {
+  promisifyAll(klass: Function, options: any) {
     if (klass.name === 'Cluster') {
       promisified = true;
     }
+    promisify.promisifyAll(klass, options);
   },
 });
 

--- a/test/family.ts
+++ b/test/family.ts
@@ -23,10 +23,11 @@ import {Table} from '../src/table';
 
 let promisified = false;
 const fakePromisify = Object.assign({}, promisify, {
-  promisifyAll(klass: Function) {
+  promisifyAll(klass: Function, options: any) {
     if (klass.name === 'Family') {
       promisified = true;
     }
+    promisify.promisifyAll(klass, options);
   },
 });
 

--- a/test/index.ts
+++ b/test/index.ts
@@ -49,6 +49,7 @@ const fakePromisify = Object.assign({}, promisify, {
       'operation',
       'request',
     ]);
+    promisify.promisifyAll(klass, options);
   },
 });
 const fakeReplaceProjectIdToken = Object.assign({}, projectify, {
@@ -503,7 +504,7 @@ describe('Bigtable', () => {
       );
     });
 
-    it('should throw an error if cluster id not provided.', () => {
+    it('should reject if cluster id not provided.', async () => {
       const options = {
         displayName: 'my-sweet-instance',
         labels: {env: 'prod'},
@@ -515,9 +516,28 @@ describe('Bigtable', () => {
           },
         ],
       };
-      assert.throws(() => {
-        bigtable.createInstance(INSTANCE_ID, options);
-      }, /A cluster was provided without an `id` property defined\./);
+      await assert.rejects(
+        async () => await bigtable.createInstance(INSTANCE_ID, options),
+        /A cluster was provided without an `id` property defined\./
+      );
+    });
+
+    it('should throw if falsy cluster id not provided.', () => {
+      const options = {
+        displayName: 'my-sweet-instance',
+        labels: {env: 'prod'},
+        clusters: [
+          {
+            nodes: 3,
+            location: 'us-central1-b',
+            storage: 'ssd',
+          },
+        ],
+      };
+      assert.throws(
+        () => bigtable.createInstance(INSTANCE_ID, options, () => {}),
+        /A cluster was provided without an `id` property defined\./
+      );
     });
 
     it('should throw an error if configuration object is not provided', () => {

--- a/test/instance.ts
+++ b/test/instance.ts
@@ -1,4 +1,4 @@
-// Copyright 2016 Google LLC
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -97,6 +97,10 @@ describe('Bigtable/Instance', () => {
   const INSTANCE_NAME = `${BIGTABLE.projectName}/instances/${INSTANCE_ID}`;
   const APP_PROFILE_ID = 'my-app-profile';
   const CLUSTER_ID = 'my-cluster';
+  const TABLE_ID = 'my-table';
+  const BACKUP_ID = 'my-backup';
+  const BACKUP_NAME = `${INSTANCE_NAME}/clusters/${CLUSTER_ID}/backups/${BACKUP_ID}`;
+
   let Instance: typeof inst.Instance;
   let instance: inst.Instance;
 
@@ -1239,6 +1243,111 @@ describe('Bigtable/Instance', () => {
           assert(tables.length > 0);
           done();
         });
+    });
+  });
+
+  describe('restoreTable', () => {
+    let requestStub: sinon.SinonStub;
+
+    beforeEach(() => {
+      requestStub = sandbox.stub().yields(null, 'ok');
+      instance.bigtable.request = requestStub;
+    });
+
+    it('should throw if falsy backupId', () => {
+      assert.throws(
+        () => instance.restoreTable('', '', '', () => {}),
+        /backup id is required/i
+      );
+      assert(requestStub.notCalled);
+    });
+
+    it('should reject if missing backupId', async () => {
+      await assert.rejects(
+        async () => await (instance.restoreTable as Function)(),
+        /backup id is required/i
+      );
+      assert(requestStub.notCalled);
+    });
+
+    it('should throw if falsy clusterId', () => {
+      assert.throws(
+        () => instance.restoreTable(BACKUP_ID, '', '', () => {}),
+        /cluster id is required/i
+      );
+      assert(requestStub.notCalled);
+    });
+
+    it('should reject if missing clusterId', async () => {
+      await assert.rejects(
+        async () => await (instance.restoreTable as Function)(BACKUP_ID),
+        /cluster id is required/i
+      );
+      assert(requestStub.notCalled);
+    });
+
+    it('should throw if falsy tableId', () => {
+      assert.throws(
+        () => instance.restoreTable(BACKUP_ID, CLUSTER_ID, '', () => {}),
+        /table id is required/i
+      );
+      assert(requestStub.notCalled);
+    });
+
+    it('should reject if missing tableId', async () => {
+      await assert.rejects(
+        async () =>
+          await (instance.restoreTable as Function)(BACKUP_ID, CLUSTER_ID),
+        /table id is required/i
+      );
+      assert(requestStub.notCalled);
+    });
+
+    it('should call request with rpc signature', async () => {
+      await instance.restoreTable(BACKUP_ID, CLUSTER_ID, TABLE_ID);
+      assert(requestStub.calledOnceWith(sinon.match.object, sinon.match.func));
+      assert.deepStrictEqual(requestStub.firstCall.args[0], {
+        client: 'BigtableTableAdminClient',
+        method: 'restoreTable',
+        reqOpts: {
+          parent: INSTANCE_NAME,
+          tableId: TABLE_ID,
+          backup: BACKUP_NAME,
+        },
+        gaxOpts: undefined,
+      });
+    });
+
+    it('should handle the response', async () => {
+      const [result] = await instance.restoreTable(
+        BACKUP_ID,
+        CLUSTER_ID,
+        TABLE_ID
+      );
+      assert.strictEqual(result, 'ok');
+    });
+
+    it('should call request including opts', async () => {
+      const [result] = await instance.restoreTable(
+        BACKUP_ID,
+        CLUSTER_ID,
+        TABLE_ID,
+        {gaxOptions: {timeout: 9000}}
+      );
+      assert.deepStrictEqual(requestStub.firstCall.args[0].gaxOpts, {
+        timeout: 9000,
+      });
+      assert.strictEqual(result, 'ok');
+    });
+
+    it('should bubble up errors while restoring a table', async () => {
+      const err = new Error('uh oh!');
+      requestStub.yields(err);
+
+      await assert.rejects(
+        async () => await instance.restoreTable(BACKUP_ID, CLUSTER_ID, TABLE_ID)
+      );
+      assert(requestStub.calledOnceWith(sinon.match.object, sinon.match.func));
     });
   });
 

--- a/test/instance.ts
+++ b/test/instance.ts
@@ -49,6 +49,7 @@ const fakePromisify = Object.assign({}, promisify, {
       'table',
       'getTablesStream',
     ]);
+    promisify.promisifyAll(klass, options);
   },
 });
 
@@ -435,10 +436,18 @@ describe('Bigtable/Instance', () => {
     const TABLE_NAME =
       'projects/my-project/instances/my-instance/tables/my-table';
 
-    it('should throw if an id is not provided', () => {
-      assert.throws(() => {
-        (instance.createTable as Function)();
-      }, /An id is required to create a table\./);
+    it('should throw if a falsy id is provided', () => {
+      assert.throws(
+        () => instance.createTable('', () => {}),
+        /An id is required to create a table\./
+      );
+    });
+
+    it('should reject if an id is not provided', async () => {
+      await assert.rejects(
+        async () => await (instance.createTable as Function)(),
+        /An id is required to create a table\./
+      );
     });
 
     it('should provide the proper request options', done => {

--- a/test/row.ts
+++ b/test/row.ts
@@ -27,10 +27,11 @@ const sandbox = sinon.createSandbox();
 
 let promisified = false;
 const fakePromisify = Object.assign({}, promisify, {
-  promisifyAll(klass: Function) {
+  promisifyAll(klass: Function, options: any) {
     if (klass.name === 'Row') {
       promisified = true;
     }
+    promisify.promisifyAll(klass, options);
   },
 });
 
@@ -631,9 +632,17 @@ describe('Bigtable/Row', () => {
     ];
 
     it('should throw if a rule is not provided', () => {
-      assert.throws(() => {
-        (row.createRules as Function)();
-      }, /At least one rule must be provided\./);
+      assert.throws(
+        () => (row.createRules as Function)(undefined, () => {}),
+        /At least one rule must be provided\./
+      );
+    });
+
+    it('should reject if a rule is not provided', async () => {
+      await assert.rejects(
+        async () => await (row.createRules as Function)(),
+        /At least one rule must be provided\./
+      );
     });
 
     it('should read/modify/write rules', done => {

--- a/test/table.ts
+++ b/test/table.ts
@@ -44,6 +44,7 @@ const fakePromisify = Object.assign({}, promisify, {
     }
     promisified = true;
     assert.deepStrictEqual(options.exclude, ['family', 'row']);
+    promisify.promisifyAll(klass, options);
   },
 });
 
@@ -301,10 +302,17 @@ describe('Bigtable/Table', () => {
     const FAMILY_ID = 'test-family';
 
     it('should throw if a id is not provided', () => {
-      assert.throws(() => {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (table as any).createFamily();
-      }, /An id is required to create a family\./);
+      assert.throws(
+        () => table.createFamily(undefined, () => {}),
+        /An id is required to create a family\./
+      );
+    });
+
+    it('should reject if a id is not provided', async () => {
+      await assert.rejects(
+        async () => await table.createFamily(),
+        /An id is required to create a family\./
+      );
     });
 
     it('should provide the proper request options', done => {
@@ -2425,7 +2433,7 @@ describe('Bigtable/Table', () => {
         done();
       };
 
-      table.sampleRowKeys(gaxOptions);
+      table.sampleRowKeys(gaxOptions, () => {});
     });
 
     describe('success', () => {

--- a/test/table.ts
+++ b/test/table.ts
@@ -1,4 +1,4 @@
-// Copyright 2016 Google LLC
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -1304,6 +1304,7 @@ describe('Bigtable/Table', () => {
       await assert.rejects(async () => await table.backup('id', fields), err);
     });
 
+    // test each cluster state that is not eligible for starting a backup
     ([
       'STATE_NOT_KNOWN',
       'INITIALIZING',


### PR DESCRIPTION
This is the hand-written implementation that introduces backup support for tables.

- A backup represents a table on a specific cluster
- Backups reside local to a cluster
- A backup is restored as a table to the cluster from where it originated
- proto methods have been mirrored to the relevant classes based on parent resource requirements:
  - `createBackup`, `getBackup`, `listBackups`, `updateBackup`, and `deleteBackup` are in `Cluster`
  - `restoreTable` is in `Instance`
- Friendlier methods that are more intuitive wrap the aforementioned proto proxies requiring less input criteria:
  - `table.backup()` to create a backup
  - Introduced a `Backup` class with `delete`, `get`, `restore`, and `update` methods
  - Dates are JS-friendly and params/responses convert to/from Timestamp Struct, Date, and PreciseDate
- Some methods return a `Backup` or `Backup[]` where applicable, but Longrunning Operations (LROs) do not
  - LROs do not transform their result into a `Backup`, this is left to the user
  - LROs return POJOs instead
  - Added `cluster.asBackup` casting helper to convert POJOs into `Backup`
- Metadata results were sparse for the response structs for backups, the "backup" _is_ the metadata in most cases
- Aside: wrote tests using async/await
  - promisify is refactored as pass through to allow for promises
  - Changed this in unrelated test suites and fixed signature tests where they were incorrect
- When testing, instances _cannot_ be deleted if they have backups defined
  - Remove all backups before removing the instances
  - A fully parallel backup reaper was introduced to help, it runs before the instance reaper

PR checklist:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/nodejs-bigtable/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [X] Ensure the tests and linter pass
- [X] Code coverage does not decrease (if any source code was changed)
- [X] Appropriate docs were updated (if necessary)

Fixes ? 🦕
