### PR TITLE
chore: add test proxy

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "pretest": "npm run compile",
     "test": "c8 mocha build/test",
     "test:snap": "SNAPSHOT_UPDATE=1 npm test",
+    "testproxy": "node testproxy/index.js",
     "clean": "gts clean",
     "precompile": "gts clean"
   },
@@ -64,6 +65,8 @@
     "stream-events": "^1.0.2"
   },
   "devDependencies": {
+    "@grpc/grpc-js": "^1.7.1",
+    "@grpc/proto-loader": "^0.7.3",
     "@types/escape-string-regexp": "^1.0.0",
     "@types/extend": "^3.0.1",
     "@types/is": "0.0.21",
@@ -87,8 +90,8 @@
     "pack-n-play": "^1.0.0-2",
     "proxyquire": "^2.0.0",
     "sinon": "^14.0.0",
-    "tcp-port-used": "^1.0.2",
     "snap-shot-it": "^7.9.1",
+    "tcp-port-used": "^1.0.2",
     "ts-loader": "^9.0.0",
     "typescript": "^4.6.4",
     "uuid": "^9.0.0",

--- a/protos/v2_test_proxy.proto
+++ b/protos/v2_test_proxy.proto
@@ -1,0 +1,189 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+syntax = "proto3";
+package bigtable.client.test;
+import "google/bigtable/v2/bigtable.proto";
+import "google/bigtable/v2/data.proto";
+import "google/protobuf/duration.proto";
+import "google/rpc/status.proto";
+option java_multiple_files = true;
+option java_package = "com.google.cloud.bigtable.testproxy";
+option go_package = "./testproxypb";
+// The `status` field of response messages always represents an error returned
+// by the client binding, e.g. never a problem in either the proxy logic or
+// test driver to proxy communication. After receiving a response from the
+// proxy, the test driver should always check its `status` field.
+//
+// [test driver] <--> [test proxy <--> client binding] <--> [Cloud Bigtable]
+//                                ^^^^
+//                                `status` represents success or errors
+//                                returned from the client binding.
+//
+// Status propagation design examples, assuming the C++ client:
+//
+//   // For CloudBigtableV2TestProxy.ReadRow
+//   StatusOr<std::pair<bool, Row>> result = table.ReadRow(row_key, filter);
+//
+// Set RowResult.status to OK iff result.status() is OK.
+// OK is required even if the bool is false, indicating the row wasn't found.
+//
+//   // For CloudBigtableV2TestProxy.BulkMutateRows
+//   std::vector<FailedMutation> failed = table.BulkApply(bulk_mutation);
+//
+// The semantics are less obvious for BulkApply(), because some mutations
+// failing doesn't indicate the overall RPC fails. In such case, test proxy
+// should disambiguate between RPC failure and individual entry failure, and
+// set MutateRowsResult.status according to the overall RPC status.
+//
+// The final decision regarding semantics must be documented for the
+// CloudBigtableV2TestProxy service in this file.
+message CreateClientRequest {
+  string client_id = 1;
+  // The "host:port" address of the data API endpoint (i.e. the backend being
+  // proxied to). Example: 127.0.0.1:38543
+  string data_target = 2;
+  // The project for all calls on this client.
+  string project_id = 3;
+  // The instance for all calls on this client.
+  string instance_id = 4;
+  // Optional app profile for all calls on this client.
+  // Some client bindings allow specifying the app profile on a per-operation
+  // basis. We don't yet support this in the proxy API, but may in the future.
+  string app_profile_id = 5;
+  // If provided, a custom timeout will be set for each API call conducted by
+  // the created client. Otherwise, the default timeout from the client library
+  // will be used. Note that the override applies to all the methods.
+  google.protobuf.Duration per_operation_timeout = 6;
+}
+message CreateClientResponse {}
+message CloseClientRequest {
+  string client_id = 1;
+}
+message CloseClientResponse {}
+message RemoveClientRequest {
+  string client_id = 1;
+}
+message RemoveClientResponse {}
+message ReadRowRequest {
+  string client_id = 1;
+  // The unique name of the table from which to read the row.
+  // Values are of the form
+  // `projects/<project>/instances/<instance>/tables/<table>`.
+  string table_name = 4;
+  string row_key = 2;
+  google.bigtable.v2.RowFilter filter = 3;
+}
+message RowResult {
+  google.rpc.Status status = 1;
+  google.bigtable.v2.Row row = 2;
+}
+message ReadRowsRequest {
+  string client_id = 1;
+  google.bigtable.v2.ReadRowsRequest request = 2;
+  // The streaming read can be canceled before all items are seen.
+  // Has no effect if non-positive.
+  int32 cancel_after_rows = 3;
+}
+message RowsResult {
+  google.rpc.Status status = 1;
+  repeated google.bigtable.v2.Row row = 2;
+}
+message MutateRowRequest {
+  string client_id = 1;
+  google.bigtable.v2.MutateRowRequest request = 2;
+}
+message MutateRowResult {
+  google.rpc.Status status = 1;
+}
+message MutateRowsRequest {
+  string client_id = 1;
+  google.bigtable.v2.MutateRowsRequest request = 2;
+}
+message MutateRowsResult {
+  // Overall RPC status
+  google.rpc.Status status = 1;
+  // To record individual entry failures
+  repeated google.bigtable.v2.MutateRowsResponse.Entry entry = 2;
+}
+message CheckAndMutateRowRequest {
+  string client_id = 1;
+  google.bigtable.v2.CheckAndMutateRowRequest request = 2;
+}
+message CheckAndMutateRowResult {
+  google.rpc.Status status = 1;
+  google.bigtable.v2.CheckAndMutateRowResponse result = 2;
+}
+message SampleRowKeysRequest {
+  string client_id = 1;
+  google.bigtable.v2.SampleRowKeysRequest request = 2;
+}
+message SampleRowKeysResult {
+  google.rpc.Status status = 1;
+  repeated google.bigtable.v2.SampleRowKeysResponse sample = 2;
+}
+message ReadModifyWriteRowRequest {
+  string client_id = 1;
+  google.bigtable.v2.ReadModifyWriteRowRequest request = 2;
+}
+// Note that all RPCs are unary, even when the equivalent client binding call
+// may be streaming. This is an intentional simplification.
+//
+// Most methods have sync (default) and async variants. For async variants,
+// the proxy is expected to perform the async operation, then wait for results
+// before delivering them back to the driver client.
+//
+// Operations that may have interesting concurrency characteristics are
+// represented explicitly in the API (see ReadRowsRequest.cancel_after_rows).
+// We include such operations only when they can be meaningfully performed
+// through client bindings.
+//
+// Users should generally avoid setting deadlines for requests to the Proxy
+// because operations are not cancelable. If the deadline is set anyway, please
+// understand that the underlying operation will continue to be executed even
+// after the deadline expires.
+service CloudBigtableV2TestProxy {
+  // Client management:
+  //
+  // Creates a client in the proxy.
+  // Each client has its own dedicated channel(s), and can be used concurrently
+  // and independently with other clients.
+  rpc CreateClient(CreateClientRequest) returns (CreateClientResponse);
+  // Closes a client in the proxy, making it not accept new requests.
+  rpc CloseClient(CloseClientRequest) returns (CloseClientResponse);
+  // Removes a client in the proxy, making it inaccessible. Client closing
+  // should be done by CloseClient() separately.
+  rpc RemoveClient(RemoveClientRequest) returns (RemoveClientResponse);
+  // Bigtable operations: for each operation, you should use the synchronous or
+  // asynchronous variant of the client method based on the `use_async_method`
+  // setting of the client instance. For starters, you can choose to implement
+  // one variant, and return UNIMPLEMENTED status for the other.
+  //
+  // Reads a row with the client instance.
+  // The result row may not be present in the response.
+  // Callers should check for it (e.g. calling has_row() in C++).
+  rpc ReadRow(ReadRowRequest) returns (RowResult);
+  // Reads rows with the client instance.
+  rpc ReadRows(ReadRowsRequest) returns (RowsResult);
+  // Writes a row with the client instance.
+  rpc MutateRow(MutateRowRequest) returns (MutateRowResult);
+  // Writes multiple rows with the client instance.
+  rpc BulkMutateRows(MutateRowsRequest) returns (MutateRowsResult);
+  // Performs a check-and-mutate-row operation with the client instance.
+  rpc CheckAndMutateRow(CheckAndMutateRowRequest)
+      returns (CheckAndMutateRowResult);
+  // Obtains a row key sampling with the client instance.
+  rpc SampleRowKeys(SampleRowKeysRequest) returns (SampleRowKeysResult);
+  // Performs a read-modify-write operation with the client.
+  rpc ReadModifyWriteRow(ReadModifyWriteRowRequest) returns (RowResult);
+}

--- a/testproxy/README.md
+++ b/testproxy/README.md
@@ -1,0 +1,36 @@
+# Test Proxy
+
+This is a **Test Proxy** implementation meant to be used in conjuction with the
+[Test Framework for Cloud Bigtable Client Libraries](https://github.com/googleapis/cloud-bigtable-clients-test).
+
+## Setup
+
+Dependencies are installed as part of the main project using **npm**:
+
+```console
+$ npm install
+```
+
+## Running
+
+In order to start the **Test Proxy** server, run:
+
+```console
+$ npm run testproxy
+```
+
+This will start the proxy server that will listen to port `9999` by default
+and enable [running tests from the main go mock test implementation](https://github.com/googleapis/cloud-bigtable-clients-test#test-execution)
+against the JavaScript library implementation.
+
+## Options
+
+### Using a different port
+
+By default the **Test Proxy** will listen to port `9999`, in order to change
+the value use the `PORT` environment variable, e.g:
+
+```console
+$ PORT=1337 npm run testproxy
+```
+

--- a/testproxy/index.js
+++ b/testproxy/index.js
@@ -1,0 +1,63 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+'use strict';
+
+const {dirname, resolve} = require('node:path');
+
+const grpc = require('@grpc/grpc-js');
+const protoLoader = require('@grpc/proto-loader');
+
+const services = require('./services/index.js');
+
+const GAX_PROTOS_DIR = resolve(
+  dirname(require.resolve('google-gax')),
+  '../protos'
+);
+const PROTOS_DIR = resolve(__dirname, '../protos');
+const PROTO_PATH = resolve(PROTOS_DIR, 'v2_test_proxy.proto');
+const port = parseInt(process.env.PORT, 10) || 9999;
+
+async function loadDescriptor() {
+  const packageDefinition = await protoLoader.load(PROTO_PATH, {
+    keepCase: false,
+    longs: String,
+    enums: String,
+    defaults: true,
+    oneofs: true,
+    includeDirs: [PROTOS_DIR, GAX_PROTOS_DIR],
+  });
+  return grpc.loadPackageDefinition(packageDefinition);
+}
+
+function startServer(service) {
+  const server = new grpc.Server();
+  server.addService(service, services.getServicesImplementation());
+
+  return server.bindAsync(
+    `0.0.0.0:${port}`,
+    grpc.ServerCredentials.createInsecure(),
+    () => {
+      console.log(`grpc server started on port: ${port}`);
+      server.start();
+    }
+  );
+}
+
+async function main() {
+  const descriptor = await loadDescriptor();
+  const {service} = descriptor.bigtable.client.test.CloudBigtableV2TestProxy;
+  await startServer(service);
+}
+
+main();

--- a/testproxy/services/bulk-mutate-rows.js
+++ b/testproxy/services/bulk-mutate-rows.js
@@ -1,0 +1,51 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+'use strict';
+
+const grpc = require('@grpc/grpc-js');
+const {BigtableClient} = require('../../build/src/index.js').v2;
+
+const normalizeCallback = require('./utils/normalize-callback.js');
+
+const bulkMutateRows = ({clientMap}) =>
+  normalizeCallback(async rawRequest => {
+    const {request} = rawRequest;
+    const {request: mutateRequest} = request;
+    const {appProfileId, entries, tableName} = mutateRequest;
+
+    const {clientId} = request;
+    const bigtable = clientMap.get(clientId);
+    const client = new BigtableClient(bigtable.options.BigtableClient);
+    const result = await new Promise((res, rej) => {
+      const response = {entries: []};
+      client
+        .mutateRows({
+          appProfileId,
+          entries,
+          tableName,
+        })
+        .on('data', data => {
+          response.entries = [...data.entries];
+        })
+        .on('error', rej)
+        .on('end', () => res(response));
+    });
+
+    return {
+      status: {code: grpc.status.OK, details: []},
+      entry: result.entries,
+    };
+  });
+
+module.exports = bulkMutateRows;

--- a/testproxy/services/check-and-mutate-row.js
+++ b/testproxy/services/check-and-mutate-row.js
@@ -1,0 +1,45 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+'use strict';
+
+const grpc = require('@grpc/grpc-js');
+const {BigtableClient} = require('../../build/src/index.js').v2;
+
+const normalizeCallback = require('./utils/normalize-callback.js');
+
+const checkAndMutateRow = ({clientMap}) =>
+  normalizeCallback(async rawRequest => {
+    const {request} = rawRequest;
+    const {request: checkAndMutateRequest} = request;
+    const {appProfileId, falseMutations, rowKey, tableName, trueMutations} =
+      checkAndMutateRequest;
+
+    const {clientId} = request;
+    const bigtable = clientMap.get(clientId);
+    const client = new BigtableClient(bigtable.options.BigtableClient);
+    const [result] = await client.checkAndMutateRow({
+      appProfileId,
+      falseMutations,
+      rowKey,
+      tableName,
+      trueMutations,
+    });
+
+    return {
+      status: {code: grpc.status.OK, details: []},
+      result,
+    };
+  });
+
+module.exports = checkAndMutateRow;

--- a/testproxy/services/close-client.js
+++ b/testproxy/services/close-client.js
@@ -1,0 +1,30 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+'use strict';
+
+const normalizeCallback = require('./utils/normalize-callback.js');
+
+const closeClient = ({clientMap}) =>
+  normalizeCallback(async rawRequest => {
+    const request = rawRequest.request;
+    const {clientId} = request;
+    const bigtable = clientMap.get(clientId);
+
+    if (bigtable) {
+      bigtable.close();
+      return {};
+    }
+  });
+
+module.exports = closeClient;

--- a/testproxy/services/create-client.js
+++ b/testproxy/services/create-client.js
@@ -1,0 +1,64 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+'use strict';
+
+const normalizeCallback = require('./utils/normalize-callback.js');
+
+const grpc = require('@grpc/grpc-js');
+const {Bigtable} = require('../../build/src/index.js');
+
+const createClient = ({clientMap}) =>
+  normalizeCallback(async rawRequest => {
+    // TODO: Handle refresh periods
+    const {request} = rawRequest;
+    const {
+      callCredential,
+      clientId,
+      projectId,
+      instanceId,
+      dataTarget: apiEndpoint,
+      appProfileId,
+    } = request;
+
+    if (!(clientId && projectId && instanceId && apiEndpoint)) {
+      throw Object.assign(
+        new Error(
+          'clientId, projectId, instanceId, and apiEndpoint must be provided.'
+        ),
+        {code: grpc.status.INVALID_ARGUMENT}
+      );
+    }
+
+    if (clientMap.has(clientId)) {
+      throw Object.assign(new Error(`Client ${clientId} already exists`), {
+        code: grpc.status.ALREADY_EXISTS,
+      });
+    }
+
+    // TODO: Implement support to SSL connection
+    let authClient;
+    if (callCredential && callCredential.jsonServiceAccount) {
+      authClient = JSON.parse(request.callCredential.jsonServiceAccount);
+    }
+    const bigtable = new Bigtable({
+      projectId,
+      apiEndpoint,
+      authClient,
+      appProfileId,
+      clientConfig: require('../../src/v2/bigtable_client_config.json'),
+    });
+    clientMap.set(clientId, bigtable);
+  });
+
+module.exports = createClient;

--- a/testproxy/services/index.js
+++ b/testproxy/services/index.js
@@ -1,0 +1,53 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+'use strict';
+
+const bulkMutateRows = require('./bulk-mutate-rows.js');
+const checkAndMutateRow = require('./check-and-mutate-row.js');
+const ClientMap = require('./utils/client-map.js');
+const closeClient = require('./close-client.js');
+const createClient = require('./create-client.js');
+const mutateRow = require('./mutate-row.js');
+const readModifyWriteRow = require('./read-modify-write-row.js');
+const readRow = require('./read-row.js');
+const readRows = require('./read-rows.js');
+const removeClient = require('./remove-client.js');
+const sampleRowKeys = require('./sample-row-keys.js');
+
+/*
+ * Starts the client pool map and retrieves the object that
+ * lists all methods to be passed to grpc.Server.addService.
+ *
+ * ref: https://grpc.github.io/grpc/node/grpc.Server.html#addService__anchor
+ */
+function getServicesImplementation() {
+  const clientMap = new ClientMap();
+
+  return {
+    bulkMutateRows: bulkMutateRows({clientMap}),
+    checkAndMutateRow: checkAndMutateRow({clientMap}),
+    createClient: createClient({clientMap}),
+    closeClient: closeClient({clientMap}),
+    mutateRow: mutateRow({clientMap}),
+    readModifyWriteRow: readModifyWriteRow({clientMap}),
+    readRow: readRow({clientMap}),
+    readRows: readRows({clientMap}),
+    removeClient: removeClient({clientMap}),
+    sampleRowKeys: sampleRowKeys({clientMap}),
+  };
+}
+
+module.exports = {
+  getServicesImplementation,
+};

--- a/testproxy/services/mutate-row.js
+++ b/testproxy/services/mutate-row.js
@@ -1,0 +1,42 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+'use strict';
+
+const grpc = require('@grpc/grpc-js');
+const {BigtableClient} = require('../../build/src/index.js').v2;
+
+const normalizeCallback = require('./utils/normalize-callback.js');
+
+const mutateRow = ({clientMap}) =>
+  normalizeCallback(async rawRequest => {
+    const {request} = rawRequest;
+    const {request: mutateRequest} = request;
+    const {appProfileId, mutations, tableName, rowKey} = mutateRequest;
+
+    const {clientId} = request;
+    const bigtable = clientMap.get(clientId);
+    const client = new BigtableClient(bigtable.options.BigtableClient);
+    await client.mutateRow({
+      appProfileId,
+      mutations,
+      tableName,
+      rowKey,
+    });
+
+    return {
+      status: {code: grpc.status.OK, details: []},
+    };
+  });
+
+module.exports = mutateRow;

--- a/testproxy/services/read-modify-write-row.js
+++ b/testproxy/services/read-modify-write-row.js
@@ -1,0 +1,43 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+'use strict';
+
+const grpc = require('@grpc/grpc-js');
+const {BigtableClient} = require('../../build/src/index.js').v2;
+
+const normalizeCallback = require('./utils/normalize-callback.js');
+
+const readModifyWriteRow = ({clientMap}) =>
+  normalizeCallback(async rawRequest => {
+    const {request} = rawRequest;
+    const {request: sampleRowKeysRequest} = request;
+    const {appProfileId, rowKey, rules, tableName} = sampleRowKeysRequest;
+
+    const {clientId} = request;
+    const bigtable = clientMap.get(clientId);
+    const client = new BigtableClient(bigtable.options.BigtableClient);
+    const [result] = await client.readModifyWriteRow({
+      appProfileId,
+      rowKey,
+      rules,
+      tableName,
+    });
+
+    return {
+      status: {code: grpc.status.OK, details: []},
+      row: result.row,
+    };
+  });
+
+module.exports = readModifyWriteRow;

--- a/testproxy/services/read-row.js
+++ b/testproxy/services/read-row.js
@@ -1,0 +1,37 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+'use strict';
+
+const grpc = require('@grpc/grpc-js');
+
+const normalizeCallback = require('./utils/normalize-callback.js');
+const getRowResponse = require('./utils/get-row-response.js');
+const getTableInfo = require('./utils/get-table-info.js');
+
+const readRow = ({clientMap}) =>
+  normalizeCallback(async rawRequest => {
+    const {clientId, columns = {}, rowKey, tableName} = rawRequest.request;
+
+    const bigtable = clientMap.get(clientId);
+    const table = getTableInfo(bigtable, tableName);
+    const row = table.row(rowKey);
+    const res = await row.get(columns);
+
+    return {
+      status: {code: grpc.status.OK, details: []},
+      row: res.map(getRowResponse),
+    };
+  });
+
+module.exports = readRow;

--- a/testproxy/services/read-rows.js
+++ b/testproxy/services/read-rows.js
@@ -1,0 +1,76 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+'use strict';
+
+const grpc = require('@grpc/grpc-js');
+
+const normalizeCallback = require('./utils/normalize-callback.js');
+const getRowResponse = require('./utils/get-row-response.js');
+const getTableInfo = require('./utils/get-table-info.js');
+
+const getRowsOptions = readRowsRequest => {
+  const getRowsRequest = {};
+
+  if (readRowsRequest.rows) {
+    const {rowRanges} = readRowsRequest.rows;
+    if (rowRanges) {
+      getRowsRequest.ranges = rowRanges.map(
+        ({startKeyClosed, endKeyClosed}) => ({
+          start: {inclusive: true, value: String(startKeyClosed)},
+          end: {inclusive: true, value: String(endKeyClosed)},
+        })
+      );
+    }
+
+    const {rowKeys} = readRowsRequest.rows;
+    if (rowKeys) {
+      getRowsRequest.keys = rowKeys.map(String);
+    }
+  }
+
+  const {rowsLimit} = readRowsRequest;
+  if (rowsLimit && rowsLimit !== '0') {
+    getRowsRequest.limit = parseInt(rowsLimit, 10);
+  }
+  return getRowsRequest;
+};
+
+const getReadRowsRequest = request => {
+  const readRowsRequest = request ? request.request : undefined;
+  if (!readRowsRequest || !readRowsRequest.tableName) {
+    throw Object.assign(new Error('table_name must be provided in request.'), {
+      code: grpc.status.INVALID_ARGUMENT,
+    });
+  }
+  return readRowsRequest;
+};
+
+const readRows = ({clientMap}) =>
+  normalizeCallback(async rawRequest => {
+    const request = rawRequest.request;
+    const {clientId} = request;
+    const readRowsRequest = getReadRowsRequest(request);
+    const {tableName} = readRowsRequest;
+    const bigtable = clientMap.get(clientId);
+    const table = getTableInfo(bigtable, tableName);
+    const rowsOptions = getRowsOptions(readRowsRequest);
+    const [rows] = await table.getRows(rowsOptions);
+
+    return {
+      status: {code: grpc.status.OK, details: []},
+      row: rows.map(getRowResponse),
+    };
+  });
+
+module.exports = readRows;

--- a/testproxy/services/remove-client.js
+++ b/testproxy/services/remove-client.js
@@ -1,0 +1,31 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+'use strict';
+
+const normalizeCallback = require('./utils/normalize-callback.js');
+
+const removeClient = ({clientMap}) =>
+  normalizeCallback(async rawRequest => {
+    const request = rawRequest.request;
+    const {clientId} = request;
+    const bigtable = clientMap.get(clientId);
+
+    if (bigtable) {
+      bigtable.close();
+      clientMap.delete(clientId);
+      return {};
+    }
+  });
+
+module.exports = removeClient;

--- a/testproxy/services/sample-row-keys.js
+++ b/testproxy/services/sample-row-keys.js
@@ -1,0 +1,50 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+'use strict';
+
+const grpc = require('@grpc/grpc-js');
+const {BigtableClient} = require('../../build/src/index.js').v2;
+
+const normalizeCallback = require('./utils/normalize-callback.js');
+
+const sampleRowKeys = ({clientMap}) =>
+  normalizeCallback(async rawRequest => {
+    const {request} = rawRequest;
+    const {request: sampleRowKeysRequest} = request;
+    const {appProfileId, tableName} = sampleRowKeysRequest;
+
+    const {clientId} = request;
+    const bigtable = clientMap.get(clientId);
+    const client = new BigtableClient(bigtable.options.BigtableClient);
+    const sample = await new Promise((res, rej) => {
+      const response = [];
+      client
+        .sampleRowKeys({
+          appProfileId,
+          tableName,
+        })
+        .on('data', data => {
+          response.push(data);
+        })
+        .on('error', rej)
+        .on('end', () => res(response));
+    });
+
+    return {
+      status: {code: grpc.status.OK, details: []},
+      sample,
+    };
+  });
+
+module.exports = sampleRowKeys;

--- a/testproxy/services/utils/client-map.js
+++ b/testproxy/services/utils/client-map.js
@@ -1,0 +1,43 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+'use strict';
+
+const grpc = require('@grpc/grpc-js');
+
+class ClientMap extends Map {
+  // TODO: we might need to implement a way to lock
+  // currently used client instances here
+  get(key) {
+    if (!key) {
+      const err = {
+        code: grpc.status.INVALID_ARGUMENT,
+        details: 'Client id is not defined.',
+      };
+      throw Object.assign(new Error(err.details), err);
+    }
+
+    const res = super.get(key);
+    if (!res) {
+      const err = {
+        code: grpc.status.NOT_FOUND,
+        details: `Client ${key} not found.`,
+      };
+      throw Object.assign(new Error(err.details), err);
+    }
+
+    return res;
+  }
+}
+
+module.exports = ClientMap;

--- a/testproxy/services/utils/get-row-response.js
+++ b/testproxy/services/utils/get-row-response.js
@@ -1,0 +1,31 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+'use strict';
+
+const getRowResponse = ({id, data}) => ({
+  key: Buffer.from(id),
+  families: Object.entries(data).map(([familyKey, familyValue]) => ({
+    name: familyKey,
+    columns: Object.entries(familyValue).map(([columnKey, columnValue]) => ({
+      qualifier: Buffer.from(columnKey),
+      cells: columnValue.map(({labels, timestamp, value}) => ({
+        timestamp_micros: timestamp,
+        value: Buffer.from(value),
+        labels,
+      })),
+    })),
+  })),
+});
+
+module.exports = getRowResponse;

--- a/testproxy/services/utils/get-table-info.js
+++ b/testproxy/services/utils/get-table-info.js
@@ -1,0 +1,22 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+'use strict';
+
+const getTableInfo = (bigtable, tableName) => {
+  const [, , , instanceId, , tableId] = tableName.split('/');
+  const instance = bigtable.instance(instanceId);
+  return instance.table(tableId);
+};
+
+module.exports = getTableInfo;

--- a/testproxy/services/utils/normalize-callback.js
+++ b/testproxy/services/utils/normalize-callback.js
@@ -1,0 +1,42 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+'use strict';
+
+const grpc = require('@grpc/grpc-js');
+
+const {callbackify} = require('node:util');
+
+const normalizeCallback = fn =>
+  callbackify(async (...args) => {
+    let res;
+    try {
+      res = await fn(...args);
+    } catch (e) {
+      // sends original errors directly to standard error since
+      // callbackify is going to swallow them later
+      console.error(e);
+
+      throw Object.assign(
+        new Error(e.message),
+        {
+          code: grpc.status.UNKNOWN,
+          details: [e.message],
+        },
+        e
+      );
+    }
+    return res;
+  });
+
+module.exports = normalizeCallback;


### PR DESCRIPTION
Added a server proxy that is going to be used by the **Test Framework for Cloud Bigtable Client Libraries**.

<details>
<summary>Status of Tests</summary>

This summary currently includes status for methods: `ReadRow`, `ReadRows`, `MutateRow`, `MutateRows`
and variations: `NoRetry`, `Generic`

### Passing

```patch
+ TestReadRows_NoRetry_ErrorAfterLastRow
+ TestReadRows_NoRetry_MultipleIndividualRowKeys
+ TestReadRows_NoRetry_EmptyTableNoRows
+ TestReadRows_NoRetry_MultipleRowRanges
+ TestReadRows_NoRetry_ClosedStartUnspecifiedEnd
+ TestReadRows_NoRetry_OpenEndUnspecifiedStart
+ TestReadRows_Generic_Headers
+ TestReadRows_Generic_MultiStreams
+ TestCheckAndMutateRow_NoRetry_TrueMutations
+ TestCheckAndMutateRow_NoRetry_FalseMutations
+ TestMutateRow_NoRetry_NonprintableByteKey
+ TestMutateRow_NoRetry_MultipleMutations
+ TestCheckAndMutateRow_Generic_MultiStreams
+ TestMutateRow_Generic_MultiStreams
+ TestMutateRows_Generic_Headers
+ TestMutateRows_Generic_MultiStreams
```

### Failing

```patch
- TestReadRow_NoRetry_PointReadDeadline
- TestReadRow_NoRetry_CommitInSeparateChunk
- TestReadRow_Generic_MultiStreams
- TestReadRow_Generic_CloseClient
- TestReadRows_NoRetry_OutOfOrderError
- TestReadRows_Retry_PausedScan
- TestReadRows_Retry_LastScannedRow
- TestReadRows_Retry_StreamReset
- TestCheckAndMutateRow_NoRetry_TransientError
- TestMutateRows_NoRetry_NonTransientErrors
- TestMutateRows_NoRetry_DeadlineExceeded
```

</details>

Refs: https://github.com/googleapis/cloud-bigtable-clients-test