### PR TITLE
feat: add gapic getAppProfilesStream method

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -752,9 +752,7 @@ export class Bigtable {
 
     const gapicStreamingMethods = {
       listTablesStream: true,
-      listInstancesStream: true,
       listAppProfilesStream: true,
-      listClustersStream: true,
     };
 
     if (isStreamMode) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -750,7 +750,12 @@ export class Bigtable {
       });
     };
 
-    const gapicStreamingMethods = {listTablesStream: true};
+    const gapicStreamingMethods = {
+      listTablesStream: true,
+      listInstancesStream: true,
+      listAppProfilesStream: true,
+      listClustersStream: true,
+    };
 
     if (isStreamMode) {
       stream = streamEvents(new PassThrough({objectMode: true}));

--- a/src/instance.ts
+++ b/src/instance.ts
@@ -686,36 +686,6 @@ Please use the format 'my-instance' or '${bigtable.projectName}/instances/my-ins
     );
   }
 
-  getAppProfilesStream(options?: CallOptions): NodeJS.ReadableStream {
-    const reqOpts = {
-      parent: this.name,
-    };
-
-    // eslint-disable-next-line @typescript-eslint/no-this-alias
-    const self = this;
-
-    const transform = function (
-      this: Transform,
-      chunk: google.bigtable.admin.v2.ITable,
-      enc: string,
-      callback: Function
-    ) {
-      const appProfile = self.appProfile(chunk.name!.split('/').pop()!);
-      appProfile.metadata = chunk;
-      callback(null, appProfile);
-    };
-
-    return pumpify.obj([
-      this.bigtable.request({
-        client: 'BigtableInstanceAdminClient',
-        method: 'listAppProfilesStream',
-        reqOpts,
-        gaxOpts: options,
-      }),
-      new Transform({objectMode: true, transform}),
-    ]);
-  }
-
   getClusters(options?: CallOptions): Promise<GetClustersResponse>;
   getClusters(options: CallOptions, callback: GetClustersCallback): void;
   getClusters(callback: GetClustersCallback): void;

--- a/src/instance.ts
+++ b/src/instance.ts
@@ -686,6 +686,36 @@ Please use the format 'my-instance' or '${bigtable.projectName}/instances/my-ins
     );
   }
 
