### PR TITLE
fix: Test is less restrictive to allow changes

### DIFF
--- a/system-test/cluster.ts
+++ b/system-test/cluster.ts
@@ -41,17 +41,21 @@ describe('Cluster', () => {
     assert.strictEqual(serveNodes, compareValues.nodes);
     if (clusterConfig) {
       assert.equal(isConfigDefined, true);
-      assert.deepStrictEqual(clusterConfig, {
-        clusterAutoscalingConfig: {
-          autoscalingLimits: {
-            minServeNodes: compareValues.minServeNodes,
-            maxServeNodes: compareValues.maxServeNodes,
-          },
-          autoscalingTargets: {
-            cpuUtilizationPercent: compareValues.cpuUtilizationPercent,
-          },
-        },
-      });
+      assert.equal(
+        clusterConfig.clusterAutoscalingConfig?.autoscalingLimits
+          ?.minServeNodes,
+        compareValues.minServeNodes
+      );
+      assert.equal(
+        clusterConfig.clusterAutoscalingConfig?.autoscalingLimits
+          ?.maxServeNodes,
+        compareValues.maxServeNodes
+      );
+      assert.equal(
+        clusterConfig.clusterAutoscalingConfig?.autoscalingTargets
+          ?.cpuUtilizationPercent,
+        compareValues.cpuUtilizationPercent
+      );
     } else {
       assert.equal(isConfigDefined, false);
     }


### PR DESCRIPTION
Sometimes cluster metadata returned changes slightly and this causes tests to fail. We want to make sure that these tests only check for what really needs to be there.