### PR TITLE
fix: Make a ten minute timeout for delete operations

### DIFF
--- a/samples/package.json
+++ b/samples/package.json
@@ -27,7 +27,7 @@
     "requestretry": "^7.0.0"
   },
   "scripts": {
-    "test": "mocha --timeout=60000",
+    "test": "mocha --timeout=600000",
     "test:snap": "SNAPSHOT_UPDATE=1 npm test"
   }
 }


### PR DESCRIPTION
This PR should make the flakey tests for code samples not flakey anymore because now it will have enough time to complete the test.
