### PR TITLE
feat: Group key and encryption encoding into one function

### DIFF
--- a/__snapshots__/cluster.js
+++ b/__snapshots__/cluster.js
@@ -1,0 +1,184 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+exports[
+  'Bigtable/Cluster setMetadata should provide the proper request options asynchronously 1'
+] = {
+  input: {
+    id: 'my-cluster',
+    options: {
+      nodes: 2,
+      location: 'us-central1-b',
+    },
+  },
+  output: {
+    config: {
+      client: 'BigtableInstanceAdminClient',
+      method: 'partialUpdateCluster',
+      reqOpts: {
+        cluster: {
+          name: 'projects/grape-spaceship-123/instances/i/clusters/my-cluster',
+          location: 'us-central1-b',
+          serveNodes: 2,
+        },
+        updateMask: {
+          paths: ['serve_nodes', 'cluster_config.cluster_autoscaling_config'],
+        },
+      },
+      gaxOpts: {},
+    },
+  },
+};
+
+exports[
+  'Bigtable/Cluster setMetadata should provide the proper request options asynchronously 2'
+] = {
+  input: {
+    id: 'my-cluster',
+    options: {
+      nodes: 2,
+      storage: 'ssd',
+      location: 'us-central1-b',
+    },
+  },
+  output: {
+    config: {
+      client: 'BigtableInstanceAdminClient',
+      method: 'partialUpdateCluster',
+      reqOpts: {
+        cluster: {
+          name: 'projects/grape-spaceship-123/instances/i/clusters/my-cluster',
+          location: 'us-central1-b',
+          serveNodes: 2,
+          storage: 'ssd',
+        },
+        updateMask: {
+          paths: ['serve_nodes', 'cluster_config.cluster_autoscaling_config'],
+        },
+      },
+      gaxOpts: {},
+    },
+  },
+};
+
+exports[
+  'Bigtable/Cluster setMetadata should provide the proper request options asynchronously 3'
+] = {
+  input: {
+    id: 'my-cluster',
+    options: {
+      nodes: 2,
+      key: 'kms-key-name',
+      location: 'us-central1-b',
+    },
+  },
+  output: {
+    config: {
+      client: 'BigtableInstanceAdminClient',
+      method: 'partialUpdateCluster',
+      reqOpts: {
+        cluster: {
+          name: 'projects/grape-spaceship-123/instances/i/clusters/my-cluster',
+          location: 'us-central1-b',
+          serveNodes: 2,
+          key: 'kms-key-name',
+        },
+        updateMask: {
+          paths: ['serve_nodes', 'cluster_config.cluster_autoscaling_config'],
+        },
+      },
+      gaxOpts: {},
+    },
+  },
+};
+
+exports[
+  'Bigtable/Cluster setMetadata should provide the proper request options asynchronously 4'
+] = {
+  input: {
+    id: 'my-cluster',
+    options: {
+      nodes: 2,
+      encryption: {
+        kmsKeyName: 'kms-key-name',
+      },
+      location: 'us-central1-b',
+    },
+  },
+  output: {
+    config: {
+      client: 'BigtableInstanceAdminClient',
+      method: 'partialUpdateCluster',
+      reqOpts: {
+        cluster: {
+          name: 'projects/grape-spaceship-123/instances/i/clusters/my-cluster',
+          location: 'us-central1-b',
+          serveNodes: 2,
+          encryption: {
+            kmsKeyName: 'kms-key-name',
+          },
+        },
+        updateMask: {
+          paths: ['serve_nodes', 'cluster_config.cluster_autoscaling_config'],
+        },
+      },
+      gaxOpts: {},
+    },
+  },
+};
+
+exports[
+  'Bigtable/Cluster setMetadata should provide the proper request options asynchronously 5'
+] = {
+  input: {
+    id: 'my-cluster',
+    options: {
+      minServeNodes: 2,
+      maxServeNodes: 3,
+      cpuUtilizationPercent: 50,
+      location: 'us-central1-b',
+    },
+  },
+  output: {
+    config: {
+      client: 'BigtableInstanceAdminClient',
+      method: 'partialUpdateCluster',
+      reqOpts: {
+        cluster: {
+          name: 'projects/grape-spaceship-123/instances/i/clusters/my-cluster',
+          location: 'us-central1-b',
+          clusterConfig: {
+            clusterAutoscalingConfig: {
+              autoscalingTargets: {
+                cpuUtilizationPercent: 50,
+              },
+              autoscalingLimits: {
+                minServeNodes: 2,
+                maxServeNodes: 3,
+              },
+            },
+          },
+        },
+        updateMask: {
+          paths: [
+            'cluster_config.cluster_autoscaling_config.autoscaling_limits.min_serve_nodes',
+            'cluster_config.cluster_autoscaling_config.autoscaling_limits.max_serve_nodes',
+            'cluster_config.cluster_autoscaling_config.autoscaling_targets.cpu_utilization_percent',
+          ],
+        },
+      },
+      gaxOpts: {},
+    },
+  },
+};

