### PR TITLE
fix: Increases the maximum retries to 10

### DIFF
--- a/src/table.ts
+++ b/src/table.ts
@@ -720,7 +720,7 @@ Please use the format 'prezzy' or '${instance.name}/tables/prezzy'.`);
    */
   createReadStream(opts?: GetRowsOptions) {
     const options = opts || {};
-    const maxRetries = is.number(this.maxRetries) ? this.maxRetries! : 3;
+    const maxRetries = is.number(this.maxRetries) ? this.maxRetries! : 10;
     let activeRequestStream: AbortableDuplex | null;
     let rowKeys: string[];
     let filter: {} | null;


### PR DESCRIPTION
The client should still have the opportunity to retry after only a few retriable errors.
