### PR TITLE
feat: enable retries for RESOURCE_EXHAUSTED an simplify error codes

### DIFF
--- a/src/table.ts
+++ b/src/table.ts
@@ -44,9 +44,8 @@ import {google} from '../protos/protos';
 import {Duplex} from 'stream';
 
 // See protos/google/rpc/code.proto
-// (4=DEADLINE_EXCEEDED, 10=ABORTED, 14=UNAVAILABLE)
-const RETRYABLE_STATUS_CODES = new Set([4, 10, 14]);
-const IDEMPOTENT_RETRYABLE_STATUS_CODES = new Set([4, 14]);
+// (4=DEADLINE_EXCEEDED, 8=RESOURCE_EXHAUSTED, 10=ABORTED, 14=UNAVAILABLE)
+const RETRYABLE_STATUS_CODES = new Set([4, 8, 10, 14]);
 // (1=CANCELLED)
 const IGNORED_STATUS_CODES = new Set([1]);
 
@@ -1564,7 +1563,7 @@ Please use the format 'prezzy' or '${instance.name}/tables/prezzy'.`);
       // If the error is empty but there are still outstanding mutations,
       // it means that there are retryable errors in the mutate response
       // even when the RPC succeeded
-      return !err || IDEMPOTENT_RETRYABLE_STATUS_CODES.has(err.code);
+      return !err || RETRYABLE_STATUS_CODES.has(err.code);
     };
 
     const onBatchResponse = (err: ServiceError | null) => {
@@ -1648,7 +1647,7 @@ Please use the format 'prezzy' or '${instance.name}/tables/prezzy'.`);
               mutationErrorsByEntryIndex.delete(originalEntriesIndex);
               return;
             }
-            if (!IDEMPOTENT_RETRYABLE_STATUS_CODES.has(entry.status!.code!)) {
+            if (!RETRYABLE_STATUS_CODES.has(entry.status!.code!)) {
               pendingEntryIndices.delete(originalEntriesIndex);
             }
             const errorDetails = entry.status;

--- a/test/table.ts
+++ b/test/table.ts
@@ -2485,8 +2485,8 @@ describe('Bigtable/Table', () => {
           {
             index: 1,
             status: {
-              code: 10,
-              message: 'ABORTED',
+              code: 3,
+              message: 'INVALID_ARGUMENT',
             },
           },
         ];
@@ -2652,14 +2652,14 @@ describe('Bigtable/Table', () => {
     });
 
     describe('rpc level retries', () => {
-      let emitters: EventEmitter[] | null; // = [((stream: Writable) => { stream.push([{ key: 'a' }]);
+      let emitters: EventEmitter[]; // = [((stream: Writable) => { stream.push([{ key: 'a' }]);
       let requestArgs: RequestOptions[] = [];
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       let entryRequests: any;
 
       beforeEach(() => {
-        emitters = null; // This needs to be assigned in each test case.
+        emitters = []; // This needs to be assigned in each test case.
 
         requestArgs = [];
         entryRequests = [];
@@ -2682,7 +2682,7 @@ describe('Bigtable/Table', () => {
 
       it('should not retry unretriable errors', done => {
         const unretriableError = new Error('not retryable') as ServiceError;
-        unretriableError.code = 10; // Aborted
+        unretriableError.code = 3; // INVALID_ARGUMENT
         emitters = [
           ((stream: Writable) => {
             stream.emit('error', unretriableError);


### PR DESCRIPTION
Unify retriable status codes for ReadRows and MutateRows to be DEADLINE_EXCEEDED -  RESOURCE_EXHAUSTED, ABORTED, UNAVAILABLE.
