### PR TITLE
chore(testproxy): fix close generated (v2) clients

### DIFF
--- a/testproxy/services/check-and-mutate-row.js
+++ b/testproxy/services/check-and-mutate-row.js
@@ -14,9 +14,10 @@
 'use strict';
 
 const grpc = require('@grpc/grpc-js');
-const {BigtableClient} = require('../../build/src/index.js').v2;
 
 const normalizeCallback = require('./utils/normalize-callback.js');
+
+const v2 = Symbol.for('v2');
 
 const checkAndMutateRow = ({clientMap}) =>
   normalizeCallback(async rawRequest => {
@@ -26,8 +27,7 @@ const checkAndMutateRow = ({clientMap}) =>
       checkAndMutateRequest;
 
     const {clientId} = request;
-    const bigtable = clientMap.get(clientId);
-    const client = new BigtableClient(bigtable.options.BigtableClient);
+    const client = clientMap.get(clientId)[v2];
     const [result] = await client.checkAndMutateRow({
       appProfileId,
       falseMutations,

--- a/testproxy/services/close-client.js
+++ b/testproxy/services/close-client.js
@@ -15,6 +15,8 @@
 
 const normalizeCallback = require('./utils/normalize-callback.js');
 
+const v2 = Symbol.for('v2');
+
 const closeClient = ({clientMap}) =>
   normalizeCallback(async rawRequest => {
     const request = rawRequest.request;
@@ -22,7 +24,8 @@ const closeClient = ({clientMap}) =>
     const bigtable = clientMap.get(clientId);
 
     if (bigtable) {
-      bigtable.close();
+      await bigtable[v2].close();
+      await bigtable.close();
       return {};
     }
   });

--- a/testproxy/services/create-client.js
+++ b/testproxy/services/create-client.js
@@ -17,6 +17,9 @@ const normalizeCallback = require('./utils/normalize-callback.js');
 
 const grpc = require('@grpc/grpc-js');
 const {Bigtable} = require('../../build/src/index.js');
+const {BigtableClient} = require('../../build/src/index.js').v2;
+
+const v2 = Symbol.for('v2');
 
 const createClient = ({clientMap}) =>
   normalizeCallback(async rawRequest => {
@@ -58,6 +61,7 @@ const createClient = ({clientMap}) =>
       appProfileId,
       clientConfig: require('../../src/v2/bigtable_client_config.json'),
     });
+    bigtable[v2] = new BigtableClient(bigtable.options.BigtableClient);
     clientMap.set(clientId, bigtable);
   });
 

--- a/testproxy/services/mutate-row.js
+++ b/testproxy/services/mutate-row.js
@@ -14,9 +14,10 @@
 'use strict';
 
 const grpc = require('@grpc/grpc-js');
-const {BigtableClient} = require('../../build/src/index.js').v2;
 
 const normalizeCallback = require('./utils/normalize-callback.js');
+
+const v2 = Symbol.for('v2');
 
 const mutateRow = ({clientMap}) =>
   normalizeCallback(async rawRequest => {
@@ -25,8 +26,7 @@ const mutateRow = ({clientMap}) =>
     const {appProfileId, mutations, tableName, rowKey} = mutateRequest;
 
     const {clientId} = request;
-    const bigtable = clientMap.get(clientId);
-    const client = new BigtableClient(bigtable.options.BigtableClient);
+    const client = clientMap.get(clientId)[v2];
     await client.mutateRow({
       appProfileId,
       mutations,

--- a/testproxy/services/read-modify-write-row.js
+++ b/testproxy/services/read-modify-write-row.js
@@ -14,9 +14,10 @@
 'use strict';
 
 const grpc = require('@grpc/grpc-js');
-const {BigtableClient} = require('../../build/src/index.js').v2;
 
 const normalizeCallback = require('./utils/normalize-callback.js');
+
+const v2 = Symbol.for('v2');
 
 const readModifyWriteRow = ({clientMap}) =>
   normalizeCallback(async rawRequest => {
@@ -25,8 +26,7 @@ const readModifyWriteRow = ({clientMap}) =>
     const {appProfileId, rowKey, rules, tableName} = sampleRowKeysRequest;
 
     const {clientId} = request;
-    const bigtable = clientMap.get(clientId);
-    const client = new BigtableClient(bigtable.options.BigtableClient);
+    const client = clientMap.get(clientId)[v2];
     const [result] = await client.readModifyWriteRow({
       appProfileId,
       rowKey,

--- a/testproxy/services/remove-client.js
+++ b/testproxy/services/remove-client.js
@@ -15,6 +15,8 @@
 
 const normalizeCallback = require('./utils/normalize-callback.js');
 
+const v2 = Symbol.for('v2');
+
 const removeClient = ({clientMap}) =>
   normalizeCallback(async rawRequest => {
     const request = rawRequest.request;
@@ -22,7 +24,8 @@ const removeClient = ({clientMap}) =>
     const bigtable = clientMap.get(clientId);
 
     if (bigtable) {
-      bigtable.close();
+      await bigtable[v2].close();
+      await bigtable.close();
       clientMap.delete(clientId);
       return {};
     }

--- a/testproxy/services/sample-row-keys.js
+++ b/testproxy/services/sample-row-keys.js
@@ -14,9 +14,10 @@
 'use strict';
 
 const grpc = require('@grpc/grpc-js');
-const {BigtableClient} = require('../../build/src/index.js').v2;
 
 const normalizeCallback = require('./utils/normalize-callback.js');
+
+const v2 = Symbol.for('v2');
 
 const sampleRowKeys = ({clientMap}) =>
   normalizeCallback(async rawRequest => {
@@ -25,8 +26,7 @@ const sampleRowKeys = ({clientMap}) =>
     const {appProfileId, tableName} = sampleRowKeysRequest;
 
     const {clientId} = request;
-    const bigtable = clientMap.get(clientId);
-    const client = new BigtableClient(bigtable.options.BigtableClient);
+    const client = clientMap.get(clientId)[v2];
     const sample = await new Promise((res, rej) => {
       const response = [];
       client


### PR DESCRIPTION
Tests for closing the client are failing since a new client object is created on every operation that uses the generated (v2) layer. This changeset fixes it by moving the v2 client creation to `testproxy/services/create-client.js` alongside the veneer client creation and properly closing that v2 instance on `testproxy/services/close-client.js`.

Every command using the v2 layer is updated to read the client from the client map instead of creating a new instance.

Three previosly failing tests are now passing with this fix:
- TestCheckAndMutateRow_Generic_CloseClient
- TestMutateRow_Generic_CloseClient
- TestReadModifyWriteRow_Generic_CloseClient
