### PR TITLE
test: Add autogenerated tests to prepare for a refactor PR

### DIFF
--- a/__snapshots__/cluster.js
+++ b/__snapshots__/cluster.js
@@ -1,0 +1,184 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+exports[
+  'Bigtable/Cluster setMetadata should provide the proper request options asynchronously 1'
+] = {
+  input: {
+    id: 'my-cluster',
+    options: {
+      nodes: 2,
+      location: 'us-central1-b',
+    },
+  },
+  output: {
+    config: {
+      client: 'BigtableInstanceAdminClient',
+      method: 'partialUpdateCluster',
+      reqOpts: {
+        cluster: {
+          name: 'projects/grape-spaceship-123/instances/i/clusters/my-cluster',
+          location: 'us-central1-b',
+          serveNodes: 2,
+        },
+        updateMask: {
+          paths: ['serve_nodes', 'cluster_config.cluster_autoscaling_config'],
+        },
+      },
+      gaxOpts: {},
+    },
+  },
+};
+
+exports[
+  'Bigtable/Cluster setMetadata should provide the proper request options asynchronously 2'
+] = {
+  input: {
+    id: 'my-cluster',
+    options: {
+      nodes: 2,
+      storage: 'ssd',
+      location: 'us-central1-b',
+    },
+  },
+  output: {
+    config: {
+      client: 'BigtableInstanceAdminClient',
+      method: 'partialUpdateCluster',
+      reqOpts: {
+        cluster: {
+          name: 'projects/grape-spaceship-123/instances/i/clusters/my-cluster',
+          location: 'us-central1-b',
+          serveNodes: 2,
+          storage: 'ssd',
+        },
+        updateMask: {
+          paths: ['serve_nodes', 'cluster_config.cluster_autoscaling_config'],
+        },
+      },
+      gaxOpts: {},
+    },
+  },
+};
+
+exports[
+  'Bigtable/Cluster setMetadata should provide the proper request options asynchronously 3'
+] = {
+  input: {
+    id: 'my-cluster',
+    options: {
+      nodes: 2,
+      key: 'kms-key-name',
+      location: 'us-central1-b',
+    },
+  },
+  output: {
+    config: {
+      client: 'BigtableInstanceAdminClient',
+      method: 'partialUpdateCluster',
+      reqOpts: {
+        cluster: {
+          name: 'projects/grape-spaceship-123/instances/i/clusters/my-cluster',
+          location: 'us-central1-b',
+          serveNodes: 2,
+          key: 'kms-key-name',
+        },
+        updateMask: {
+          paths: ['serve_nodes', 'cluster_config.cluster_autoscaling_config'],
+        },
+      },
+      gaxOpts: {},
+    },
+  },
+};
+
+exports[
+  'Bigtable/Cluster setMetadata should provide the proper request options asynchronously 4'
+] = {
+  input: {
+    id: 'my-cluster',
+    options: {
+      nodes: 2,
+      encryption: {
+        kmsKeyName: 'kms-key-name',
+      },
+      location: 'us-central1-b',
+    },
+  },
+  output: {
+    config: {
+      client: 'BigtableInstanceAdminClient',
+      method: 'partialUpdateCluster',
+      reqOpts: {
+        cluster: {
+          name: 'projects/grape-spaceship-123/instances/i/clusters/my-cluster',
+          location: 'us-central1-b',
+          serveNodes: 2,
+          encryption: {
+            kmsKeyName: 'kms-key-name',
+          },
+        },
+        updateMask: {
+          paths: ['serve_nodes', 'cluster_config.cluster_autoscaling_config'],
+        },
+      },
+      gaxOpts: {},
+    },
+  },
+};
+
+exports[
+  'Bigtable/Cluster setMetadata should provide the proper request options asynchronously 5'
+] = {
+  input: {
+    id: 'my-cluster',
+    options: {
+      minServeNodes: 2,
+      maxServeNodes: 3,
+      cpuUtilizationPercent: 50,
+      location: 'us-central1-b',
+    },
+  },
+  output: {
+    config: {
+      client: 'BigtableInstanceAdminClient',
+      method: 'partialUpdateCluster',
+      reqOpts: {
+        cluster: {
+          name: 'projects/grape-spaceship-123/instances/i/clusters/my-cluster',
+          location: 'us-central1-b',
+          clusterConfig: {
+            clusterAutoscalingConfig: {
+              autoscalingTargets: {
+                cpuUtilizationPercent: 50,
+              },
+              autoscalingLimits: {
+                minServeNodes: 2,
+                maxServeNodes: 3,
+              },
+            },
+          },
+        },
+        updateMask: {
+          paths: [
+            'cluster_config.cluster_autoscaling_config.autoscaling_limits.min_serve_nodes',
+            'cluster_config.cluster_autoscaling_config.autoscaling_limits.max_serve_nodes',
+            'cluster_config.cluster_autoscaling_config.autoscaling_targets.cpu_utilization_percent',
+          ],
+        },
+      },
+      gaxOpts: {},
+    },
+  },
+};

