### PR TITLE
feat: Add npm run compile to the testproxy command

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "pretest": "npm run compile",
     "test": "c8 mocha build/test",
     "test:snap": "SNAPSHOT_UPDATE=1 npm test",
-    "testproxy": "node testproxy/index.js",
+    "testproxy": "npm run compile && node testproxy/index.js",
     "clean": "gts clean",
     "precompile": "gts clean"
   },


### PR DESCRIPTION
The test proxy references the compiled client library code. Every time the test proxy is run, we want it to reflect the source code so that as we develop we don’t get confused about what gets observed.

Fixes #1253 🦕
