### PR TITLE
feat: getAppProfilesStream emits (if there are any failed locations present) decorated error with failedLocations info

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -824,6 +824,9 @@ export class Bigtable {
           .on('error', (err: Error) => {
             stream.destroy(err);
           })
+          .on('response', response => {
+            stream.emit('response', response);
+          })
           .pipe(stream);
       });
     }

--- a/src/instance.ts
+++ b/src/instance.ts
@@ -779,7 +779,7 @@ Please use the format 'my-instance' or '${bigtable.projectName}/instances/my-ins
       gaxOpts,
     });
     stream.on('response', apiResp => {
-      if (apiResp.failedLocations.length > 0) {
+      if (arrify(apiResp.failedLocations).length > 0) {
         failedLocations = failedLocations.concat(apiResp.failedLocations);
       }
     });

--- a/src/instance.ts
+++ b/src/instance.ts
@@ -758,14 +758,38 @@ Please use the format 'my-instance' or '${bigtable.projectName}/instances/my-ins
       appProfile.metadata = chunk;
       callback(null, appProfile);
     };
+    let failedLocations: string[] = [];
+    const flush = (callback: Function) => {
+      if (failedLocations.length > 0) {
+        callback(
+          new Error(
+            `Resources from the following locations are currently not available\n${JSON.stringify(
+              failedLocations
+            )}`
+          )
+        );
+      } else {
+        callback();
+      }
+    };
+    const stream = this.bigtable.request({
+      client: 'BigtableInstanceAdminClient',
+      method: 'listAppProfilesStream',
+      reqOpts,
+      gaxOpts,
+    });
+    stream.on('response', apiResp => {
+      if (apiResp.failedLocations.length > 0) {
+        failedLocations = failedLocations.concat(apiResp.failedLocations);
+      }
+    });
     return pumpify.obj([
-      this.bigtable.request({
-        client: 'BigtableInstanceAdminClient',
-        method: 'listAppProfilesStream',
-        reqOpts,
-        gaxOpts,
+      stream,
+      new Transform({
+        objectMode: true,
+        transform: transformToAppProfile,
+        flush,
       }),
-      new Transform({objectMode: true, transform: transformToAppProfile}),
     ]);
   }
 

--- a/test/index.ts
+++ b/test/index.ts
@@ -635,12 +635,7 @@ describe('Bigtable', () => {
       gaxOpts: {},
     };
 
-    const gapicStreamingMethods = [
-      'listTablesStream',
-      'listInstancesStream',
-      'listAppProfilesStream',
-      'listClustersStream',
-    ];
+    const gapicStreamingMethods = ['listTablesStream', 'listAppProfilesStream'];
 
     beforeEach(() => {
       bigtable.getProjectId_ = (callback: Function) => {
@@ -954,6 +949,17 @@ describe('Bigtable', () => {
               assert.strictEqual(err, error);
               done();
             });
+          });
+
+          it('should emit resmonse from GAX stream', done => {
+            const response = {};
+            const requestStream = bigtable.request(config);
+            requestStream.emit('reading');
+            requestStream.on('response', (resp: {}) => {
+              assert.strictEqual(resp, response);
+              done();
+            });
+            GAX_STREAM.emit('response', response);
           });
         });
       });


### PR DESCRIPTION

- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

