### PR TITLE
feat: implement restore table to a different instance feature

### DIFF
--- a/samples/backups.restore.js
+++ b/samples/backups.restore.js
@@ -17,7 +17,7 @@ async function main(
   tableId = 'YOUR_TABLE_ID',
   backupId = 'YOUR_BACKUP_ID'
 ) {
-  // [START bigtable_restore_backups]
+  // [START bigtable_restore_backup]
   const {Bigtable} = require('@google-cloud/bigtable');
   const bigtable = new Bigtable();
 

--- a/src/backup.ts
+++ b/src/backup.ts
@@ -36,6 +36,7 @@ import {
   IOperation,
 } from './cluster';
 import {CallOptions, LROperation, Operation, ServiceError} from 'google-gax';
+import {Instance} from './instance';
 
 type IEmpty = google.protobuf.IEmpty;
 export type IBackup = google.bigtable.admin.v2.IBackup;
@@ -86,6 +87,12 @@ export type BackupSetMetadataCallback = (
   resp: IBackup
 ) => void;
 export type BackupSetMetadataResponse = [IBackup, IBackup];
+
+export interface RestoreTableConfig {
+  tableId: string;
+  instance?: Instance | string;
+  gaxOptions?: CallOptions;
+}
 
 export type RestoreTableCallback = (
   err: ServiceError | null,
@@ -491,9 +498,66 @@ Please use the format 'my-backup' or '${cluster.name}/backups/my-backup'.`);
     cb?: RestoreTableCallback
   ): void | Promise<RestoreTableResponse> {
     const gaxOpts =
-      typeof gaxOptionsOrCallback === 'object' ? gaxOptionsOrCallback : {};
+      typeof gaxOptionsOrCallback === 'object'
+        ? gaxOptionsOrCallback
+        : undefined;
     const callback =
       typeof gaxOptionsOrCallback === 'function' ? gaxOptionsOrCallback : cb!;
+
+    this.restoreTo(
+      {
+        tableId,
+        instance: this.cluster.instance,
+        gaxOptions: gaxOpts,
+      },
+      callback
+    );
+  }
+
+  restoreTo(config: RestoreTableConfig): Promise<RestoreTableResponse>;
+  restoreTo(config: RestoreTableConfig, callback: RestoreTableCallback): void;
+  /**
+   * Create a new table by restoring from this completed backup.
+   *
+   * The returned
+   * {@link google.longrunning.Operation|long-running operation} can be used
+   * to track the progress of the operation, and to cancel it.
+   *
+   * @param {RestoreTableConfig} config Configuration object.
+   * @param {string} tableId The id of the table to create and restore to. This
+   *     table must not already exist.
+   * @param {Instance|string} [instance] Instance in which the new table will
+   *     be created and restored to. Instance must be in the same project as the
+   *     project containing backup.
+   *     If omitted the instance containing the backup will be used instead.
+   * @param {CallOptions} [gaxOptions] Request configuration options,
+   *     outlined here:
+   *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
+   * @param {RestoreTableCallback} [callback] The callback function.
+   * @param {?error} callback.err An error returned while making this request.
+   * @param {Table} callback.table The newly created Table.
+   * @param {Operation} callback.operation An operation object that can be used
+   *     to check the status of the request.
+   * @param {object} callback.apiResponse The full API response.
+   * @return {void | Promise<RestoreTableResponse>}
+   *
+   * @example <caption>include:samples/backups.restore.js</caption>
+   * region_tag:bigtable_restore_backup
+   */
+  restoreTo(
+    config: RestoreTableConfig,
+    callback?: RestoreTableCallback
+  ): void | Promise<RestoreTableResponse> {
+    let parent: string;
+    if (config.instance) {
+      if (config.instance instanceof Instance) {
+        parent = config.instance.name;
+      } else {
+        parent = this.bigtable.instance(config.instance).name;
+      }
+    } else {
+      parent = this.cluster.instance.name;
+    }
 
     this.bigtable.request<
       LROperation<
@@ -505,18 +569,18 @@ Please use the format 'my-backup' or '${cluster.name}/backups/my-backup'.`);
         client: 'BigtableTableAdminClient',
         method: 'restoreTable',
         reqOpts: {
-          parent: this.cluster.instance.name,
-          tableId,
+          parent,
+          tableId: config.tableId,
           backup: this.name,
         },
-        gaxOpts,
+        gaxOpts: config.gaxOptions,
       },
       (err, ...args) => {
         if (err) {
-          callback(err, undefined, ...args);
+          callback!(err, undefined, ...args);
           return;
         }
-        callback(err, this.cluster.instance.table(tableId), ...args);
+        callback!(err, this.cluster.instance.table(config.tableId), ...args);
       }
     );
   }

