### PR TITLE
fix: Require stream destruction to be done with error

### DIFF
--- a/src/chunktransformer.ts
+++ b/src/chunktransformer.ts
@@ -169,11 +169,11 @@ export class ChunkTransformer extends Transform {
    */
   destroy(err?: Error): this {
     if (this._destroyed) return this;
-    this._destroyed = true;
     if (err) {
+      this._destroyed = true;
       this.emit('error', err);
+      this.emit('close');
     }
-    this.emit('close');
     return this;
   }
 

--- a/src/chunktransformer.ts
+++ b/src/chunktransformer.ts
@@ -167,6 +167,8 @@ export class ChunkTransformer extends Transform {
    * @public
    * @param {error} err error if any
    */
+  // When this function is called in nodejs-bigtable, ensure an error is passed
+  // in to destroy the stream properly.
   destroy(err?: Error): this {
     if (this._destroyed) return this;
     if (err) {

--- a/test/chunktransformer.ts
+++ b/test/chunktransformer.ts
@@ -1208,10 +1208,14 @@ describe('Bigtable/ChunkTransformer', () => {
     });
     it('should not emit if transform is already destroyed', done => {
       chunkTransformer.on('close', () => {
-        done();
+        assert.fail(
+          'The chunk transformer should not close if no error is provided'
+        );
       });
       chunkTransformer.destroy();
       chunkTransformer.destroy();
+      assert.strictEqual(chunkTransformer._destroyed, false);
+      done();
     });
   });
 });


### PR DESCRIPTION
This fix will ensure that users receive all the data they request even if the chunk transformer stream is unintentionally destroyed.