+  getAppProfilesStream(options?: CallOptions): NodeJS.ReadableStream {
+    const reqOpts = {
+      parent: this.name,
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    const self = this;
+
+    const transform = function (
+      this: Transform,
+      chunk: google.bigtable.admin.v2.ITable,
+      enc: string,
+      callback: Function
+    ) {
+      const appProfile = self.appProfile(chunk.name!.split('/').pop()!);
+      appProfile.metadata = chunk;
+      callback(null, appProfile);
+    };
+
+    return pumpify.obj([
+      this.bigtable.request({
+        client: 'BigtableInstanceAdminClient',
+        method: 'listAppProfilesStream',
+        reqOpts,
+        gaxOpts: options,
+      }),
+      new Transform({objectMode: true, transform}),
+    ]);
+  }
+
   getClusters(options?: CallOptions): Promise<GetClustersResponse>;
   getClusters(options: CallOptions, callback: GetClustersCallback): void;
   getClusters(callback: GetClustersCallback): void;

--- a/system-test/bigtable.ts
+++ b/system-test/bigtable.ts
@@ -163,6 +163,20 @@ describe('Bigtable', () => {
       assert(appProfiles.length > 0);
     });
 
+    it('should retrieve a list of app profiles in stream mode', done => {
+      const appProfiles: AppProfile[] = [];
+      INSTANCE.getAppProfilesStream()
+        .on('error', done)
+        .on('data', appProfile => {
+          assert(appProfile instanceof AppProfile);
+          appProfiles.push(appProfile);
+        })
+        .on('end', () => {
+          assert(appProfiles.length > 0);
+          done();
+        });
+    });
+
     it('should check if an app profile exists', async () => {
       const [exists] = await APP_PROFILE.exists();
       assert.strictEqual(exists, true);

--- a/test/index.ts
+++ b/test/index.ts
@@ -635,6 +635,13 @@ describe('Bigtable', () => {
       gaxOpts: {},
     };
 
+    const gapicStreamingMethods = [
+      'listTablesStream',
+      'listInstancesStream',
+      'listAppProfilesStream',
+      'listClustersStream',
+    ];
+
     beforeEach(() => {
       bigtable.getProjectId_ = (callback: Function) => {
         callback(null, PROJECT_ID);
@@ -874,76 +881,80 @@ describe('Bigtable', () => {
       });
     });
 
-    describe('makeGapicStreamRequest', () => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      let GAX_STREAM: any;
-      const config = {
-        client: 'client',
-        method: 'listTablesStream',
-        reqOpts: {
-          a: 'b',
-          c: 'd',
-        },
-        gaxOpts: {},
-      };
+    gapicStreamingMethods.forEach(method => {
+      describe('makeGapicStreamRequest', () => {
+        describe(method, () => {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          let GAX_STREAM: any;
+          const config = {
+            client: 'client',
+            method: method,
+            reqOpts: {
+              a: 'b',
+              c: 'd',
+            },
+            gaxOpts: {},
+          };
 
-      beforeEach(() => {
-        GAX_STREAM = new PassThrough();
-        bigtable.api[config.client][config.method] = {
-          bind() {
-            return () => {
-              return GAX_STREAM;
+          beforeEach(() => {
+            GAX_STREAM = new PassThrough();
+            bigtable.api[config.client][config.method] = {
+              bind() {
+                return () => {
+                  return GAX_STREAM;
+                };
+              },
             };
-          },
-        };
-      });
+          });
 
-      it('should expose an abort function', done => {
-        GAX_STREAM.cancel = done;
+          it('should expose an abort function', done => {
+            GAX_STREAM.cancel = done;
 
-        const requestStream = bigtable.request(config);
-        requestStream.emit('reading');
-        requestStream.abort();
-      });
+            const requestStream = bigtable.request(config);
+            requestStream.emit('reading');
+            requestStream.abort();
+          });
 
-      it('should prepare the request once reading', done => {
-        bigtable.api[config.client][config.method] = {
-          bind(gaxClient: {}, reqOpts: {}, gaxOpts: {}) {
-            assert.strictEqual(gaxClient, bigtable.api[config.client]);
-            assert.deepStrictEqual(reqOpts, config.reqOpts);
-            assert.strictEqual(gaxOpts, config.gaxOpts);
-            setImmediate(done);
-            return () => {
-              return GAX_STREAM;
+          it('should prepare the request once reading', done => {
+            bigtable.api[config.client][config.method] = {
+              bind(gaxClient: {}, reqOpts: {}, gaxOpts: {}) {
+                assert.strictEqual(gaxClient, bigtable.api[config.client]);
+                assert.deepStrictEqual(reqOpts, config.reqOpts);
+                assert.strictEqual(gaxOpts, config.gaxOpts);
+                setImmediate(done);
+                return () => {
+                  return GAX_STREAM;
+                };
+              },
             };
-          },
-        };
 
-        const requestStream = bigtable.request(config);
-        requestStream.emit('reading');
-      });
+            const requestStream = bigtable.request(config);
+            requestStream.emit('reading');
+          });
 
-      it('should destroy the stream with prepare error', done => {
-        const error = new Error('Error.');
-        bigtable.getProjectId_ = (callback: Function) => {
-          callback(error);
-        };
-        const requestStream = bigtable.request(config);
-        requestStream.emit('reading');
-        requestStream.on('error', (err: Error) => {
-          assert.strictEqual(err, error);
-          done();
-        });
-      });
+          it('should destroy the stream with prepare error', done => {
+            const error = new Error('Error.');
+            bigtable.getProjectId_ = (callback: Function) => {
+              callback(error);
+            };
+            const requestStream = bigtable.request(config);
+            requestStream.emit('reading');
+            requestStream.on('error', (err: Error) => {
+              assert.strictEqual(err, error);
+              done();
+            });
+          });
 
-      it('should destroy the stream with GAX error', done => {
-        const error = new Error('Error.');
-        const requestStream = bigtable.request(config);
-        requestStream.emit('reading');
-        GAX_STREAM.emit('error', error);
-        requestStream.on('error', (err: Error) => {
-          assert.strictEqual(err, error);
-          done();
+          it('should destroy the stream with GAX error', done => {
+            const error = new Error('Error.');
+            const requestStream = bigtable.request(config);
+            requestStream.emit('reading');
+            GAX_STREAM.emit('error', error);
+            requestStream.on('error', (err: Error) => {
+              assert.strictEqual(err, error);
+              done();
+            });
+          });
         });
       });
     });


### PR DESCRIPTION
Adding streaming methods for getInstances, getClusters, getAppProfiles to mimic gapic client
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

blocked by #762 