### PR TITLE
fix: prevent full table scan from happening

### DIFF
--- a/src/table.ts
+++ b/src/table.ts
@@ -895,6 +895,10 @@ Please use the format 'prezzy' or '${instance.name}/tables/prezzy'.`);
         reqOpts.rowsLimit = rowsLimit - rowsRead;
       }
 
+      if (!reqOpts.rows && lastRowKey) {
+        return
+      }
+
       const requestStream = this.bigtable.request({
         client: 'BigtableClient',
         method: 'readRows',


### PR DESCRIPTION
This change prevents a full table scan from happening unless the user did one intentionally.
