### PR TITLE
fix: fix retry logic in mutate and read

### DIFF
--- a/src/table.ts
+++ b/src/table.ts
@@ -1574,7 +1574,7 @@ Please use the format 'prezzy' or '${instance.name}/tables/prezzy'.`);
           });
         })
         .on('end', onBatchResponse);
-        numRequestsMade++;
+      numRequestsMade++;
     };
 
     makeNextBatchRequest();

--- a/src/table.ts
+++ b/src/table.ts
@@ -1502,6 +1502,7 @@ Please use the format 'prezzy' or '${instance.name}/tables/prezzy'.`);
     const onBatchResponse = (
       err: ServiceError | PartialFailureError | null
     ) => {
+      // TODO: enable retries when the entire RPC fails
       if (err) {
         // The error happened before a request was even made, don't retry.
         callback(err);
@@ -1546,6 +1547,8 @@ Please use the format 'prezzy' or '${instance.name}/tables/prezzy'.`);
           retryOpts,
         })
         .on('error', (err: ServiceError) => {
+          // TODO: this check doesn't actually do anything, onBatchResponse
+          // currently doesn't retry RPC errors, only entry failures
           if (numRequestsMade === 0) {
             callback(err); // Likely a "projectId not detected" error.
             return;

--- a/src/table.ts
+++ b/src/table.ts
@@ -905,8 +905,6 @@ Please use the format 'prezzy' or '${instance.name}/tables/prezzy'.`);
 
       activeRequestStream = requestStream!;
 
-      requestStream!.on('request', () => numRequestsMade++);
-
       const toRowStream = new Transform({
         transform: (rowData, _, next) => {
           if (
@@ -945,6 +943,7 @@ Please use the format 'prezzy' or '${instance.name}/tables/prezzy'.`);
         }
       });
       rowStream.pipe(userStream);
+      numRequestsMade++;
     };
 
     makeNewRequest();

--- a/src/table.ts
+++ b/src/table.ts
@@ -1545,7 +1545,6 @@ Please use the format 'prezzy' or '${instance.name}/tables/prezzy'.`);
           gaxOpts: options.gaxOptions,
           retryOpts,
         })
-        .on('request', () => numRequestsMade++)
         .on('error', (err: ServiceError) => {
           if (numRequestsMade === 0) {
             callback(err); // Likely a "projectId not detected" error.
@@ -1575,6 +1574,7 @@ Please use the format 'prezzy' or '${instance.name}/tables/prezzy'.`);
           });
         })
         .on('end', onBatchResponse);
+        numRequestsMade++;
     };
 
     makeNextBatchRequest();

--- a/test/table.ts
+++ b/test/table.ts
@@ -1187,7 +1187,6 @@ describe('Bigtable/Table', () => {
           (stream as any).abort = () => {};
 
           setImmediate(() => {
-            stream.emit('request');
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             (emitters!.shift() as any)(stream);
           });
@@ -2372,7 +2371,6 @@ describe('Bigtable/Table', () => {
             });
 
             setImmediate(() => {
-              stream.emit('request');
               stream.emit('error', error);
             });
 
@@ -2525,7 +2523,6 @@ describe('Bigtable/Table', () => {
           });
 
           setImmediate(() => {
-            stream.emit('request');
             stream.end({entries: fakeStatuses.shift()});
           });
 

--- a/test/table.ts
+++ b/test/table.ts
@@ -2471,7 +2471,6 @@ describe('Bigtable/Table', () => {
           });
 
           setImmediate(() => {
-            stream.emit('request');
             stream.end({entries: fakeStatuses});
           });
 


### PR DESCRIPTION
There's no 'request' event when a request is sent, so `numRequestsMade` is never incremented in mutate and reads which means failures will be retried forever. Increment the counter in `makeNextBatchRequest` and `makeNewRequest ` instead.