--- a/src/backup.ts
+++ b/src/backup.ts
@@ -540,9 +540,6 @@ Please use the format 'my-backup' or '${cluster.name}/backups/my-backup'.`);
    *     to check the status of the request.
    * @param {object} callback.apiResponse The full API response.
    * @return {void | Promise<RestoreTableResponse>}
-   *
-   * @example <caption>include:samples/backups.restore.js</caption>
-   * region_tag:bigtable_restore_backup
    */
   restoreTo(
     config: RestoreTableConfig,

--- a/src/backup.ts
+++ b/src/backup.ts
@@ -532,7 +532,7 @@ Please use the format 'my-backup' or '${cluster.name}/backups/my-backup'.`);
    *     If omitted the instance containing the backup will be used instead.
    * @param {CallOptions} [gaxOptions] Request configuration options,
    *     outlined here:
-   *     https://googleapis.github.io/gax-nodejs/CallSettings.html.
+   *     https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html.
    * @param {RestoreTableCallback} [callback] The callback function.
    * @param {?error} callback.err An error returned while making this request.
    * @param {Table} callback.table The newly created Table.

--- a/src/instance.ts
+++ b/src/instance.ts
@@ -1228,7 +1228,15 @@ Please use the format 'my-instance' or '${bigtable.projectName}/instances/my-ins
     } else {
       try {
         const clusterId = config.backup.match(/clusters\/([^/]+)/)![1];
-        backup = this.cluster(clusterId).backup(config.backup);
+        const instanceId = config.backup.match(/instances\/([^/]+)/)![1];
+        if (instanceId !== this.id) {
+          backup = this.bigtable
+            .instance(instanceId)
+            .cluster(clusterId)
+            .backup(config.backup);
+        } else {
+          backup = this.cluster(clusterId).backup(config.backup);
+        }
       } catch (e) {
         throw new Error(
           'A complete backup name (path) is required or a Backup object.'
@@ -1236,7 +1244,10 @@ Please use the format 'my-instance' or '${bigtable.projectName}/instances/my-ins
       }
     }
 
-    backup.restore(config.table, config.gaxOptions!, callback!);
+    backup.restoreTo(
+      {tableId: config.table, instance: this, gaxOptions: config.gaxOptions!},
+      callback!
+    );
   }
 
   setIamPolicy(


### PR DESCRIPTION
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

**#ToDo**

- [x] Add System test
- [ ] Add Samples for
   - [ ] `Backup#restoreTo()`
   - [ ] `Instance#createTableFromBackup()`

### This PR proposes the following design

- Introduce an additional function `Backup#restoreTo(config, callback?)` which accepts a config parameter of the type
   ```ts
   export interface RestoreTableConfig {
     tableId: string;
     instance?: Instance | string;
     gaxOptions?: CallOptions;
   }
   ```
- `Backup#restore()` delegates to `Backup#restoreTo()` with `this.cluster.instance` value for `config.instance`.
- `Instance#createTableFromBackup()` now respects both 
   - `Backup` object created on a different instance.
   - As well as a `string` of full backup name (path) that contains a different (form `this.id`) instanceId.

### Other design options 
**!Breaking:**
- Replace `Backup#restore()` with the proposed `Backup#restoreTo()` implementation 
- Include the changes with current pending **4.0.0** release 

**Non Breaking:**
- Add an optional `instance` parameter to `Backup#restore()`
   - This design might be a bit messier than desired
      ```ts
      restore(
        tableId: string,
        instanceOrGaxOptionsOrCallback?:
          | Instance
          | string
          | CallOptions
          | RestoreTableCallback,
        gaxOptionsOrCallback?: CallOptions | RestoreTableCallback,
        cb?: RestoreTableCallback
      ): void | Promise<RestoreTableResponse> {...}
      ```
    - This design will diverge from the established pattern
       ```ts
        function(OneRequiredParamIfAny, optionsOrCallback?, callback?) {...}
       ```