### PR TITLE
fix: Parsing for qualifiers with colon characters

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,5 @@
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,4 @@
 on:
-  workflow_dispatch:
   push:
     branches:
       - main

--- a/src/mutation.ts
+++ b/src/mutation.ts
@@ -386,7 +386,7 @@ export class Mutation {
       // columnName does not contain ':'
       return {
         family: columnName,
-        qualifier: undefined,
+        qualifier: null,
       };
     }
       

--- a/src/mutation.ts
+++ b/src/mutation.ts
@@ -381,15 +381,15 @@ export class Mutation {
    */
   static parseColumnName(columnName: string): ParsedColumn {
     const colonIdx = columnName.indexOf(':');
-      
-    if (colonIdx == -1) {
+
+    if (colonIdx === -1) {
       // columnName does not contain ':'
       return {
         family: columnName,
         qualifier: null,
       };
     }
-      
+ 
     return {
       family: columnName.slice(0, colonIdx),
       qualifier: columnName.slice(colonIdx + 1),

--- a/src/mutation.ts
+++ b/src/mutation.ts
@@ -32,7 +32,7 @@ export type Value = string | number | boolean;
 
 export interface ParsedColumn {
   family: string | null;
-  qualifier: string | null;
+  qualifier: string | null | undefined;
 }
 export interface ConvertFromBytesOptions {
   userOptions?: ConvertFromBytesUserOptions;
@@ -386,7 +386,7 @@ export class Mutation {
       // columnName does not contain ':'
       return {
         family: columnName,
-        qualifier: null,
+        qualifier: undefined,
       };
     }
 

--- a/src/mutation.ts
+++ b/src/mutation.ts
@@ -380,11 +380,11 @@ export class Mutation {
    * @private
    */
   static parseColumnName(columnName: string): ParsedColumn {
-    const parts = columnName.split(':');
+    const colonIdx = columnName.indexOf(':');
 
     return {
-      family: parts[0],
-      qualifier: parts[1],
+      family: columnName.slice(0, colonIdx),
+      qualifier: columnName.slice(colonIdx + 1),
     };
   }
 

--- a/src/mutation.ts
+++ b/src/mutation.ts
@@ -381,7 +381,15 @@ export class Mutation {
    */
   static parseColumnName(columnName: string): ParsedColumn {
     const colonIdx = columnName.indexOf(':');
-
+      
+    if (colonIdx == -1) {
+      // columnName does not contain ':'
+      return {
+        family: columnName,
+        qualifier: undefined,
+      };
+    }
+      
     return {
       family: columnName.slice(0, colonIdx),
       qualifier: columnName.slice(colonIdx + 1),

--- a/src/mutation.ts
+++ b/src/mutation.ts
@@ -389,7 +389,7 @@ export class Mutation {
         qualifier: null,
       };
     }
- 
+
     return {
       family: columnName.slice(0, colonIdx),
       qualifier: columnName.slice(colonIdx + 1),

--- a/test/mutation.ts
+++ b/test/mutation.ts
@@ -458,7 +458,7 @@ describe('Bigtable/Mutation', () => {
       const parsed = Mutation.parseColumnName('a');
 
       assert.strictEqual(parsed.family, 'a');
-      assert.strictEqual(parsed.qualifier, undefined);
+      assert.strictEqual(parsed.qualifier, null);
     });
   });
 

--- a/test/mutation.ts
+++ b/test/mutation.ts
@@ -458,7 +458,7 @@ describe('Bigtable/Mutation', () => {
       const parsed = Mutation.parseColumnName('a');
 
       assert.strictEqual(parsed.family, 'a');
-      assert.strictEqual(parsed.qualifier, null);
+      assert.strictEqual(parsed.qualifier, undefined);
     });
   });
 

--- a/test/mutation.ts
+++ b/test/mutation.ts
@@ -460,6 +460,13 @@ describe('Bigtable/Mutation', () => {
       assert.strictEqual(parsed.family, 'a');
       assert.strictEqual(parsed.qualifier, undefined);
     });
+
+    it('should parse a qualifier name with colons', () => {
+      const parsed = Mutation.parseColumnName('a:b:c');
+
+      assert.strictEqual(parsed.family, 'a');
+      assert.strictEqual(parsed.qualifier, 'b:c');
+    });
   });
 
   describe('toProto', () => {


### PR DESCRIPTION

`parseColumnName()` uses `.split(':')` to find the qualifier, but this parses qualifiers with `:` chars in it incorrectly, since they also are picked up by the split. This causes it to ignore everything after `:` in the qualifier.

e.g. consider a column name `"foo:bar:baz"`
`parseColumnName()` parses this incorrectly as 
```
{
  family: 'foo', 
  qualifier: 'bar'
}
```

Using `slice()` instead with the index of the first `:` character fixes this:
```
{
  family: 'foo', 
  qualifier: 'bar:baz'
}
```
