### PR TITLE
fix: Always set the retry attempt to 0 for now

### DIFF
--- a/src/table.ts
+++ b/src/table.ts
@@ -776,7 +776,7 @@ Please use the format 'prezzy' or '${instance.name}/tables/prezzy'.`);
       } as google.bigtable.v2.IReadRowsRequest;
 
       const retryOpts = {
-        currentRetryAttempt: numConsecutiveErrors,
+        currentRetryAttempt: 0, // was numConsecutiveErrors
         // Handling retries in this client. Specify the retry options to
         // make sure nothing is retried in retry-request.
         noResponseRetries: 0,


### PR DESCRIPTION
If the retry attempt is greater than 1 then a library called retryRequest creates a large delay. If we force the retry count to be 0 then we skip this delay and the requests run in the required timeline.
