### PR TITLE
feat: implement support for clusters with CMEK encryption

### DIFF
--- a/src/cluster.ts
+++ b/src/cluster.ts
@@ -81,6 +81,8 @@ export type SetClusterMetadataCallback = GenericOperationCallback<
   Operation | null | undefined
 >;
 export interface BasicClusterConfig {
+  encryption?: google.bigtable.admin.v2.Cluster.IEncryptionConfig;
+  key?: string;
   location: string;
   nodes: number;
   storage?: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -577,11 +577,30 @@ export class Bigtable {
         );
       }
 
+      if (
+        typeof cluster.key !== 'undefined' &&
+        typeof cluster.encryption !== 'undefined'
+      ) {
+        throw new Error(
+          'A cluster was provided with both `encryption` and `key` defined.'
+        );
+      }
+
       clusters[cluster.id!] = {
         location: Cluster.getLocation_(this.projectId, cluster.location!),
         serveNodes: cluster.nodes,
         defaultStorageType: Cluster.getStorageType_(cluster.storage!),
       };
+
+      if (cluster.key) {
+        clusters[cluster.id!].encryptionConfig = {
+          kmsKeyName: cluster.key,
+        };
+      }
+
+      if (cluster.encryption) {
+        clusters[cluster.id!].encryptionConfig = cluster.encryption;
+      }
 
       return clusters;
     }, {} as {[index: string]: google.bigtable.admin.v2.ICluster});

--- a/src/instance.ts
+++ b/src/instance.ts
@@ -349,6 +349,9 @@ Please use the format 'my-instance' or '${bigtable.projectName}/instances/my-ins
    * @param {object} options Cluster creation options.
    * @param {object} [options.gaxOptions]  Request configuration options, outlined
    *     here: https://googleapis.github.io/gax-nodejs/global.html#CallOptions.
+   * @param {object} [options.encryption] CMEK configuration options.
+   * @param {string} options.encryption.kmsKeyName The KMS key name.
+   * @param {string} [options.key] Alias for `options.encryption.kmsKeyName`.
    * @param {string} options.location The location where this cluster's nodes
    *     and storage reside. For best performance clients should be located as
    *     as close as possible to this cluster. Currently only zones are
@@ -387,6 +390,25 @@ Please use the format 'my-instance' or '${bigtable.projectName}/instances/my-ins
 
     if (!is.empty(options)) {
       reqOpts.cluster = {};
+    }
+
+    if (
+      typeof options.key !== 'undefined' &&
+      typeof options.encryption !== 'undefined'
+    ) {
+      throw new Error(
+        'The cluster cannot have both `encryption` and `key` defined.'
+      );
+    }
+
+    if (options.key) {
+      reqOpts.cluster!.encryptionConfig = {
+        kmsKeyName: options.key,
+      };
+    }
+
+    if (options.encryption) {
+      reqOpts.cluster!.encryptionConfig = options.encryption;
     }
 
     if (options.location) {

--- a/system-test/bigtable.ts
+++ b/system-test/bigtable.ts
@@ -169,6 +169,85 @@ describe('Bigtable', () => {
     });
   });
 