--- a/__snapshots__/index.js
+++ b/__snapshots__/index.js
@@ -1,0 +1,211 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+exports[
+  'Bigtable createInstance should provide the proper request options asynchronously 1'
+] = {
+  input: {
+    id: 'my-instance',
+    options: {
+      clusters: {
+        nodes: 2,
+        location: 'us-central1-b',
+        id: 'my-cluster',
+      },
+    },
+  },
+  output: {
+    config: {
+      client: 'BigtableInstanceAdminClient',
+      method: 'createInstance',
+      reqOpts: {
+        parent: 'projects/test-project',
+        instanceId: 'my-instance',
+        instance: {
+          displayName: 'my-instance',
+        },
+        clusters: {
+          'my-cluster': {
+            location: 'projects/test-project/locations/us-central1-b',
+            serveNodes: 2,
+            defaultStorageType: 0,
+          },
+        },
+      },
+    },
+  },
+};
+
+exports[
+  'Bigtable createInstance should provide the proper request options asynchronously 2'
+] = {
+  input: {
+    id: 'my-instance',
+    options: {
+      clusters: {
+        nodes: 2,
+        storage: 'ssd',
+        location: 'us-central1-b',
+        id: 'my-cluster',
+      },
+    },
+  },
+  output: {
+    config: {
+      client: 'BigtableInstanceAdminClient',
+      method: 'createInstance',
+      reqOpts: {
+        parent: 'projects/test-project',
+        instanceId: 'my-instance',
+        instance: {
+          displayName: 'my-instance',
+        },
+        clusters: {
+          'my-cluster': {
+            location: 'projects/test-project/locations/us-central1-b',
+            serveNodes: 2,
+            defaultStorageType: 1,
+          },
+        },
+      },
+    },
+  },
+};
+
+exports[
+  'Bigtable createInstance should provide the proper request options asynchronously 3'
+] = {
+  input: {
+    id: 'my-instance',
+    options: {
+      clusters: {
+        nodes: 2,
+        key: 'kms-key-name',
+        location: 'us-central1-b',
+        id: 'my-cluster',
+      },
+    },
+  },
+  output: {
+    config: {
+      client: 'BigtableInstanceAdminClient',
+      method: 'createInstance',
+      reqOpts: {
+        parent: 'projects/test-project',
+        instanceId: 'my-instance',
+        instance: {
+          displayName: 'my-instance',
+        },
+        clusters: {
+          'my-cluster': {
+            location: 'projects/test-project/locations/us-central1-b',
+            serveNodes: 2,
+            defaultStorageType: 0,
+            encryptionConfig: {
+              kmsKeyName: 'kms-key-name',
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
+exports[
+  'Bigtable createInstance should provide the proper request options asynchronously 4'
+] = {
+  input: {
+    id: 'my-instance',
+    options: {
+      clusters: {
+        nodes: 2,
+        encryption: {
+          kmsKeyName: 'kms-key-name',
+        },
+        location: 'us-central1-b',
+        id: 'my-cluster',
+      },
+    },
+  },
+  output: {
+    config: {
+      client: 'BigtableInstanceAdminClient',
+      method: 'createInstance',
+      reqOpts: {
+        parent: 'projects/test-project',
+        instanceId: 'my-instance',
+        instance: {
+          displayName: 'my-instance',
+        },
+        clusters: {
+          'my-cluster': {
+            location: 'projects/test-project/locations/us-central1-b',
+            serveNodes: 2,
+            defaultStorageType: 0,
+            encryptionConfig: {
+              kmsKeyName: 'kms-key-name',
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
+exports[
+  'Bigtable createInstance should provide the proper request options asynchronously 5'
+] = {
+  input: {
+    id: 'my-instance',
+    options: {
+      clusters: {
+        minServeNodes: 2,
+        maxServeNodes: 3,
+        cpuUtilizationPercent: 50,
+        location: 'us-central1-b',
+        id: 'my-cluster',
+      },
+    },
+  },
+  output: {
+    config: {
+      client: 'BigtableInstanceAdminClient',
+      method: 'createInstance',
+      reqOpts: {
+        parent: 'projects/test-project',
+        instanceId: 'my-instance',
+        instance: {
+          displayName: 'my-instance',
+        },
+        clusters: {
+          'my-cluster': {
+            location: 'projects/test-project/locations/us-central1-b',
+            clusterConfig: {
+              clusterAutoscalingConfig: {
+                autoscalingTargets: {
+                  cpuUtilizationPercent: 50,
+                },
+                autoscalingLimits: {
+                  minServeNodes: 2,
+                  maxServeNodes: 3,
+                },
+              },
+            },
+            defaultStorageType: 0,
+          },
+        },
+      },
+    },
+  },
+};

--- a/__snapshots__/instance.js
+++ b/__snapshots__/instance.js
@@ -1,0 +1,147 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+exports[
+  'Bigtable/Instance createCluster should provide the proper request options asynchronously 1'
+] = {
+  id: 'my-cluster',
+  options: {
+    nodes: 2,
+    location: 'us-central1-b',
+  },
+  request: {
+    client: 'BigtableInstanceAdminClient',
+    method: 'createCluster',
+    reqOpts: {
+      parent: 'projects/my-project/instances/my-instance',
+      clusterId: 'my-cluster',
+      cluster: {
+        location: 'projects/my-project/locations/us-central1-b',
+        serveNodes: 2,
+      },
+    },
+  },
+};
+
+exports[
+  'Bigtable/Instance createCluster should provide the proper request options asynchronously 2'
+] = {
+  id: 'my-cluster',
+  options: {
+    nodes: 2,
+    storage: 'ssd',
+    location: 'us-central1-b',
+  },
+  request: {
+    client: 'BigtableInstanceAdminClient',
+    method: 'createCluster',
+    reqOpts: {
+      parent: 'projects/my-project/instances/my-instance',
+      clusterId: 'my-cluster',
+      cluster: {
+        location: 'projects/my-project/locations/us-central1-b',
+        serveNodes: 2,
+        defaultStorageType: 1,
+      },
+    },
+  },
+};
+
+exports[
+  'Bigtable/Instance createCluster should provide the proper request options asynchronously 3'
+] = {
+  id: 'my-cluster',
+  options: {
+    nodes: 2,
+    key: 'kms-key-name',
+    location: 'us-central1-b',
+  },
+  request: {
+    client: 'BigtableInstanceAdminClient',
+    method: 'createCluster',
+    reqOpts: {
+      parent: 'projects/my-project/instances/my-instance',
+      clusterId: 'my-cluster',
+      cluster: {
+        location: 'projects/my-project/locations/us-central1-b',
+        serveNodes: 2,
+        encryptionConfig: {
+          kmsKeyName: 'kms-key-name',
+        },
+      },
+    },
+  },
+};
+
+exports[
+  'Bigtable/Instance createCluster should provide the proper request options asynchronously 4'
+] = {
+  id: 'my-cluster',
+  options: {
+    nodes: 2,
+    encryption: {
+      kmsKeyName: 'kms-key-name',
+    },
+    location: 'us-central1-b',
+  },
+  request: {
+    client: 'BigtableInstanceAdminClient',
+    method: 'createCluster',
+    reqOpts: {
+      parent: 'projects/my-project/instances/my-instance',
+      clusterId: 'my-cluster',
+      cluster: {
+        location: 'projects/my-project/locations/us-central1-b',
+        serveNodes: 2,
+        encryptionConfig: {
+          kmsKeyName: 'kms-key-name',
+        },
+      },
+    },
+  },
+};
+
+exports[
+  'Bigtable/Instance createCluster should provide the proper request options asynchronously 5'
+] = {
+  id: 'my-cluster',
+  options: {
+    minServeNodes: 2,
+    maxServeNodes: 3,
+    cpuUtilizationPercent: 50,
+    location: 'us-central1-b',
+  },
+  request: {
+    client: 'BigtableInstanceAdminClient',
+    method: 'createCluster',
+    reqOpts: {
+      parent: 'projects/my-project/instances/my-instance',
+      clusterId: 'my-cluster',
+      cluster: {
+        location: 'projects/my-project/locations/us-central1-b',
+        clusterConfig: {
+          clusterAutoscalingConfig: {
+            autoscalingTargets: {
+              cpuUtilizationPercent: 50,
+            },
+            autoscalingLimits: {
+              minServeNodes: 2,
+              maxServeNodes: 3,
+            },
+          },
+        },
+      },
+    },
+  },
+};

--- a/__snapshots__/instance.js
+++ b/__snapshots__/instance.js
@@ -20,7 +20,7 @@ exports[
     nodes: 2,
     location: 'us-central1-b',
   },
-  request: {
+  config: {
     client: 'BigtableInstanceAdminClient',
     method: 'createCluster',
     reqOpts: {
@@ -43,7 +43,7 @@ exports[
     storage: 'ssd',
     location: 'us-central1-b',
   },
-  request: {
+  config: {
     client: 'BigtableInstanceAdminClient',
     method: 'createCluster',
     reqOpts: {
@@ -67,7 +67,7 @@ exports[
     key: 'kms-key-name',
     location: 'us-central1-b',
   },
-  request: {
+  config: {
     client: 'BigtableInstanceAdminClient',
     method: 'createCluster',
     reqOpts: {
@@ -95,7 +95,7 @@ exports[
     },
     location: 'us-central1-b',
   },
-  request: {
+  config: {
     client: 'BigtableInstanceAdminClient',
     method: 'createCluster',
     reqOpts: {
@@ -122,7 +122,7 @@ exports[
     cpuUtilizationPercent: 50,
     location: 'us-central1-b',
   },
-  request: {
+  config: {
     client: 'BigtableInstanceAdminClient',
     method: 'createCluster',
     reqOpts: {

--- a/__snapshots__/instance.js
+++ b/__snapshots__/instance.js
@@ -15,20 +15,24 @@
 exports[
   'Bigtable/Instance createCluster should provide the proper request options asynchronously 1'
 ] = {
-  id: 'my-cluster',
-  options: {
-    nodes: 2,
-    location: 'us-central1-b',
+  input: {
+    id: 'my-cluster',
+    options: {
+      nodes: 2,
+      location: 'us-central1-b',
+    },
   },
-  config: {
-    client: 'BigtableInstanceAdminClient',
-    method: 'createCluster',
-    reqOpts: {
-      parent: 'projects/my-project/instances/my-instance',
-      clusterId: 'my-cluster',
-      cluster: {
-        location: 'projects/my-project/locations/us-central1-b',
-        serveNodes: 2,
+  output: {
+    config: {
+      client: 'BigtableInstanceAdminClient',
+      method: 'createCluster',
+      reqOpts: {
+        parent: 'projects/my-project/instances/my-instance',
+        clusterId: 'my-cluster',
+        cluster: {
+          location: 'projects/my-project/locations/us-central1-b',
+          serveNodes: 2,
+        },
       },
     },
   },
@@ -37,22 +41,26 @@ exports[
 exports[
   'Bigtable/Instance createCluster should provide the proper request options asynchronously 2'
 ] = {
-  id: 'my-cluster',
-  options: {
-    nodes: 2,
-    storage: 'ssd',
-    location: 'us-central1-b',
+  input: {
+    id: 'my-cluster',
+    options: {
+      nodes: 2,
+      storage: 'ssd',
+      location: 'us-central1-b',
+    },
   },
-  config: {
-    client: 'BigtableInstanceAdminClient',
-    method: 'createCluster',
-    reqOpts: {
-      parent: 'projects/my-project/instances/my-instance',
-      clusterId: 'my-cluster',
-      cluster: {
-        location: 'projects/my-project/locations/us-central1-b',
-        serveNodes: 2,
-        defaultStorageType: 1,
+  output: {
+    config: {
+      client: 'BigtableInstanceAdminClient',
+      method: 'createCluster',
+      reqOpts: {
+        parent: 'projects/my-project/instances/my-instance',
+        clusterId: 'my-cluster',
+        cluster: {
+          location: 'projects/my-project/locations/us-central1-b',
+          serveNodes: 2,
+          defaultStorageType: 1,
+        },
       },
     },
   },
@@ -61,23 +69,27 @@ exports[
 exports[
   'Bigtable/Instance createCluster should provide the proper request options asynchronously 3'
 ] = {
-  id: 'my-cluster',
-  options: {
-    nodes: 2,
-    key: 'kms-key-name',
-    location: 'us-central1-b',
+  input: {
+    id: 'my-cluster',
+    options: {
+      nodes: 2,
+      key: 'kms-key-name',
+      location: 'us-central1-b',
+    },
   },
-  config: {
-    client: 'BigtableInstanceAdminClient',
-    method: 'createCluster',
-    reqOpts: {
-      parent: 'projects/my-project/instances/my-instance',
-      clusterId: 'my-cluster',
-      cluster: {
-        location: 'projects/my-project/locations/us-central1-b',
-        serveNodes: 2,
-        encryptionConfig: {
-          kmsKeyName: 'kms-key-name',
+  output: {
+    config: {
+      client: 'BigtableInstanceAdminClient',
+      method: 'createCluster',
+      reqOpts: {
+        parent: 'projects/my-project/instances/my-instance',
+        clusterId: 'my-cluster',
+        cluster: {
+          location: 'projects/my-project/locations/us-central1-b',
+          serveNodes: 2,
+          encryptionConfig: {
+            kmsKeyName: 'kms-key-name',
+          },
         },
       },
     },
@@ -87,25 +99,29 @@ exports[
 exports[
   'Bigtable/Instance createCluster should provide the proper request options asynchronously 4'
 ] = {
-  id: 'my-cluster',
-  options: {
-    nodes: 2,
-    encryption: {
-      kmsKeyName: 'kms-key-name',
+  input: {
+    id: 'my-cluster',
+    options: {
+      nodes: 2,
+      encryption: {
+        kmsKeyName: 'kms-key-name',
+      },
+      location: 'us-central1-b',
     },
-    location: 'us-central1-b',
   },
-  config: {
-    client: 'BigtableInstanceAdminClient',
-    method: 'createCluster',
-    reqOpts: {
-      parent: 'projects/my-project/instances/my-instance',
-      clusterId: 'my-cluster',
-      cluster: {
-        location: 'projects/my-project/locations/us-central1-b',
-        serveNodes: 2,
-        encryptionConfig: {
-          kmsKeyName: 'kms-key-name',
+  output: {
+    config: {
+      client: 'BigtableInstanceAdminClient',
+      method: 'createCluster',
+      reqOpts: {
+        parent: 'projects/my-project/instances/my-instance',
+        clusterId: 'my-cluster',
+        cluster: {
+          location: 'projects/my-project/locations/us-central1-b',
+          serveNodes: 2,
+          encryptionConfig: {
+            kmsKeyName: 'kms-key-name',
+          },
         },
       },
     },
@@ -115,29 +131,33 @@ exports[
 exports[
   'Bigtable/Instance createCluster should provide the proper request options asynchronously 5'
 ] = {
-  id: 'my-cluster',
-  options: {
-    minServeNodes: 2,
-    maxServeNodes: 3,
-    cpuUtilizationPercent: 50,
-    location: 'us-central1-b',
+  input: {
+    id: 'my-cluster',
+    options: {
+      minServeNodes: 2,
+      maxServeNodes: 3,
+      cpuUtilizationPercent: 50,
+      location: 'us-central1-b',
+    },
   },
-  config: {
-    client: 'BigtableInstanceAdminClient',
-    method: 'createCluster',
-    reqOpts: {
-      parent: 'projects/my-project/instances/my-instance',
-      clusterId: 'my-cluster',
-      cluster: {
-        location: 'projects/my-project/locations/us-central1-b',
-        clusterConfig: {
-          clusterAutoscalingConfig: {
-            autoscalingTargets: {
-              cpuUtilizationPercent: 50,
-            },
-            autoscalingLimits: {
-              minServeNodes: 2,
-              maxServeNodes: 3,
+  output: {
+    config: {
+      client: 'BigtableInstanceAdminClient',
+      method: 'createCluster',
+      reqOpts: {
+        parent: 'projects/my-project/instances/my-instance',
+        clusterId: 'my-cluster',
+        cluster: {
+          location: 'projects/my-project/locations/us-central1-b',
+          clusterConfig: {
+            clusterAutoscalingConfig: {
+              autoscalingTargets: {
+                cpuUtilizationPercent: 50,
+              },
+              autoscalingLimits: {
+                minServeNodes: 2,
+                maxServeNodes: 3,
+              },
             },
           },
         },

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "pack-n-play": "^1.0.0-2",
     "proxyquire": "^2.0.0",
     "sinon": "^14.0.0",
+    "snap-shot-it": "^7.9.1",
     "ts-loader": "^9.0.0",
     "typescript": "^4.6.4",
     "uuid": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "system-test": "mocha build/system-test --timeout 600000",
     "pretest": "npm run compile",
     "test": "c8 mocha build/test",
+    "test:snap": "SNAPSHOT_UPDATE=1 npm test",
     "clean": "gts clean",
     "precompile": "gts clean"
   },

--- a/test/cluster.ts
+++ b/test/cluster.ts
@@ -20,6 +20,9 @@ import {PassThrough, Readable} from 'stream';
 import {CallOptions} from 'google-gax';
 import {PreciseDate} from '@google-cloud/precise-date';
 import {ClusterUtils} from '../src/utils/cluster';
+import {InstanceOptions, RequestOptions} from '../src';
+import {createClusterOptionsList} from './constants/cluster';
+import * as snapshot from 'snap-shot-it';
 
 export interface Options {
   nodes?: Number;
@@ -979,6 +982,25 @@ describe('Bigtable/Cluster', () => {
       };
 
       cluster.setMetadata({nodes: 2}, done);
+    });
+
+    it('should provide the proper request options asynchronously', async () => {
+      let currentRequestInput = null;
+      (cluster.bigtable.request as Function) = (config: RequestOptions) => {
+        currentRequestInput = config;
+      };
+      for (const options of createClusterOptionsList) {
+        await cluster.setMetadata(options);
+        snapshot({
+          input: {
+            id: cluster.id,
+            options: options,
+          },
+          output: {
+            config: currentRequestInput,
+          },
+        });
+      }
     });
 
     it('should respect the nodes option', done => {

--- a/test/constants/cluster.ts
+++ b/test/constants/cluster.ts
@@ -1,0 +1,13 @@
+import {CreateClusterOptions} from '../../src';
+
+export const createClusterOptionsList: CreateClusterOptions[] = [
+  {nodes: 2},
+  {nodes: 2, storage: 'ssd'},
+  {nodes: 2, key: 'kms-key-name'},
+  {nodes: 2, encryption: {kmsKeyName: 'kms-key-name'}},
+  {
+    minServeNodes: 2,
+    maxServeNodes: 3,
+    cpuUtilizationPercent: 50,
+  },
+].map(option => Object.assign(option, {location: 'us-central1-b'}));

--- a/test/constants/cluster.ts
+++ b/test/constants/cluster.ts
@@ -1,3 +1,17 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import {CreateClusterOptions} from '../../src';
 
 export const createClusterOptionsList: CreateClusterOptions[] = [

--- a/test/index.ts
+++ b/test/index.ts
@@ -25,6 +25,7 @@ import {Instance, InstanceOptions} from '../src/instance.js';
 import {PassThrough} from 'stream';
 import {RequestOptions} from '../src';
 import * as snapshot from 'snap-shot-it';
+import {createClusterOptionsList} from './constants/cluster';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const v2 = require('../src/v2');
@@ -406,19 +407,8 @@ describe('Bigtable', () => {
       (bigtable.request as Function) = (config: RequestOptions) => {
         currentRequestInput = config;
       };
-      const createClusterOptionsList: CreateClusterOptions[] = [
-        {nodes: 2},
-        {nodes: 2, storage: 'ssd'},
-        {nodes: 2, key: 'kms-key-name'},
-        {nodes: 2, encryption: {kmsKeyName: 'kms-key-name'}},
-        {
-          minServeNodes: 2,
-          maxServeNodes: 3,
-          cpuUtilizationPercent: 50,
-        },
-      ].map(option => Object.assign(option, {location: 'us-central1-b'}));
       const instanceOptionsList: InstanceOptions[] = createClusterOptionsList
-        .map(options => Object.assign(options, {id: 'my-cluster'}))
+        .map(options => Object.assign({}, options, {id: 'my-cluster'}))
         .map(options => {
           return {
             clusters: options,

--- a/test/index.ts
+++ b/test/index.ts
@@ -20,9 +20,11 @@ import * as gax from 'google-gax';
 import * as proxyquire from 'proxyquire';
 import * as sn from 'sinon';
 
-import {Cluster} from '../src/cluster.js';
-import {Instance} from '../src/instance.js';
+import {Cluster, CreateClusterOptions} from '../src/cluster.js';
+import {Instance, InstanceOptions} from '../src/instance.js';
 import {PassThrough} from 'stream';
+import {RequestOptions} from '../src';
+import * as snapshot from 'snap-shot-it';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const v2 = require('../src/v2');
@@ -397,6 +399,43 @@ describe('Bigtable', () => {
         done();
       };
       bigtable.createInstance(INSTANCE_ID, OPTIONS, assert.ifError);
+    });
+
+    it('should provide the proper request options asynchronously', async () => {
+      let currentRequestInput = null;
+      (bigtable.request as Function) = (config: RequestOptions) => {
+        currentRequestInput = config;
+      };
+      const createClusterOptionsList: CreateClusterOptions[] = [
+        {nodes: 2},
+        {nodes: 2, storage: 'ssd'},
+        {nodes: 2, key: 'kms-key-name'},
+        {nodes: 2, encryption: {kmsKeyName: 'kms-key-name'}},
+        {
+          minServeNodes: 2,
+          maxServeNodes: 3,
+          cpuUtilizationPercent: 50,
+        },
+      ].map(option => Object.assign(option, {location: 'us-central1-b'}));
+      const instanceOptionsList: InstanceOptions[] = createClusterOptionsList
+        .map(options => Object.assign(options, {id: 'my-cluster'}))
+        .map(options => {
+          return {
+            clusters: options,
+          };
+        });
+      for (const options of instanceOptionsList) {
+        await bigtable.createInstance(INSTANCE_ID, options, assert.ifError);
+        snapshot({
+          input: {
+            id: INSTANCE_ID,
+            options: options,
+          },
+          output: {
+            config: currentRequestInput,
+          },
+        });
+      }
     });
 
     it('should accept gaxOptions', done => {

--- a/test/instance.ts
+++ b/test/instance.ts
@@ -384,9 +384,13 @@ describe('Bigtable/Instance', () => {
       for (const options of optionsList) {
         await instance.createCluster(CLUSTER_ID, options);
         snapshot({
-          id: CLUSTER_ID,
-          options: options,
-          config: currentRequestInput,
+          input: {
+            id: CLUSTER_ID,
+            options: options,
+          },
+          output: {
+            config: currentRequestInput,
+          },
         });
       }
     });

--- a/test/instance.ts
+++ b/test/instance.ts
@@ -386,7 +386,7 @@ describe('Bigtable/Instance', () => {
         snapshot({
           id: CLUSTER_ID,
           options: options,
-          request: currentRequestInput,
+          config: currentRequestInput,
         });
       }
     });

--- a/test/instance.ts
+++ b/test/instance.ts
@@ -36,6 +36,7 @@ import * as pumpify from 'pumpify';
 import {FakeCluster} from '../system-test/common';
 import {RestoreTableConfig} from '../src/backup';
 import {Options} from './cluster';
+import {createClusterOptionsList} from './constants/cluster';
 
 const sandbox = sinon.createSandbox();
 
@@ -370,17 +371,7 @@ describe('Bigtable/Instance', () => {
       (instance.bigtable.request as Function) = (config: RequestOptions) => {
         currentRequestInput = config;
       };
-      const optionsList = [
-        {nodes: 2},
-        {nodes: 2, storage: 'ssd'},
-        {nodes: 2, key: 'kms-key-name'},
-        {nodes: 2, encryption: {kmsKeyName: 'kms-key-name'}},
-        {
-          minServeNodes: 2,
-          maxServeNodes: 3,
-          cpuUtilizationPercent: 50,
-        },
-      ].map(option => Object.assign(option, {location: 'us-central1-b'}));
+      const optionsList = createClusterOptionsList;
       for (const options of optionsList) {
         await instance.createCluster(CLUSTER_ID, options);
         snapshot({


### PR DESCRIPTION
The only thing this PR does is add tests with automatically generated snapshots that capture the data that will be sent to the generated layer. There should be no functionality changes to code in the `src` folder.

The main reason for creating these autogenerated snapshots is that next I will open a technical debt PR which refactors code and we want to be sure that when we do that refactor, we don't actually change what the code does. Comparing variable values to these previously generated snapshots will allow us to do this to ensure data being passed to the generated layer remains unchanged. If there are subtle changes then we will see the difference in the snapshot in the tech debt PR and we can check with team members that manage code server side to ensure the changes won't break anything.
