### PR TITLE
feat: enable channel pooling

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "escape-string-regexp": "^4.0.0",
     "extend": "^3.0.2",
     "google-gax": "^2.29.5",
+    "grpc-gcp": "^0.3.3",
     "is": "^3.0.1",
     "is-utf8": "^0.2.1",
     "lodash.snakecase": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "escape-string-regexp": "^4.0.0",
     "extend": "^3.0.2",
     "google-gax": "^2.29.5",
-    "grpc-gcp": "^0.3.3",
+    "grpc-gcp": "0.4.1",
     "is": "^3.0.1",
     "is-utf8": "^0.2.1",
     "lodash.snakecase": "^4.1.1",

--- a/src/bigtable_grpc_config.json
+++ b/src/bigtable_grpc_config.json
@@ -1,8 +1,0 @@
-{
-    "channelPool": {
-      "minxSize": 2,
-      "maxSize": 4,
-      "maxConcurrentStreamsLowWatermark": 10,
-      "debugHeaderIntervalSecs": 600
-    }
-  }

--- a/src/bigtable_grpc_config.json
+++ b/src/bigtable_grpc_config.json
@@ -1,0 +1,6 @@
+{
+    "channelPool": {
+      "maxSize": 10,
+      "maxConcurrentStreamsLowWatermark": 30
+    }
+  }

--- a/src/bigtable_grpc_config.json
+++ b/src/bigtable_grpc_config.json
@@ -1,6 +1,8 @@
 {
     "channelPool": {
-      "maxSize": 10,
-      "maxConcurrentStreamsLowWatermark": 30
+      "minxSize": 2,
+      "maxSize": 4,
+      "maxConcurrentStreamsLowWatermark": 10,
+      "debugHeaderIntervalSecs": 600
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -427,8 +427,8 @@ export class Bigtable {
     if (customEndpoint) {
       const customEndpointParts = customEndpoint.split(':');
       customEndpointBaseUrl = customEndpointParts[0];
-      customEndpointPort = customEndpointParts[1];
-      sslCreds = grpc.credentials.createInsecure()
+      customEndpointPort = Number(customEndpointParts[1]);
+      sslCreds = grpc.credentials.createInsecure();
     }
 
     const baseOptions = Object.assign({
@@ -476,7 +476,7 @@ export class Bigtable {
     };
 
     this.api = {};
-    this.auth = new GoogleAuth(options);
+    this.auth = new GoogleAuth(Object.assign({}, baseOptions, options));
     this.projectId = options.projectId || '{{projectId}}';
     this.appProfileId = options.appProfileId;
     this.projectName = `projects/${this.projectId}`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,6 @@ import {ServiceError} from 'google-gax';
 import * as v2 from './v2';
 import {PassThrough, Duplex} from 'stream';
 import grpcGcpModule = require('grpc-gcp');
-import base = Mocha.reporters.base;
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const streamEvents = require('stream-events');

--- a/src/index.ts
+++ b/src/index.ts
@@ -449,7 +449,7 @@ export class Bigtable {
         'grpc.channelFactoryOverride': grpcGcp.gcpChannelFactoryOverride,
         'grpc.gcpApiConfig': grpcGcp.createGcpApiConfig({
           channelPool: {
-            minxSize: 2,
+            minSize: 2,
             maxSize: 4,
             maxConcurrentStreamsLowWatermark: 10,
             debugHeaderIntervalSecs: 600,

--- a/system-test/install.ts
+++ b/system-test/install.ts
@@ -46,6 +46,14 @@ describe('📦 pack-n-play test', () => {
         ).toString(),
       },
     };
-    await packNTest(options);
+    try {
+      await packNTest(options);
+    } catch (e) {
+      // all of the actionable information is on the output attribute
+      if (e.output) {
+        e.message += "output: " + e.output;
+      }
+      throw e;
+    }
   });
 });

--- a/system-test/install.ts
+++ b/system-test/install.ts
@@ -51,7 +51,7 @@ describe('📦 pack-n-play test', () => {
     } catch (e) {
       // all of the actionable information is on the output attribute
       if (e.output) {
-        e.message += "output: " + e.output;
+        e.message += 'output: ' + e.output;
       }
       throw e;
     }

--- a/test/index.ts
+++ b/test/index.ts
@@ -190,6 +190,8 @@ describe('Bigtable', () => {
         assert.deepStrictEqual(
           options_,
           Object.assign(
+            {},
+            options_,
             {
               libName: 'gccl',
               libVersion: PKG.version,
@@ -233,18 +235,24 @@ describe('Bigtable', () => {
 
       assert.deepStrictEqual(bigtable.options, {
         BigtableClient: Object.assign(
+          {},
+          bigtable.options['BigtableClient'],
           {
             servicePath: 'bigtable.googleapis.com',
           },
           expectedOptions
         ),
         BigtableInstanceAdminClient: Object.assign(
+          {},
+          bigtable.options['BigtableInstanceAdminClient'],
           {
             servicePath: 'bigtableadmin.googleapis.com',
           },
           expectedOptions
         ),
         BigtableTableAdminClient: Object.assign(
+          {},
+          bigtable.options['BigtableTableAdminClient'],
           {
             servicePath: 'bigtableadmin.googleapis.com',
           },
@@ -283,9 +291,21 @@ describe('Bigtable', () => {
       );
 
       assert.deepStrictEqual(bigtable.options, {
-        BigtableClient: expectedOptions,
-        BigtableInstanceAdminClient: expectedOptions,
-        BigtableTableAdminClient: expectedOptions,
+        BigtableClient: Object.assign(
+          {},
+          bigtable.options['BigtableClient'],
+          expectedOptions
+        ),
+        BigtableInstanceAdminClient: Object.assign(
+          {},
+          bigtable.options['BigtableInstanceAdminClient'],
+          expectedOptions
+        ),
+        BigtableTableAdminClient: Object.assign(
+          {},
+          bigtable.options['BigtableTableAdminClient'],
+          expectedOptions
+        ),
       });
     });
 
@@ -315,9 +335,21 @@ describe('Bigtable', () => {
       assert.strictEqual(bigtable.customEndpoint, options.apiEndpoint);
 
       assert.deepStrictEqual(bigtable.options, {
-        BigtableClient: expectedOptions,
-        BigtableInstanceAdminClient: expectedOptions,
-        BigtableTableAdminClient: expectedOptions,
+        BigtableClient: Object.assign(
+          {},
+          bigtable.options['BigtableClient'],
+          expectedOptions
+        ),
+        BigtableInstanceAdminClient: Object.assign(
+          {},
+          bigtable.options['BigtableInstanceAdminClient'],
+          expectedOptions
+        ),
+        BigtableTableAdminClient: Object.assign(
+          {},
+          bigtable.options['BigtableTableAdminClient'],
+          expectedOptions
+        ),
       });
     });
 


### PR DESCRIPTION
This is a continuation of #1062

This enables the channel pool from grpc-gcp-node and configures it to have 2-4 channels and also enables encrypted gfe headers every 10 mins. The results of the headers can be viewed by enabling verbose grpc logs (`GRPC_TRACE=all GRPC_VERBOSITY=debug`), however they can only be decrypted by google engineers