### PR TITLE
feat: enable channel pooling

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "escape-string-regexp": "^4.0.0",
     "extend": "^3.0.2",
     "google-gax": "^2.29.5",
+    "grpc-gcp": "^0.3.3",
     "is": "^3.0.1",
     "is-utf8": "^0.2.1",
     "lodash.snakecase": "^4.1.1",

--- a/src/bigtable_grpc_config.json
+++ b/src/bigtable_grpc_config.json
@@ -1,0 +1,6 @@
+{
+    "channelPool": {
+      "maxSize": 10,
+      "maxConcurrentStreamsLowWatermark": 30
+    }
+  }

--- a/test/index.ts
+++ b/test/index.ts
@@ -190,6 +190,8 @@ describe('Bigtable', () => {
         assert.deepStrictEqual(
           options_,
           Object.assign(
+            {},
+            options_,
             {
               libName: 'gccl',
               libVersion: PKG.version,
@@ -233,18 +235,24 @@ describe('Bigtable', () => {
 
       assert.deepStrictEqual(bigtable.options, {
         BigtableClient: Object.assign(
+          {},
+          bigtable.options['BigtableClient'],
           {
             servicePath: 'bigtable.googleapis.com',
           },
           expectedOptions
         ),
         BigtableInstanceAdminClient: Object.assign(
+          {},
+          bigtable.options['BigtableInstanceAdminClient'],
           {
             servicePath: 'bigtableadmin.googleapis.com',
           },
           expectedOptions
         ),
         BigtableTableAdminClient: Object.assign(
+          {},
+          bigtable.options['BigtableTableAdminClient'],
           {
             servicePath: 'bigtableadmin.googleapis.com',
           },
@@ -283,9 +291,21 @@ describe('Bigtable', () => {
       );
 
       assert.deepStrictEqual(bigtable.options, {
-        BigtableClient: expectedOptions,
-        BigtableInstanceAdminClient: expectedOptions,
-        BigtableTableAdminClient: expectedOptions,
+        BigtableClient: Object.assign(
+          {},
+          bigtable.options['BigtableClient'],
+          expectedOptions
+        ),
+        BigtableInstanceAdminClient: Object.assign(
+          {},
+          bigtable.options['BigtableInstanceAdminClient'],
+          expectedOptions
+        ),
+        BigtableTableAdminClient: Object.assign(
+          {},
+          bigtable.options['BigtableTableAdminClient'],
+          expectedOptions
+        ),
       });
     });
 
@@ -315,9 +335,21 @@ describe('Bigtable', () => {
       assert.strictEqual(bigtable.customEndpoint, options.apiEndpoint);
 
       assert.deepStrictEqual(bigtable.options, {
-        BigtableClient: expectedOptions,
-        BigtableInstanceAdminClient: expectedOptions,
-        BigtableTableAdminClient: expectedOptions,
+        BigtableClient: Object.assign(
+          {},
+          bigtable.options['BigtableClient'],
+          expectedOptions
+        ),
+        BigtableInstanceAdminClient: Object.assign(
+          {},
+          bigtable.options['BigtableInstanceAdminClient'],
+          expectedOptions
+        ),
+        BigtableTableAdminClient: Object.assign(
+          {},
+          bigtable.options['BigtableTableAdminClient'],
+          expectedOptions
+        ),
       });
     });
 


### PR DESCRIPTION
Enabling channel pooling with grpc-gcp-node. Max channel pool size is set to 10. It'll create a new channel when a channel has more than 30 concurrent streams.
