### PR TITLE
chore(testproxy): read row should return a single row

### DIFF
--- a/testproxy/services/read-row.js
+++ b/testproxy/services/read-row.js
@@ -27,10 +27,11 @@ const readRow = ({clientMap}) =>
     const table = getTableInfo(bigtable, tableName);
     const row = table.row(rowKey);
     const res = await row.get(columns);
+    const firstRow = getRowResponse(res[0]);
 
     return {
       status: {code: grpc.status.OK, details: []},
-      row: res.map(getRowResponse),
+      row: firstRow,
     };
   });
 

--- a/testproxy/services/utils/get-row-response.js
+++ b/testproxy/services/utils/get-row-response.js
@@ -20,7 +20,7 @@ const getRowResponse = ({id, data}) => ({
     columns: Object.entries(familyValue).map(([columnKey, columnValue]) => ({
       qualifier: Buffer.from(columnKey),
       cells: columnValue.map(({labels, timestamp, value}) => ({
-        timestamp_micros: timestamp,
+        timestampMicros: timestamp,
         value: Buffer.from(value),
         labels,
       })),


### PR DESCRIPTION
To get one of the specific test cases passing for readRow, we need a slight fix to the way returned data is parsed.
