### PR TITLE
fix: this makes the full table scan issue go away

### DIFF
--- a/src/table.ts
+++ b/src/table.ts
@@ -815,7 +815,7 @@ Please use the format 'prezzy' or '${instance.name}/tables/prezzy'.`);
         };
         const greaterThan = (lhs: string, rhs: string) => lessThan(rhs, lhs);
         const greaterThanOrEqualTo = (lhs: string, rhs: string) =>
-          !lessThan(rhs, lhs);
+          !lessThan(lhs, rhs);
 
         if (ranges.length === 0) {
           ranges.push({


### PR DESCRIPTION
This fixes the full table scan issue and prevents it from happening when calling readRowStream with a row range as described in buganizer using the emulator.