### PR TITLE
feat: make INTERNAL RST_STREAM errors retryable

### DIFF
--- a/src/table.ts
+++ b/src/table.ts
@@ -931,14 +931,17 @@ Please use the format 'prezzy' or '${instance.name}/tables/prezzy'.`);
           return;
         }
         rowStream.unpipe(userStream);
-        
+
         // Under normal conditions RST_STREAM errors will get wrapped as UNAVAILABLE.
         // However if the RST_STREAM occurs further upstream, it can come down
         // as an INTERNAL. This is a workaround to enable retrying those errors.
         let effectiveCode = error.code;
-        if (effectiveCode == INTERNAL_STATUS_CODE) {
-          const errMsg = (error.message || "").toLowerCase();
-          if (errMsg.indexOf("rst stream") > -1 || errMsg.indexOf("rst_stream") > -1) {
+        if (effectiveCode === INTERNAL_STATUS_CODE) {
+          const errMsg = (error.message || '').toLowerCase();
+          if (
+            errMsg.indexOf('rst stream') > -1 ||
+            errMsg.indexOf('rst_stream') > -1
+          ) {
             effectiveCode = UNAVAILABLE_STATUS_CODE;
           }
         }

--- a/test/table.ts
+++ b/test/table.ts
@@ -1220,7 +1220,9 @@ describe('Bigtable/Table', () => {
       it('should retry the stream on internal rst_stream errors', done => {
         emitters = [
           ((stream: Writable) => {
-            const error = new Error('Received RST_STREAM with code 2 (Internal server error)') as ServiceError;
+            const error = new Error(
+              'Received RST_STREAM with code 2 (Internal server error)'
+            ) as ServiceError;
             error.code = 13; // INTERNAL
             stream.emit('error', error);
             stream.end();
@@ -1234,7 +1236,7 @@ describe('Bigtable/Table', () => {
           assert.strictEqual(reqOptsCalls.length, 2);
           done();
         });
-      })
+      });
 
       it('should not retry CANCELLED errors', done => {
         emitters = [


### PR DESCRIPTION
Normally RST_STREAM frames will get wrapped in UNAVAILABLE statuses.
However if the stream is reset higher upstream, it can trigger an INTERNAL error.
ReadRows doesn't really care what was the trigger, so this PR will treat INTERNAL
RST_STREAMs as UNAVAILABLE and retry them

Prior art:
https://github.com/googleapis/java-bigtable/pull/586 
https://github.com/googleapis/java-bigtable/pull/1029
https://github.com/googleapis/java-bigquerystorage/pull/419