--- a/__snapshots__/index.js
+++ b/__snapshots__/index.js
@@ -1,0 +1,211 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+exports[
+  'Bigtable createInstance should provide the proper request options asynchronously 1'
+] = {
+  input: {
+    id: 'my-instance',
+    options: {
+      clusters: {
+        nodes: 2,
+        location: 'us-central1-b',
+        id: 'my-cluster',
+      },
+    },
+  },
+  output: {
+    config: {
+      client: 'BigtableInstanceAdminClient',
+      method: 'createInstance',
+      reqOpts: {
+        parent: 'projects/test-project',
+        instanceId: 'my-instance',
+        instance: {
+          displayName: 'my-instance',
+        },
+        clusters: {
+          'my-cluster': {
+            location: 'projects/test-project/locations/us-central1-b',
+            serveNodes: 2,
+            defaultStorageType: 0,
+          },
+        },
+      },
+    },
+  },
+};
+
+exports[
+  'Bigtable createInstance should provide the proper request options asynchronously 2'
+] = {
+  input: {
+    id: 'my-instance',
+    options: {
+      clusters: {
+        nodes: 2,
+        storage: 'ssd',
+        location: 'us-central1-b',
+        id: 'my-cluster',
+      },
+    },
+  },
+  output: {
+    config: {
+      client: 'BigtableInstanceAdminClient',
+      method: 'createInstance',
+      reqOpts: {
+        parent: 'projects/test-project',
+        instanceId: 'my-instance',
+        instance: {
+          displayName: 'my-instance',
+        },
+        clusters: {
+          'my-cluster': {
+            location: 'projects/test-project/locations/us-central1-b',
+            serveNodes: 2,
+            defaultStorageType: 1,
+          },
+        },
+      },
+    },
+  },
+};
+
+exports[
+  'Bigtable createInstance should provide the proper request options asynchronously 3'
+] = {
+  input: {
+    id: 'my-instance',
+    options: {
+      clusters: {
+        nodes: 2,
+        key: 'kms-key-name',
+        location: 'us-central1-b',
+        id: 'my-cluster',
+      },
+    },
+  },
+  output: {
+    config: {
+      client: 'BigtableInstanceAdminClient',
+      method: 'createInstance',
+      reqOpts: {
+        parent: 'projects/test-project',
+        instanceId: 'my-instance',
+        instance: {
+          displayName: 'my-instance',
+        },
+        clusters: {
+          'my-cluster': {
+            location: 'projects/test-project/locations/us-central1-b',
+            serveNodes: 2,
+            defaultStorageType: 0,
+            encryptionConfig: {
+              kmsKeyName: 'kms-key-name',
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
+exports[
+  'Bigtable createInstance should provide the proper request options asynchronously 4'
+] = {
+  input: {
+    id: 'my-instance',
+    options: {
+      clusters: {
+        nodes: 2,
+        encryption: {
+          kmsKeyName: 'kms-key-name',
+        },
+        location: 'us-central1-b',
+        id: 'my-cluster',
+      },
+    },
+  },
+  output: {
+    config: {
+      client: 'BigtableInstanceAdminClient',
+      method: 'createInstance',
+      reqOpts: {
+        parent: 'projects/test-project',
+        instanceId: 'my-instance',
+        instance: {
+          displayName: 'my-instance',
+        },
+        clusters: {
+          'my-cluster': {
+            location: 'projects/test-project/locations/us-central1-b',
+            serveNodes: 2,
+            defaultStorageType: 0,
+            encryptionConfig: {
+              kmsKeyName: 'kms-key-name',
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
+exports[
+  'Bigtable createInstance should provide the proper request options asynchronously 5'
+] = {
+  input: {
+    id: 'my-instance',
+    options: {
+      clusters: {
+        minServeNodes: 2,
+        maxServeNodes: 3,
+        cpuUtilizationPercent: 50,
+        location: 'us-central1-b',
+        id: 'my-cluster',
+      },
+    },
+  },
+  output: {
+    config: {
+      client: 'BigtableInstanceAdminClient',
+      method: 'createInstance',
+      reqOpts: {
+        parent: 'projects/test-project',
+        instanceId: 'my-instance',
+        instance: {
+          displayName: 'my-instance',
+        },
+        clusters: {
+          'my-cluster': {
+            location: 'projects/test-project/locations/us-central1-b',
+            clusterConfig: {
+              clusterAutoscalingConfig: {
+                autoscalingTargets: {
+                  cpuUtilizationPercent: 50,
+                },
+                autoscalingLimits: {
+                  minServeNodes: 2,
+                  maxServeNodes: 3,
+                },
+              },
+            },
+            defaultStorageType: 0,
+          },
+        },
+      },
+    },
+  },
+};

--- a/__snapshots__/instance.js
+++ b/__snapshots__/instance.js
@@ -1,0 +1,147 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+exports[
+  'Bigtable/Instance createCluster should provide the proper request options asynchronously 1'
+] = {
+  id: 'my-cluster',
+  options: {
+    nodes: 2,
+    location: 'us-central1-b',
+  },
+  request: {
+    client: 'BigtableInstanceAdminClient',
+    method: 'createCluster',
+    reqOpts: {
+      parent: 'projects/my-project/instances/my-instance',
+      clusterId: 'my-cluster',
+      cluster: {
+        location: 'projects/my-project/locations/us-central1-b',
+        serveNodes: 2,
+      },
+    },
+  },
+};
+
+exports[
+  'Bigtable/Instance createCluster should provide the proper request options asynchronously 2'
+] = {
+  id: 'my-cluster',
+  options: {
+    nodes: 2,
+    storage: 'ssd',
+    location: 'us-central1-b',
+  },
+  request: {
+    client: 'BigtableInstanceAdminClient',
+    method: 'createCluster',
+    reqOpts: {
+      parent: 'projects/my-project/instances/my-instance',
+      clusterId: 'my-cluster',
+      cluster: {
+        location: 'projects/my-project/locations/us-central1-b',
+        serveNodes: 2,
+        defaultStorageType: 1,
+      },
+    },
+  },
+};
+
+exports[
+  'Bigtable/Instance createCluster should provide the proper request options asynchronously 3'
+] = {
+  id: 'my-cluster',
+  options: {
+    nodes: 2,
+    key: 'kms-key-name',
+    location: 'us-central1-b',
+  },
+  request: {
+    client: 'BigtableInstanceAdminClient',
+    method: 'createCluster',
+    reqOpts: {
+      parent: 'projects/my-project/instances/my-instance',
+      clusterId: 'my-cluster',
+      cluster: {
+        location: 'projects/my-project/locations/us-central1-b',
+        serveNodes: 2,
+        encryptionConfig: {
+          kmsKeyName: 'kms-key-name',
+        },
+      },
+    },
+  },
+};
+
+exports[
+  'Bigtable/Instance createCluster should provide the proper request options asynchronously 4'
+] = {
+  id: 'my-cluster',
+  options: {
+    nodes: 2,
+    encryption: {
+      kmsKeyName: 'kms-key-name',
+    },
+    location: 'us-central1-b',
+  },
+  request: {
+    client: 'BigtableInstanceAdminClient',
+    method: 'createCluster',
+    reqOpts: {
+      parent: 'projects/my-project/instances/my-instance',
+      clusterId: 'my-cluster',
+      cluster: {
+        location: 'projects/my-project/locations/us-central1-b',
+        serveNodes: 2,
+        encryptionConfig: {
+          kmsKeyName: 'kms-key-name',
+        },
+      },
+    },
+  },
+};
+
+exports[
+  'Bigtable/Instance createCluster should provide the proper request options asynchronously 5'
+] = {
+  id: 'my-cluster',
+  options: {
+    minServeNodes: 2,
+    maxServeNodes: 3,
+    cpuUtilizationPercent: 50,
+    location: 'us-central1-b',
+  },
+  request: {
+    client: 'BigtableInstanceAdminClient',
+    method: 'createCluster',
+    reqOpts: {
+      parent: 'projects/my-project/instances/my-instance',
+      clusterId: 'my-cluster',
+      cluster: {
+        location: 'projects/my-project/locations/us-central1-b',
+        clusterConfig: {
+          clusterAutoscalingConfig: {
+            autoscalingTargets: {
+              cpuUtilizationPercent: 50,
+            },
+            autoscalingLimits: {
+              minServeNodes: 2,
+              maxServeNodes: 3,
+            },
+          },
+        },
+      },
+    },
+  },
+};

--- a/__snapshots__/instance.js
+++ b/__snapshots__/instance.js
@@ -20,7 +20,7 @@ exports[
     nodes: 2,
     location: 'us-central1-b',
   },
-  request: {
+  config: {
     client: 'BigtableInstanceAdminClient',
     method: 'createCluster',
     reqOpts: {
@@ -43,7 +43,7 @@ exports[
     storage: 'ssd',
     location: 'us-central1-b',
   },
-  request: {
+  config: {
     client: 'BigtableInstanceAdminClient',
     method: 'createCluster',
     reqOpts: {
@@ -67,7 +67,7 @@ exports[
     key: 'kms-key-name',
     location: 'us-central1-b',
   },
-  request: {
+  config: {
     client: 'BigtableInstanceAdminClient',
     method: 'createCluster',
     reqOpts: {
@@ -95,7 +95,7 @@ exports[
     },
     location: 'us-central1-b',
   },
-  request: {
+  config: {
     client: 'BigtableInstanceAdminClient',
     method: 'createCluster',
     reqOpts: {
@@ -122,7 +122,7 @@ exports[
     cpuUtilizationPercent: 50,
     location: 'us-central1-b',
   },
-  request: {
+  config: {
     client: 'BigtableInstanceAdminClient',
     method: 'createCluster',
     reqOpts: {

--- a/__snapshots__/instance.js
+++ b/__snapshots__/instance.js
@@ -15,20 +15,24 @@
 exports[
   'Bigtable/Instance createCluster should provide the proper request options asynchronously 1'
 ] = {
-  id: 'my-cluster',
-  options: {
-    nodes: 2,
-    location: 'us-central1-b',
+  input: {
+    id: 'my-cluster',
+    options: {
+      nodes: 2,
+      location: 'us-central1-b',
+    },
   },
-  config: {
-    client: 'BigtableInstanceAdminClient',
-    method: 'createCluster',
-    reqOpts: {
-      parent: 'projects/my-project/instances/my-instance',
-      clusterId: 'my-cluster',
-      cluster: {
-        location: 'projects/my-project/locations/us-central1-b',
-        serveNodes: 2,
+  output: {
+    config: {
+      client: 'BigtableInstanceAdminClient',
+      method: 'createCluster',
+      reqOpts: {
+        parent: 'projects/my-project/instances/my-instance',
+        clusterId: 'my-cluster',
+        cluster: {
+          location: 'projects/my-project/locations/us-central1-b',
+          serveNodes: 2,
+        },
       },
     },
   },
@@ -37,22 +41,26 @@ exports[
 exports[
   'Bigtable/Instance createCluster should provide the proper request options asynchronously 2'
 ] = {
-  id: 'my-cluster',
-  options: {
-    nodes: 2,
-    storage: 'ssd',
-    location: 'us-central1-b',
+  input: {
+    id: 'my-cluster',
+    options: {
+      nodes: 2,
+      storage: 'ssd',
+      location: 'us-central1-b',
+    },
   },
-  config: {
-    client: 'BigtableInstanceAdminClient',
-    method: 'createCluster',
-    reqOpts: {
-      parent: 'projects/my-project/instances/my-instance',
-      clusterId: 'my-cluster',
-      cluster: {
-        location: 'projects/my-project/locations/us-central1-b',
-        serveNodes: 2,
-        defaultStorageType: 1,
+  output: {
+    config: {
+      client: 'BigtableInstanceAdminClient',
+      method: 'createCluster',
+      reqOpts: {
+        parent: 'projects/my-project/instances/my-instance',
+        clusterId: 'my-cluster',
+        cluster: {
+          location: 'projects/my-project/locations/us-central1-b',
+          serveNodes: 2,
+          defaultStorageType: 1,
+        },
       },
     },
   },
@@ -61,23 +69,27 @@ exports[
 exports[
   'Bigtable/Instance createCluster should provide the proper request options asynchronously 3'
 ] = {
-  id: 'my-cluster',
-  options: {
-    nodes: 2,
-    key: 'kms-key-name',
-    location: 'us-central1-b',
+  input: {
+    id: 'my-cluster',
+    options: {
+      nodes: 2,
+      key: 'kms-key-name',
+      location: 'us-central1-b',
+    },
   },
-  config: {
-    client: 'BigtableInstanceAdminClient',
-    method: 'createCluster',
-    reqOpts: {
-      parent: 'projects/my-project/instances/my-instance',
-      clusterId: 'my-cluster',
-      cluster: {
-        location: 'projects/my-project/locations/us-central1-b',
-        serveNodes: 2,
-        encryptionConfig: {
-          kmsKeyName: 'kms-key-name',
+  output: {
+    config: {
+      client: 'BigtableInstanceAdminClient',
+      method: 'createCluster',
+      reqOpts: {
+        parent: 'projects/my-project/instances/my-instance',
+        clusterId: 'my-cluster',
+        cluster: {
+          location: 'projects/my-project/locations/us-central1-b',
+          serveNodes: 2,
+          encryptionConfig: {
+            kmsKeyName: 'kms-key-name',
+          },
         },
       },
     },
@@ -87,25 +99,29 @@ exports[
 exports[
   'Bigtable/Instance createCluster should provide the proper request options asynchronously 4'
 ] = {
-  id: 'my-cluster',
-  options: {
-    nodes: 2,
-    encryption: {
-      kmsKeyName: 'kms-key-name',
+  input: {
+    id: 'my-cluster',
+    options: {
+      nodes: 2,
+      encryption: {
+        kmsKeyName: 'kms-key-name',
+      },
+      location: 'us-central1-b',
     },
-    location: 'us-central1-b',
   },
-  config: {
-    client: 'BigtableInstanceAdminClient',
-    method: 'createCluster',
-    reqOpts: {
-      parent: 'projects/my-project/instances/my-instance',
-      clusterId: 'my-cluster',
-      cluster: {
-        location: 'projects/my-project/locations/us-central1-b',
-        serveNodes: 2,
-        encryptionConfig: {
-          kmsKeyName: 'kms-key-name',
+  output: {
+    config: {
+      client: 'BigtableInstanceAdminClient',
+      method: 'createCluster',
+      reqOpts: {
+        parent: 'projects/my-project/instances/my-instance',
+        clusterId: 'my-cluster',
+        cluster: {
+          location: 'projects/my-project/locations/us-central1-b',
+          serveNodes: 2,
+          encryptionConfig: {
+            kmsKeyName: 'kms-key-name',
+          },
         },
       },
     },
@@ -115,29 +131,33 @@ exports[
 exports[
   'Bigtable/Instance createCluster should provide the proper request options asynchronously 5'
 ] = {
-  id: 'my-cluster',
-  options: {
-    minServeNodes: 2,
-    maxServeNodes: 3,
-    cpuUtilizationPercent: 50,
-    location: 'us-central1-b',
+  input: {
+    id: 'my-cluster',
+    options: {
+      minServeNodes: 2,
+      maxServeNodes: 3,
+      cpuUtilizationPercent: 50,
+      location: 'us-central1-b',
+    },
   },
-  config: {
-    client: 'BigtableInstanceAdminClient',
-    method: 'createCluster',
-    reqOpts: {
-      parent: 'projects/my-project/instances/my-instance',
-      clusterId: 'my-cluster',
-      cluster: {
-        location: 'projects/my-project/locations/us-central1-b',
-        clusterConfig: {
-          clusterAutoscalingConfig: {
-            autoscalingTargets: {
-              cpuUtilizationPercent: 50,
-            },
-            autoscalingLimits: {
-              minServeNodes: 2,
-              maxServeNodes: 3,
+  output: {
+    config: {
+      client: 'BigtableInstanceAdminClient',
+      method: 'createCluster',
+      reqOpts: {
+        parent: 'projects/my-project/instances/my-instance',
+        clusterId: 'my-cluster',
+        cluster: {
+          location: 'projects/my-project/locations/us-central1-b',
+          clusterConfig: {
+            clusterAutoscalingConfig: {
+              autoscalingTargets: {
+                cpuUtilizationPercent: 50,
+              },
+              autoscalingLimits: {
+                minServeNodes: 2,
+                maxServeNodes: 3,
+              },
             },
           },
         },

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "pack-n-play": "^1.0.0-2",
     "proxyquire": "^2.0.0",
     "sinon": "^14.0.0",
+    "snap-shot-it": "^7.9.1",
     "ts-loader": "^9.0.0",
     "typescript": "^4.6.4",
     "uuid": "^8.0.0",

--- a/src/cluster.ts
+++ b/src/cluster.ts
@@ -693,7 +693,7 @@ Please use the format 'my-cluster' or '${instance.name}/clusters/my-cluster'.`);
    * region_tag:bigtable_api_cluster_set_meta
    */
   setMetadata(
-    metadata: SetClusterMetadataOptions,
+    metadata: BasicClusterConfig,
     gaxOptionsOrCallback?: CallOptions | SetClusterMetadataCallback,
     cb?: SetClusterMetadataCallback
   ): void | Promise<SetClusterMetadataResponse> {
@@ -704,11 +704,7 @@ Please use the format 'my-cluster' or '${instance.name}/clusters/my-cluster'.`);
       typeof gaxOptionsOrCallback === 'object'
         ? gaxOptionsOrCallback
         : ({} as CallOptions);
-    const reqOpts = ClusterUtils.getRequestFromMetadata(
-      metadata,
-      this?.metadata?.location,
-      this.name
-    );
+    const reqOpts = ClusterUtils.getRequestFromMetadata(metadata, this.name);
     this.bigtable.request<Operation>(
       {
         client: 'BigtableInstanceAdminClient',

--- a/src/index.ts
+++ b/src/index.ts
@@ -621,12 +621,6 @@ export class Bigtable {
         defaultStorageType: Cluster.getStorageType_(cluster.storage!),
       });
 
-      if (cluster.key) {
-        clusters[cluster.id!].encryptionConfig = {
-          kmsKeyName: cluster.key,
-        };
-      }
-
       if (cluster.encryption) {
         clusters[cluster.id!].encryptionConfig = cluster.encryption;
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -621,10 +621,6 @@ export class Bigtable {
         defaultStorageType: Cluster.getStorageType_(cluster.storage!),
       });
 
-      if (cluster.encryption) {
-        clusters[cluster.id!].encryptionConfig = cluster.encryption;
-      }
-
       return clusters;
     }, {} as {[index: string]: google.bigtable.admin.v2.ICluster});
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -612,15 +612,9 @@ export class Bigtable {
         );
       }
       ClusterUtils.validateClusterMetadata(cluster);
-      const clusterClone = Object.assign({}, cluster);
-      if (clusterClone.location) {
-        clusterClone.location = Cluster.getLocation_(
-          this.projectId,
-          clusterClone.location
-        );
-      }
-      clusters[cluster.id!] = ClusterUtils.getClusterBaseConfig(
-        clusterClone,
+      clusters[cluster.id!] = ClusterUtils.getClusterBaseConfigWithFullLocation(
+        cluster,
+        this.projectId,
         undefined
       );
       Object.assign(clusters[cluster.id!], {

--- a/src/index.ts
+++ b/src/index.ts
@@ -612,9 +612,15 @@ export class Bigtable {
         );
       }
       ClusterUtils.validateClusterMetadata(cluster);
+      const clusterClone = Object.assign({}, cluster);
+      if (clusterClone.location) {
+        clusterClone.location = Cluster.getLocation_(
+          this.projectId,
+          clusterClone.location
+        );
+      }
       clusters[cluster.id!] = ClusterUtils.getClusterBaseConfig(
-        cluster,
-        Cluster.getLocation_(this.projectId, cluster.location!),
+        clusterClone,
         undefined
       );
       Object.assign(clusters[cluster.id!], {

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,7 @@ import {ServiceError} from 'google-gax';
 import * as v2 from './v2';
 import {PassThrough, Duplex} from 'stream';
 import grpcGcpModule = require('grpc-gcp');
-import {ClusterUtils} from './utils/cluster';
+import {ClusterCredentialsUtils, ClusterUtils} from './utils/cluster';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const streamEvents = require('stream-events');
@@ -602,15 +602,7 @@ export class Bigtable {
           'A cluster was provided without an `id` property defined.'
         );
       }
-
-      if (
-        typeof cluster.key !== 'undefined' &&
-        typeof cluster.encryption !== 'undefined'
-      ) {
-        throw new Error(
-          'A cluster was provided with both `encryption` and `key` defined.'
-        );
-      }
+      ClusterCredentialsUtils.validateCredentialsForInstance(cluster);
       ClusterUtils.validateClusterMetadata(cluster);
       clusters[cluster.id!] = ClusterUtils.getClusterBaseConfigWithFullLocation(
         cluster,

--- a/src/instance.ts
+++ b/src/instance.ts
@@ -394,15 +394,9 @@ Please use the format 'my-instance' or '${bigtable.projectName}/instances/my-ins
     } as google.bigtable.admin.v2.CreateClusterRequest;
     ClusterUtils.validateClusterMetadata(options);
     if (!is.empty(options)) {
-      const optionsClone = Object.assign({}, options);
-      if (optionsClone.location) {
-        optionsClone.location = Cluster.getLocation_(
-          this.bigtable.projectId,
-          optionsClone.location
-        );
-      }
-      reqOpts.cluster = ClusterUtils.getClusterBaseConfig(
-        optionsClone,
+      reqOpts.cluster = ClusterUtils.getClusterBaseConfigWithFullLocation(
+        options,
+        this.bigtable.projectId,
         undefined
       );
     }

--- a/src/instance.ts
+++ b/src/instance.ts
@@ -410,10 +410,6 @@ Please use the format 'my-instance' or '${bigtable.projectName}/instances/my-ins
       );
     }
 
-    if (options.encryption) {
-      reqOpts.cluster!.encryptionConfig = options.encryption;
-    }
-
     if (options.storage) {
       const storageType = Cluster.getStorageType_(options.storage);
       reqOpts.cluster!.defaultStorageType = storageType;

--- a/src/instance.ts
+++ b/src/instance.ts
@@ -67,7 +67,7 @@ import {ServiceError} from 'google-gax';
 import {Bigtable} from '.';
 import {google} from '../protos/protos';
 import {Backup, RestoreTableCallback, RestoreTableResponse} from './backup';
-import {ClusterUtils} from './utils/cluster';
+import {ClusterCredentialsUtils, ClusterUtils} from './utils/cluster';
 
 export interface ClusterInfo extends BasicClusterConfig {
   id: string;
@@ -400,16 +400,7 @@ Please use the format 'my-instance' or '${bigtable.projectName}/instances/my-ins
         undefined
       );
     }
-
-    if (
-      typeof options.key !== 'undefined' &&
-      typeof options.encryption !== 'undefined'
-    ) {
-      throw new Error(
-        'The cluster cannot have both `encryption` and `key` defined.'
-      );
-    }
-
+    ClusterCredentialsUtils.validateCredentialsForCluster(options);
     if (options.storage) {
       const storageType = Cluster.getStorageType_(options.storage);
       reqOpts.cluster!.defaultStorageType = storageType;

--- a/src/instance.ts
+++ b/src/instance.ts
@@ -410,12 +410,6 @@ Please use the format 'my-instance' or '${bigtable.projectName}/instances/my-ins
       );
     }
 
-    if (options.key) {
-      reqOpts.cluster!.encryptionConfig = {
-        kmsKeyName: options.key,
-      };
-    }
-
     if (options.encryption) {
       reqOpts.cluster!.encryptionConfig = options.encryption;
     }

--- a/src/instance.ts
+++ b/src/instance.ts
@@ -394,11 +394,15 @@ Please use the format 'my-instance' or '${bigtable.projectName}/instances/my-ins
     } as google.bigtable.admin.v2.CreateClusterRequest;
     ClusterUtils.validateClusterMetadata(options);
     if (!is.empty(options)) {
+      const optionsClone = Object.assign({}, options);
+      if (optionsClone.location) {
+        optionsClone.location = Cluster.getLocation_(
+          this.bigtable.projectId,
+          optionsClone.location
+        );
+      }
       reqOpts.cluster = ClusterUtils.getClusterBaseConfig(
-        options,
-        options.location
-          ? Cluster.getLocation_(this.bigtable.projectId, options.location)
-          : undefined,
+        optionsClone,
         undefined
       );
     }

--- a/src/utils/cluster.ts
+++ b/src/utils/cluster.ts
@@ -113,7 +113,8 @@ export class ClusterUtils {
     const baseConfig = ClusterUtils.getClusterBaseConfig(metadata, name);
     return Object.assign(
       baseConfig,
-      metadata.key ? {encryptionConfig: {kmsKeyName: metadata.key}} : null
+      metadata.key ? {encryptionConfig: {kmsKeyName: metadata.key}} : null,
+      metadata.encryption ? {encryptionConfig: metadata.encryption} : null
     );
   }
 

--- a/src/utils/cluster.ts
+++ b/src/utils/cluster.ts
@@ -16,10 +16,12 @@ import * as protos from '../../protos/protos';
 import {
   BasicClusterConfig,
   Cluster,
+  CreateClusterOptions,
   ICluster,
   SetClusterMetadataOptions,
 } from '../cluster';
 import {google} from '../../protos/protos';
+import {ClusterInfo} from '../instance';
 
 export class ClusterUtils {
   static noConfigError =
@@ -174,5 +176,33 @@ export class ClusterUtils {
       cluster: this.getClusterFromMetadata(metadata, name),
       updateMask: {paths: this.getUpdateMask(metadata)},
     };
+  }
+}
+
+export class ClusterCredentialsUtils {
+  static validateCredentialsForInstance(cluster: ClusterInfo) {
+    this.validateErrorAndKey(
+      cluster,
+      'A cluster was provided with both `encryption` and `key` defined.'
+    );
+  }
+
+  static validateCredentialsForCluster(cluster: CreateClusterOptions) {
+    this.validateErrorAndKey(
+      cluster,
+      'The cluster cannot have both `encryption` and `key` defined.'
+    );
+  }
+
+  static validateErrorAndKey(
+    cluster: CreateClusterOptions | ClusterInfo,
+    message: string
+  ) {
+    if (
+      typeof cluster.key !== 'undefined' &&
+      typeof cluster.encryption !== 'undefined'
+    ) {
+      throw new Error(message);
+    }
   }
 }

--- a/src/utils/cluster.ts
+++ b/src/utils/cluster.ts
@@ -14,7 +14,8 @@
 
 import * as protos from '../../protos/protos';
 import {
-  BasicClusterConfig, Cluster,
+  BasicClusterConfig,
+  Cluster,
   ICluster,
   SetClusterMetadataOptions,
 } from '../cluster';

--- a/src/utils/cluster.ts
+++ b/src/utils/cluster.ts
@@ -118,7 +118,6 @@ export class ClusterUtils {
       location ? {location} : null,
       clusterConfig ? {clusterConfig} : null,
       metadata.nodes ? {serveNodes: metadata.nodes} : null
-      // metadata.key ? {encryptionConfig: {kmsKeyName: metadata.key}} : null
     );
   }
 

--- a/src/utils/cluster.ts
+++ b/src/utils/cluster.ts
@@ -57,6 +57,7 @@ export class ClusterUtils {
       }
     }
   }
+
   static getUpdateMask(metadata: SetClusterMetadataOptions): string[] {
     const updateMask: string[] = [];
     if (metadata.nodes) {

--- a/src/utils/cluster.ts
+++ b/src/utils/cluster.ts
@@ -14,7 +14,7 @@
 
 import * as protos from '../../protos/protos';
 import {
-  BasicClusterConfig,
+  BasicClusterConfig, Cluster,
   ICluster,
   SetClusterMetadataOptions,
 } from '../cluster';
@@ -87,6 +87,21 @@ export class ClusterUtils {
       );
     }
     return updateMask;
+  }
+
+  static getClusterBaseConfigWithFullLocation(
+    metadata: BasicClusterConfig,
+    projectId: string,
+    name: string | undefined
+  ): google.bigtable.admin.v2.ICluster {
+    const metadataClone = Object.assign({}, metadata);
+    if (metadataClone.location) {
+      metadataClone.location = Cluster.getLocation_(
+        projectId,
+        metadataClone.location
+      );
+    }
+    return ClusterUtils.getClusterBaseConfig(metadataClone, name);
   }
 
   static getClusterBaseConfig(

--- a/src/utils/cluster.ts
+++ b/src/utils/cluster.ts
@@ -103,7 +103,18 @@ export class ClusterUtils {
         metadataClone.location
       );
     }
-    return ClusterUtils.getClusterBaseConfig(metadataClone, name);
+    return ClusterUtils.getClusterAdvancedConfig(metadataClone, name);
+  }
+
+  static getClusterAdvancedConfig(
+    metadata: BasicClusterConfig,
+    name: string | undefined
+  ): google.bigtable.admin.v2.ICluster {
+    const baseConfig = ClusterUtils.getClusterBaseConfig(metadata, name);
+    return Object.assign(
+      baseConfig,
+      metadata.key ? {encryptionConfig: {kmsKeyName: metadata.key}} : null
+    );
   }
 
   static getClusterBaseConfig(

--- a/test/cluster.ts
+++ b/test/cluster.ts
@@ -1026,7 +1026,6 @@ describe('Bigtable/Cluster', () => {
 
       const expectedReqOpts = ClusterUtils.getRequestFromMetadata(
         options,
-        options.location,
         CLUSTER_NAME
       );
 

--- a/test/cluster.ts
+++ b/test/cluster.ts
@@ -20,6 +20,9 @@ import {PassThrough, Readable} from 'stream';
 import {CallOptions} from 'google-gax';
 import {PreciseDate} from '@google-cloud/precise-date';
 import {ClusterUtils} from '../src/utils/cluster';
+import {InstanceOptions, RequestOptions} from '../src';
+import {createClusterOptionsList} from './constants/cluster';
+import * as snapshot from 'snap-shot-it';
 
 export interface Options {
   nodes?: Number;
@@ -979,6 +982,25 @@ describe('Bigtable/Cluster', () => {
       };
 
       cluster.setMetadata({nodes: 2}, done);
+    });
+
+    it('should provide the proper request options asynchronously', async () => {
+      let currentRequestInput = null;
+      (cluster.bigtable.request as Function) = (config: RequestOptions) => {
+        currentRequestInput = config;
+      };
+      for (const options of createClusterOptionsList) {
+        await cluster.setMetadata(options);
+        snapshot({
+          input: {
+            id: cluster.id,
+            options: options,
+          },
+          output: {
+            config: currentRequestInput,
+          },
+        });
+      }
     });
 
     it('should respect the nodes option', done => {

--- a/test/constants/cluster.ts
+++ b/test/constants/cluster.ts
@@ -1,0 +1,13 @@
+import {CreateClusterOptions} from '../../src';
+
+export const createClusterOptionsList: CreateClusterOptions[] = [
+  {nodes: 2},
+  {nodes: 2, storage: 'ssd'},
+  {nodes: 2, key: 'kms-key-name'},
+  {nodes: 2, encryption: {kmsKeyName: 'kms-key-name'}},
+  {
+    minServeNodes: 2,
+    maxServeNodes: 3,
+    cpuUtilizationPercent: 50,
+  },
+].map(option => Object.assign(option, {location: 'us-central1-b'}));

--- a/test/constants/cluster.ts
+++ b/test/constants/cluster.ts
@@ -1,3 +1,17 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import {CreateClusterOptions} from '../../src';
 
 export const createClusterOptionsList: CreateClusterOptions[] = [

--- a/test/index.ts
+++ b/test/index.ts
@@ -25,6 +25,7 @@ import {Instance, InstanceOptions} from '../src/instance.js';
 import {PassThrough} from 'stream';
 import {RequestOptions} from '../src';
 import * as snapshot from 'snap-shot-it';
+import {createClusterOptionsList} from './constants/cluster';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const v2 = require('../src/v2');
@@ -406,19 +407,8 @@ describe('Bigtable', () => {
       (bigtable.request as Function) = (config: RequestOptions) => {
         currentRequestInput = config;
       };
-      const createClusterOptionsList: CreateClusterOptions[] = [
-        {nodes: 2},
-        {nodes: 2, storage: 'ssd'},
-        {nodes: 2, key: 'kms-key-name'},
-        {nodes: 2, encryption: {kmsKeyName: 'kms-key-name'}},
-        {
-          minServeNodes: 2,
-          maxServeNodes: 3,
-          cpuUtilizationPercent: 50,
-        },
-      ].map(option => Object.assign(option, {location: 'us-central1-b'}));
       const instanceOptionsList: InstanceOptions[] = createClusterOptionsList
-        .map(options => Object.assign(options, {id: 'my-cluster'}))
+        .map(options => Object.assign({}, options, {id: 'my-cluster'}))
         .map(options => {
           return {
             clusters: options,

--- a/test/index.ts
+++ b/test/index.ts
@@ -20,7 +20,7 @@ import * as gax from 'google-gax';
 import * as proxyquire from 'proxyquire';
 import * as sn from 'sinon';
 
-import {Cluster, CreateClusterOptions} from '../src/cluster.js';
+import {Cluster} from '../src/cluster.js';
 import {Instance, InstanceOptions} from '../src/instance.js';
 import {PassThrough} from 'stream';
 import {RequestOptions} from '../src';
@@ -493,7 +493,10 @@ describe('Bigtable', () => {
     });
 
     it('should respect the clusters option', done => {
-      const fakeLocation = 'a/b/c/d';
+      const fakeLocation = Cluster.getLocation_(
+        PROJECT_ID,
+        OPTIONS.clusters[0].location
+      );
       FakeCluster.getLocation_ = (project: string, location: string) => {
         assert.strictEqual(project, PROJECT_ID);
         assert.strictEqual(location, OPTIONS.clusters[0].location);

--- a/test/index.ts
+++ b/test/index.ts
@@ -20,9 +20,11 @@ import * as gax from 'google-gax';
 import * as proxyquire from 'proxyquire';
 import * as sn from 'sinon';
 
-import {Cluster} from '../src/cluster.js';
-import {Instance} from '../src/instance.js';
+import {Cluster, CreateClusterOptions} from '../src/cluster.js';
+import {Instance, InstanceOptions} from '../src/instance.js';
 import {PassThrough} from 'stream';
+import {RequestOptions} from '../src';
+import * as snapshot from 'snap-shot-it';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const v2 = require('../src/v2');
@@ -397,6 +399,43 @@ describe('Bigtable', () => {
         done();
       };
       bigtable.createInstance(INSTANCE_ID, OPTIONS, assert.ifError);
+    });
+
+    it('should provide the proper request options asynchronously', async () => {
+      let currentRequestInput = null;
+      (bigtable.request as Function) = (config: RequestOptions) => {
+        currentRequestInput = config;
+      };
+      const createClusterOptionsList: CreateClusterOptions[] = [
+        {nodes: 2},
+        {nodes: 2, storage: 'ssd'},
+        {nodes: 2, key: 'kms-key-name'},
+        {nodes: 2, encryption: {kmsKeyName: 'kms-key-name'}},
+        {
+          minServeNodes: 2,
+          maxServeNodes: 3,
+          cpuUtilizationPercent: 50,
+        },
+      ].map(option => Object.assign(option, {location: 'us-central1-b'}));
+      const instanceOptionsList: InstanceOptions[] = createClusterOptionsList
+        .map(options => Object.assign(options, {id: 'my-cluster'}))
+        .map(options => {
+          return {
+            clusters: options,
+          };
+        });
+      for (const options of instanceOptionsList) {
+        await bigtable.createInstance(INSTANCE_ID, options, assert.ifError);
+        snapshot({
+          input: {
+            id: INSTANCE_ID,
+            options: options,
+          },
+          output: {
+            config: currentRequestInput,
+          },
+        });
+      }
     });
 
     it('should accept gaxOptions', done => {

--- a/test/instance.ts
+++ b/test/instance.ts
@@ -384,9 +384,13 @@ describe('Bigtable/Instance', () => {
       for (const options of optionsList) {
         await instance.createCluster(CLUSTER_ID, options);
         snapshot({
-          id: CLUSTER_ID,
-          options: options,
-          config: currentRequestInput,
+          input: {
+            id: CLUSTER_ID,
+            options: options,
+          },
+          output: {
+            config: currentRequestInput,
+          },
         });
       }
     });

--- a/test/instance.ts
+++ b/test/instance.ts
@@ -386,7 +386,7 @@ describe('Bigtable/Instance', () => {
         snapshot({
           id: CLUSTER_ID,
           options: options,
-          request: currentRequestInput,
+          config: currentRequestInput,
         });
       }
     });

--- a/test/instance.ts
+++ b/test/instance.ts
@@ -36,6 +36,7 @@ import * as pumpify from 'pumpify';
 import {FakeCluster} from '../system-test/common';
 import {RestoreTableConfig} from '../src/backup';
 import {Options} from './cluster';
+import {createClusterOptionsList} from './constants/cluster';
 
 const sandbox = sinon.createSandbox();
 
@@ -370,17 +371,7 @@ describe('Bigtable/Instance', () => {
       (instance.bigtable.request as Function) = (config: RequestOptions) => {
         currentRequestInput = config;
       };
-      const optionsList = [
-        {nodes: 2},
-        {nodes: 2, storage: 'ssd'},
-        {nodes: 2, key: 'kms-key-name'},
-        {nodes: 2, encryption: {kmsKeyName: 'kms-key-name'}},
-        {
-          minServeNodes: 2,
-          maxServeNodes: 3,
-          cpuUtilizationPercent: 50,
-        },
-      ].map(option => Object.assign(option, {location: 'us-central1-b'}));
+      const optionsList = createClusterOptionsList;
       for (const options of optionsList) {
         await instance.createCluster(CLUSTER_ID, options);
         snapshot({

--- a/test/instance.ts
+++ b/test/instance.ts
@@ -22,7 +22,7 @@ import * as snapshot from 'snap-shot-it';
 
 import * as inst from '../src/instance';
 import {AppProfile, AppProfileOptions} from '../src/app-profile';
-import {CreateClusterOptions} from '../src/cluster';
+import {Cluster, CreateClusterOptions} from '../src/cluster';
 import {Family} from '../src/family';
 import {
   Policy,
@@ -404,7 +404,10 @@ describe('Bigtable/Instance', () => {
         location: 'us-central1-b',
         nodes: 2,
       } as CreateClusterOptions;
-      const fakeLocation = 'a/b/c/d';
+      const fakeLocation = Cluster.getLocation_(
+        BIGTABLE.projectId,
+        options.location
+      );
       sandbox
         .stub(FakeCluster, 'getLocation_')
         .callsFake((project, location) => {

--- a/test/utils/cluster.ts
+++ b/test/utils/cluster.ts
@@ -21,21 +21,17 @@ describe('Bigtable/Utils/Cluster', () => {
     it('should translate metadata for a full set of parameters', () => {
       const metadata = {
         nodes: 1,
+        location: 'projects/{{projectId}}/locations/us-east4-b',
         minServeNodes: 2,
         maxServeNodes: 3,
         cpuUtilizationPercent: 50,
       };
       const name = 'cluster1';
-      const location = 'projects/{{projectId}}/locations/us-east4-b';
-      const reqOpts = ClusterUtils.getRequestFromMetadata(
-        metadata,
-        location,
-        name
-      );
+      const reqOpts = ClusterUtils.getRequestFromMetadata(metadata, name);
       assert.deepStrictEqual(reqOpts, {
         cluster: {
-          name: name,
-          location: location,
+          name,
+          location: metadata.location,
           serveNodes: metadata.nodes,
           clusterConfig: {
             clusterAutoscalingConfig: {
@@ -61,21 +57,17 @@ describe('Bigtable/Utils/Cluster', () => {
     });
     it('should translate metadata for autoscaling parameters', () => {
       const metadata = {
+        location: 'projects/{{projectId}}/locations/us-east4-b',
         minServeNodes: 2,
         maxServeNodes: 3,
         cpuUtilizationPercent: 50,
       };
       const name = 'cluster1';
-      const location = 'projects/{{projectId}}/locations/us-east4-b';
-      const reqOpts = ClusterUtils.getRequestFromMetadata(
-        metadata,
-        location,
-        name
-      );
+      const reqOpts = ClusterUtils.getRequestFromMetadata(metadata, name);
       assert.deepStrictEqual(reqOpts, {
         cluster: {
-          name: name,
-          location: location,
+          name,
+          location: metadata.location,
           clusterConfig: {
             clusterAutoscalingConfig: {
               autoscalingLimits: {


### PR DESCRIPTION
This pull request is dependent on https://github.com/googleapis/nodejs-bigtable/pull/1093. This PR is the 4th of a series of PRs for refactoring the conversion of cluster input parameters `key` and `encryption` into one function so that we don't have repeated code. Still more needs to be done like we should do the same for the storage parameter and we should also think about doing these conversions for cluster updates as well though breaking changes are involved with such tasks so those changes should be considered carefully.