+  describe('CMEK', () => {
+    let kmsKeyName: string;
+
+    const CMEK_INSTANCE = bigtable.instance(generateId('instance'));
+    const CMEK_CLUSTER = CMEK_INSTANCE.cluster(generateId('cluster'));
+
+    before(async () => {
+      const projectId = await bigtable.auth.getProjectId();
+      const cryptoKeyId = generateId('key');
+      const keyRingId = generateId('key');
+      const keyRingsBaseUrl = `https://cloudkms.googleapis.com/v1/projects/${projectId}/locations/us-central1/keyRings`;
+      kmsKeyName = `projects/${projectId}/locations/us-central1/keyRings/${keyRingId}/cryptoKeys/${cryptoKeyId}`;
+
+      await bigtable.auth.request({
+        method: 'POST',
+        url: keyRingsBaseUrl,
+        params: {keyRingId},
+      });
+
+      await bigtable.auth.request({
+        method: 'POST',
+        url: `${keyRingsBaseUrl}/${keyRingId}/cryptoKeys`,
+        params: {cryptoKeyId},
+        data: {purpose: 'ENCRYPT_DECRYPT'},
+      });
+
+      const [_, operation] = await CMEK_INSTANCE.create({
+        clusters: [
+          {
+            id: CMEK_CLUSTER.id,
+            location: 'us-central1-a',
+            nodes: 3,
+            key: kmsKeyName,
+          },
+        ],
+        labels: {
+          time_created: Date.now(),
+        },
+      });
+      await operation.promise();
+    });
+
+    it('should have created an instance', async () => {
+      const [metadata] = await CMEK_CLUSTER.getMetadata();
+      assert.deepStrictEqual(metadata.encryptionConfig, {kmsKeyName});
+    });
+
+    it('should create a cluster', async () => {
+      const cluster = CMEK_INSTANCE.cluster(generateId('cluster'));
+
+      const [_, operation] = await cluster.create({
+        location: 'us-central1-b',
+        nodes: 3,
+        key: kmsKeyName,
+      });
+      await operation.promise();
+
+      const [metadata] = await cluster.getMetadata();
+      assert.deepStrictEqual(metadata.encryptionConfig, {kmsKeyName});
+    });
+
+    it('should fail if key not provided', async () => {
+      const cluster = CMEK_INSTANCE.cluster(generateId('cluster'));
+
+      try {
+        const [_, operation] = await cluster.create({
+          location: 'us-central1-b',
+          nodes: 3,
+        });
+        await operation.promise();
+        throw new Error('Cluster creation should not have succeeded');
+      } catch (e) {
+        assert(
+          e.message.includes('All clusters must specify the same CMEK key')
+        );
+      }
+    });
+  });
+
   describe('appProfiles', () => {
     it('should retrieve a list of app profiles', async () => {
       const [appProfiles] = await INSTANCE.getAppProfiles();

--- a/test/index.ts
+++ b/test/index.ts
@@ -460,6 +460,95 @@ describe('Bigtable', () => {
       bigtable.createInstance(INSTANCE_ID, OPTIONS, assert.ifError);
     });
 
+    it('should handle clusters with a CMEK key', done => {
+      const key = 'kms-key-name';
+
+      FakeCluster.getLocation_ = () => {};
+      FakeCluster.getStorageType_ = () => {};
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      bigtable.request = (config: any) => {
+        assert.deepStrictEqual(
+          config.reqOpts.clusters['my-cluster'].encryptionConfig,
+          {
+            kmsKeyName: key,
+          }
+        );
+        done();
+      };
+
+      bigtable.createInstance(
+        INSTANCE_ID,
+        {
+          clusters: [
+            {
+              id: 'my-cluster',
+              key,
+            },
+          ],
+        },
+        assert.ifError
+      );
+    });
+
+    it('should handle clusters with an encryption object', done => {
+      const key = 'kms-key-name';
+
+      FakeCluster.getLocation_ = () => {};
+      FakeCluster.getStorageType_ = () => {};
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      bigtable.request = (config: any) => {
+        assert.deepStrictEqual(
+          config.reqOpts.clusters['my-cluster'].encryptionConfig,
+          {
+            kmsKeyName: key,
+          }
+        );
+        done();
+      };
+
+      bigtable.createInstance(
+        INSTANCE_ID,
+        {
+          clusters: [
+            {
+              id: 'my-cluster',
+              encryption: {
+                kmsKeyName: key,
+              },
+            },
+          ],
+        },
+        assert.ifError
+      );
+    });
+
+    it('should throw if both an encryption object and a key are provided', () => {
+      const key = 'kms-key-name';
+
+      FakeCluster.getLocation_ = () => {};
+      FakeCluster.getStorageType_ = () => {};
+
+      assert.throws(() => {
+        bigtable.createInstance(
+          INSTANCE_ID,
+          {
+            clusters: [
+              {
+                id: 'my-cluster',
+                encryption: {
+                  kmsKeyName: key,
+                },
+                key,
+              },
+            ],
+          },
+          assert.ifError
+        );
+      }, /A cluster was provided with both `encryption` and `key` defined\./);
+    });
+
     it('should return an error to the callback', done => {
       const error = new Error('err');
       bigtable.request = (config: {}, callback: Function) => {

--- a/test/instance.ts
+++ b/test/instance.ts
@@ -414,6 +414,54 @@ describe('Bigtable/Instance', () => {
       instance.createCluster(CLUSTER_ID, options, assert.ifError);
     });
 
+    it('should respect the key option', done => {
+      const key = 'kms-key-name';
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (instance.bigtable.request as Function) = (config: any) => {
+        assert.deepStrictEqual(config.reqOpts.cluster.encryptionConfig, {
+          kmsKeyName: key,
+        });
+        done();
+      };
+
+      instance.createCluster(
+        CLUSTER_ID,
+        {key} as CreateClusterOptions,
+        assert.ifError
+      );
+    });
+
+    it('should handle clusters with an encryption object', done => {
+      const key = 'kms-key-name';
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (instance.bigtable.request as Function) = (config: any) => {
+        assert.deepStrictEqual(config.reqOpts.cluster.encryptionConfig, {
+          kmsKeyName: key,
+        });
+        done();
+      };
+
+      instance.createCluster(
+        CLUSTER_ID,
+        {encryption: {kmsKeyName: key}} as CreateClusterOptions,
+        assert.ifError
+      );
+    });
+
+    it('should throw if both an encryption object and a key are provided', () => {
+      const key = 'kms-key-name';
+
+      assert.throws(() => {
+        instance.createCluster(
+          CLUSTER_ID,
+          {encryption: {kmsKeyName: key}, key} as CreateClusterOptions,
+          assert.ifError
+        );
+      }, /The cluster cannot have both `encryption` and `key` defined\./);
+    });
+
     it('should execute callback with arguments from GAPIC', done => {
       const response = {};
       sandbox


### PR DESCRIPTION
edit (kolea2): removing doc

This adds support for CMEK configuration of a Cluster when it is created.

#### Creating an instance

```js
await bigtable.createInstance('my-instance', {
  clusters: [
    {
      id: 'my-cluster',
      encryption: {
        kmsKeyName: 'kms-key-name',
      },
      // ... other options
    },
  ],
});
```

#### Creating a cluster

```js
await instance.createCluster('my-cluster', {
  encryption: {
    kmsKeyName: 'kms-key-name',
  },
  // ... other options
});
```

#### The `key` alias

Instead of providing the `encryption` option, the user has a choice to use the alias `key`:

```diff
await bigtable.createInstance('my-instance', {
  clusters: [
    {
      id: 'my-cluster',
-     encryption: {
-       kmsKeyName: 'kms-key-name',
-     },
+     key: 'kms-key-name',
      // ... other options
    },
  ],
});

await instance.createCluster('my-cluster', {
- encryption: {
-   kmsKeyName: 'kms-key-name',
- },
+ key: 'kms-key-name',
  // ... other options
});
```

If both options are set, an error is thrown.