### PR TITLE
test: test ReadRows logic with local gRPC server

### DIFF
--- a/test/readrows.ts
+++ b/test/readrows.ts
@@ -23,7 +23,7 @@ import {BigtableClientMockService} from '../src/util/mock-servers/service-implem
 import {MockService} from '../src/util/mock-servers/mock-service';
 import {debugLog, readRowsImpl} from './utils/readRowsImpl';
 
-describe('Bigtable/Streams', () => {
+describe('Bigtable/ReadRows', () => {
   let server: MockServer;
   let service: MockService;
   let bigtable: Bigtable;

--- a/test/readrows.ts
+++ b/test/readrows.ts
@@ -123,7 +123,11 @@ describe('Bigtable/Streams', () => {
   });
 
   // TODO(@alexander-fenster): enable after https://github.com/googleapis/nodejs-bigtable/issues/607 is fixed
-  it.skip('should create read stream and read asynchronously using Transform stream', done => {
+  it.skip('should create read stream and read asynchronously using Transform stream', function (done) {
+    if (process.platform === 'win32') {
+      this.timeout(60000); // it runs much slower on Windows!
+    }
+
     // 1000 rows must be enough to reproduce issues with losing the data and to create backpressure
     const keyFrom = 0;
     const keyTo = 1000;
@@ -219,7 +223,11 @@ describe('Bigtable/Streams', () => {
   });
 
   // TODO(@alexander-fenster): enable after it's fixed
-  it.skip('should be able to stop reading from the read stream when reading asynchronously', done => {
+  it.skip('should be able to stop reading from the read stream when reading asynchronously', function (done) {
+    if (process.platform === 'win32') {
+      this.timeout(60000); // it runs much slower on Windows!
+    }
+
     // 1000 rows must be enough to reproduce issues with losing the data and to create backpressure
     const keyFrom = 0;
     const keyTo = 1000;
@@ -282,12 +290,7 @@ describe('Bigtable/Streams', () => {
     pipeline(readStream, transform, passThrough, () => {});
   });
 
-  // TODO(@alexander-fenster): enable after the resumption logic is fixed.
-  // Currently, lastRowKey is updated in _transform (chunktransfomer.ts:155)
-  // https://github.com/googleapis/nodejs-bigtable/blob/436e77807e87e13f80ac2bc2c43813b09090000f/src/chunktransformer.ts#L155
-  // before the record is committed, which makes it omit this record when
-  // the call is resumed. I believe lastRowKey should only be set in commit().
-  it.skip('should silently resume after server or network error', done => {
+  it('should silently resume after server or network error', done => {
     // 1000 rows must be enough to reproduce issues with losing the data and to create backpressure
     const keyFrom = 0;
     const keyTo = 1000;

--- a/test/streams.ts
+++ b/test/streams.ts
@@ -29,13 +29,15 @@ describe('Bigtable/Streams', () => {
   let bigtable: Bigtable;
   let table: Table;
 
-  before(() => {
-    server = new MockServer(() => {
-      bigtable = new Bigtable({
-        apiEndpoint: `localhost:${server.port}`,
-      });
-      table = bigtable.instance('fake-instance').table('fake-table');
+  before(async () => {
+    // make sure we have everything initialized before starting tests
+    const port = await new Promise<string>(resolve => {
+      server = new MockServer(resolve);
     });
+    bigtable = new Bigtable({
+      apiEndpoint: `localhost:${port}`,
+    });
+    table = bigtable.instance('fake-instance').table('fake-table');
     service = new BigtableClientMockService(server);
   });
 

--- a/test/streams.ts
+++ b/test/streams.ts
@@ -1,0 +1,254 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {before, describe, it} from 'mocha';
+import {Bigtable, Row, Table} from '../src';
+import * as assert from 'assert';
+import {Transform, PassThrough, pipeline} from 'stream';
+
+import {GoogleError} from 'google-gax';
+import {MockServer} from '../src/util/mock-servers/mock-server';
+import {BigtableClientMockService} from '../src/util/mock-servers/service-implementations/bigtable-client-mock-service';
+import {MockService} from '../src/util/mock-servers/mock-service';
+import {debugLog, readRowsImpl} from './utils/readRowsImpl';
+
+describe('Bigtable/Streams', () => {
+  let server: MockServer;
+  let service: MockService;
+  let bigtable: Bigtable;
+  let table: Table;
+
+  before(() => {
+    server = new MockServer(() => {
+      bigtable = new Bigtable({
+        apiEndpoint: `localhost:${server.port}`,
+      });
+      table = bigtable.instance('fake-instance').table('fake-table');
+    });
+    service = new BigtableClientMockService(server);
+  });
+
+  it('should create read stream and read synchronously', done => {
+    const keyFrom = 0;
+    const keyTo = 1000;
+
+    service.setService({
+      ReadRows: readRowsImpl(keyFrom, keyTo),
+    });
+
+    let receivedRowCount = 0;
+    let lastKeyReceived: number | undefined;
+
+    const readStream = table.createReadStream();
+    readStream.on('error', (err: GoogleError) => {
+      done(err);
+    });
+    readStream.on('data', (row: Row) => {
+      ++receivedRowCount;
+      const key = parseInt(row.id);
+      if (lastKeyReceived && key <= lastKeyReceived) {
+        done(new Error('Test error: keys are not in order'));
+      }
+      lastKeyReceived = key;
+      debugLog(`received row key ${key}`);
+    });
+    readStream.on('end', () => {
+      assert.strictEqual(receivedRowCount, keyTo - keyFrom);
+      assert.strictEqual(lastKeyReceived, keyTo - 1);
+      done();
+    });
+  });
+
+  it('should create read stream and read synchronously using Transform stream', done => {
+    const keyFrom = 0;
+    const keyTo = 1000;
+
+    service.setService({
+      ReadRows: readRowsImpl(keyFrom, keyTo),
+    });
+
+    let receivedRowCount = 0;
+    let lastKeyReceived: number | undefined;
+
+    // BigTable stream
+    const readStream = table.createReadStream();
+
+    // Transform stream
+    const transform = new Transform({
+      objectMode: true,
+      transform: (row, _encoding, callback) => {
+        callback(null, row);
+      },
+    });
+
+    // Final stream
+    const passThrough = new PassThrough({
+      objectMode: true,
+    });
+
+    passThrough.on('error', (err: GoogleError) => {
+      done(err);
+    });
+    passThrough.on('data', (row: Row) => {
+      ++receivedRowCount;
+      const key = parseInt(row.id);
+      if (lastKeyReceived && key <= lastKeyReceived) {
+        done(new Error('Test error: keys are not in order'));
+      }
+      lastKeyReceived = key;
+      debugLog(`received row key ${key}`);
+    });
+    passThrough.on('end', () => {
+      assert.strictEqual(receivedRowCount, keyTo - keyFrom);
+      assert.strictEqual(lastKeyReceived, keyTo - 1);
+      done();
+    });
+
+    pipeline(readStream, transform, passThrough, () => {});
+  });
+
+  // TODO(@alexander-fenster): enable after https://github.com/googleapis/nodejs-bigtable/issues/607 is fixed
+  it.skip('should create read stream and read asynchronously using Transform stream', done => {
+    const keyFrom = 0;
+    const keyTo = 1000;
+
+    service.setService({
+      ReadRows: readRowsImpl(keyFrom, keyTo),
+    });
+
+    let receivedRowCount = 0;
+    let lastKeyReceived: number | undefined;
+
+    // BigTable stream
+    const readStream = table.createReadStream();
+
+    // Transform stream
+    const transform = new Transform({
+      objectMode: true,
+      transform: (row, _encoding, callback) => {
+        setTimeout(() => {
+          callback(null, row);
+        }, 0);
+      },
+    });
+
+    // Final stream
+    const passThrough = new PassThrough({
+      objectMode: true,
+    });
+
+    passThrough.on('error', (err: GoogleError) => {
+      done(err);
+    });
+    passThrough.on('data', (row: Row) => {
+      ++receivedRowCount;
+      const key = parseInt(row.id);
+      if (lastKeyReceived && key <= lastKeyReceived) {
+        done(new Error('Test error: keys are not in order'));
+      }
+      lastKeyReceived = key;
+      debugLog(`received row key ${key}`);
+    });
+    passThrough.on('end', () => {
+      assert.strictEqual(receivedRowCount, keyTo - keyFrom);
+      assert.strictEqual(lastKeyReceived, keyTo - 1);
+      done();
+    });
+
+    pipeline(readStream, transform, passThrough, () => {});
+  });
+
+  it('should be able to stop reading from the read stream', done => {
+    const keyFrom = 0;
+    const keyTo = 1000;
+    const stopAfter = 42;
+
+    service.setService({
+      ReadRows: readRowsImpl(keyFrom, keyTo),
+    });
+
+    let receivedRowCount = 0;
+    let lastKeyReceived: number | undefined;
+
+    const readStream = table.createReadStream({
+      // workaround for https://github.com/grpc/grpc-node/issues/2446, remove when fixed
+      gaxOptions: {
+        timeout: 3000,
+      },
+    });
+    readStream.on('error', (err: GoogleError) => {
+      done(err);
+    });
+    readStream.on('data', (row: Row) => {
+      ++receivedRowCount;
+      const key = parseInt(row.id);
+      if (lastKeyReceived && key <= lastKeyReceived) {
+        done(new Error('Test error: keys are not in order'));
+      }
+      lastKeyReceived = key;
+      debugLog(`received row key ${key}`);
+
+      if (receivedRowCount === stopAfter) {
+        debugLog(`requesting to stop after receiving key ${key}`);
+        readStream.end();
+      }
+    });
+    readStream.on('end', () => {
+      assert.strictEqual(receivedRowCount, stopAfter);
+      assert.strictEqual(lastKeyReceived, stopAfter - 1);
+      done();
+    });
+  });
+
+  // TODO(@alexander-fenster): enable after the resumption logic is fixed.
+  // Currently, lastRowKey is updated in _transform (chunktransfomer.ts:155)
+  // https://github.com/googleapis/nodejs-bigtable/blob/436e77807e87e13f80ac2bc2c43813b09090000f/src/chunktransformer.ts#L155
+  // before the record is committed, which makes it omit this record when
+  // the call is resumed. I believe lastRowKey should only be set in commit().
+  it.skip('should silently resume after server or network error', done => {
+    const keyFrom = 0;
+    const keyTo = 1000;
+    const errorAfterChunkNo = 423;
+
+    service.setService({
+      ReadRows: readRowsImpl(keyFrom, keyTo, errorAfterChunkNo),
+    });
+
+    let receivedRowCount = 0;
+    let lastKeyReceived: number | undefined;
+
+    const readStream = table.createReadStream();
+    readStream.on('error', (err: GoogleError) => {
+      done(err);
+    });
+    readStream.on('data', (row: Row) => {
+      ++receivedRowCount;
+      const key = parseInt(row.id);
+      if (lastKeyReceived && key <= lastKeyReceived) {
+        done(new Error('Test error: keys are not in order'));
+      }
+      lastKeyReceived = key;
+      debugLog(`received row key ${key}`);
+    });
+    readStream.on('end', () => {
+      assert.strictEqual(receivedRowCount, keyTo - keyFrom);
+      assert.strictEqual(lastKeyReceived, keyTo - 1);
+      done();
+    });
+  });
+
+  after(async () => {
+    server.shutdown(() => {});
+  });
+});

--- a/test/streams.ts
+++ b/test/streams.ts
@@ -40,6 +40,7 @@ describe('Bigtable/Streams', () => {
   });
 
   it('should create read stream and read synchronously', done => {
+    // 1000 rows must be enough to reproduce issues with losing the data and to create backpressure
     const keyFrom = 0;
     const keyTo = 1000;
 
@@ -71,6 +72,7 @@ describe('Bigtable/Streams', () => {
   });
 
   it('should create read stream and read synchronously using Transform stream', done => {
+    // 1000 rows must be enough to reproduce issues with losing the data and to create backpressure
     const keyFrom = 0;
     const keyTo = 1000;
 
@@ -120,6 +122,7 @@ describe('Bigtable/Streams', () => {
 
   // TODO(@alexander-fenster): enable after https://github.com/googleapis/nodejs-bigtable/issues/607 is fixed
   it.skip('should create read stream and read asynchronously using Transform stream', done => {
+    // 1000 rows must be enough to reproduce issues with losing the data and to create backpressure
     const keyFrom = 0;
     const keyTo = 1000;
 
@@ -170,8 +173,10 @@ describe('Bigtable/Streams', () => {
   });
 
   it('should be able to stop reading from the read stream', done => {
+    // 1000 rows must be enough to reproduce issues with losing the data and to create backpressure
     const keyFrom = 0;
     const keyTo = 1000;
+    // pick any key to stop after
     const stopAfter = 42;
 
     service.setService({
@@ -217,8 +222,10 @@ describe('Bigtable/Streams', () => {
   // before the record is committed, which makes it omit this record when
   // the call is resumed. I believe lastRowKey should only be set in commit().
   it.skip('should silently resume after server or network error', done => {
+    // 1000 rows must be enough to reproduce issues with losing the data and to create backpressure
     const keyFrom = 0;
     const keyTo = 1000;
+    // the server will error after sending this chunk (not row)
     const errorAfterChunkNo = 423;
 
     service.setService({

--- a/test/utils/readRowsImpl.ts
+++ b/test/utils/readRowsImpl.ts
@@ -16,27 +16,67 @@ import {ServerWritableStream} from '@grpc/grpc-js';
 import {protos} from '../../src';
 import {GoogleError, Status} from 'google-gax';
 
-const valueSize = 1024 * 1024;
+const VALUE_SIZE = 1024 * 1024;
 // we want each row to be splitted into 2 chunks of different sizes
-const chunkSize = 1023 * 1024 - 1;
-const chunksPerResponse = 10;
+const CHUNK_SIZE = 1023 * 1024 - 1;
+const CHUNK_PER_RESPONSE = 10;
 
-const debug = process.env.BIGTABLE_TEST_DEBUG === 'true';
+const DEBUG = process.env.BIGTABLE_TEST_DEBUG === 'true';
 
 export function debugLog(text: string) {
-  if (debug) {
+  if (DEBUG) {
     console.log(text);
   }
 }
 
-function generateChunks(
-  keyFrom: number,
-  keyTo: number,
-  stream: ServerWritableStream<
-    protos.google.bigtable.v2.IReadRowsRequest,
-    protos.google.bigtable.v2.IReadRowsResponse
-  >
+function prettyPrintRequest(
+  request: protos.google.bigtable.v2.IReadRowsRequest
 ) {
+  // pretty-printing important parts of the request.
+  // doing it field by field because we want to apply .toString() to all key fields
+  debugLog('received request: {');
+  debugLog(`  tableName: "${request.tableName}",`);
+  if (request.rows) {
+    debugLog('  rows: {');
+    if (request.rows.rowKeys) {
+      debugLog('    rowKeys: [');
+      for (const key of request.rows.rowKeys) {
+        debugLog(`      "${key.toString()}",`);
+      }
+      debugLog('    ],');
+    }
+    if (request.rows.rowRanges) {
+      debugLog('    rowRanges: [');
+      for (const range of request.rows.rowRanges) {
+        debugLog('      {');
+        if (range.startKeyOpen) {
+          debugLog(`        startKeyOpen: "${range.startKeyOpen.toString()}",`);
+        }
+        if (range.startKeyClosed) {
+          debugLog(
+            `        startKeyClosed: "${range.startKeyClosed.toString()}",`
+          );
+        }
+        if (range.endKeyOpen) {
+          debugLog(`        endKeyOpen: "${range.endKeyOpen.toString()}",`);
+        }
+        if (range.endKeyClosed) {
+          debugLog(`        endKeyClosed: "${range.endKeyClosed.toString()}",`);
+        }
+        debugLog('      },');
+      }
+      debugLog('    ],');
+    }
+    debugLog('  },');
+  }
+  debugLog('}');
+}
+
+/** Generates chunks for rows in a fake table that match the provided RowSet.
+ * The fake table contains monotonically increasing zero padded rows
+ * in the range [keyFrom, keyTo).
+ */
+function generateChunks(keyFrom: number, keyTo: number) {
   debugLog(`generating chunks from ${keyFrom} to ${keyTo}`);
 
   const chunks: protos.google.bigtable.v2.ReadRowsResponse.ICellChunk[] = [];
@@ -44,50 +84,9 @@ function generateChunks(
     // the keys must be increasing, but we also want to keep them readable,
     // so we'll use keys 00000000, 00000001, 00000002, etc. stored as Buffers
     const binaryKey = Buffer.from(key.toString().padStart(8, '0'));
-
-    // primitive support for row ranges
-    if (stream.request.rows?.rowRanges || stream.request.rows?.rowKeys) {
-      let take = false;
-      const stringKey = binaryKey.toString();
-      for (const requestKey of stream.request.rows?.rowKeys ?? []) {
-        if (stringKey === requestKey.toString()) {
-          take;
-          break;
-        }
-      }
-      for (const range of stream.request.rows?.rowRanges ?? []) {
-        let startOk = true;
-        let endOk = true;
-        if (range.startKeyOpen && range.startKeyOpen.toString() >= stringKey) {
-          startOk = false;
-        }
-        if (
-          range.startKeyClosed &&
-          range.startKeyClosed.toString() > stringKey
-        ) {
-          startOk = false;
-        }
-        if (range.endKeyOpen && range.endKeyOpen.toString() <= stringKey) {
-          endOk = false;
-        }
-        if (range.endKeyClosed && range.endKeyClosed.toString() < stringKey) {
-          endOk = false;
-        }
-        if (startOk && endOk) {
-          take = true;
-        }
-      }
-      if (!take) {
-        debugLog(
-          `skipping key ${key} because it's out of requested range or keys`
-        );
-        continue;
-      }
-    }
-
     debugLog(`generating chunks for ${key}`);
     const rowKey = binaryKey.toString('base64');
-    let remainingBytes = valueSize;
+    let remainingBytes = VALUE_SIZE;
     let chunkCounter = 0;
     while (remainingBytes > 0) {
       debugLog(`  remaining bytes: ${remainingBytes}`);
@@ -101,8 +100,7 @@ function generateChunks(
           value: Buffer.from('qualifier').toString('base64'),
         };
       }
-      const thisChunkSize =
-        remainingBytes >= chunkSize ? chunkSize : remainingBytes;
+      const thisChunkSize = Math.min(CHUNK_SIZE, remainingBytes);
       remainingBytes -= thisChunkSize;
       const value = Buffer.from('a'.repeat(remainingBytes)).toString('base64');
       chunk.value = value;
@@ -118,62 +116,101 @@ function generateChunks(
   return chunks;
 }
 
+function isKeyInRowSet(
+  stringKey: string,
+  rowSet?: protos.google.bigtable.v2.IRowSet | null
+): boolean {
+  if (!rowSet) {
+    return true;
+  }
+  // primitive support for row ranges
+  if (rowSet.rowRanges || rowSet.rowKeys) {
+    for (const requestKey of rowSet.rowKeys ?? []) {
+      if (stringKey === requestKey.toString()) {
+        return true;
+      }
+    }
+    for (const range of rowSet.rowRanges ?? []) {
+      let startOk = true;
+      let endOk = true;
+      if (range.startKeyOpen && range.startKeyOpen.toString() >= stringKey) {
+        startOk = false;
+      }
+      if (range.startKeyClosed && range.startKeyClosed.toString() > stringKey) {
+        startOk = false;
+      }
+      if (range.endKeyOpen && range.endKeyOpen.toString() <= stringKey) {
+        endOk = false;
+      }
+      if (range.endKeyClosed && range.endKeyClosed.toString() < stringKey) {
+        endOk = false;
+      }
+      if (startOk && endOk) {
+        return true;
+      }
+    }
+    return false;
+  }
+  return true;
+}
+
+// Returns an implementation of the server streaming ReadRows call that would return
+// monotonically increasing zero padded rows in the range [keyFrom, keyTo).
+// The returned implementation can be passed to gRPC server.
 export function readRowsImpl(
   keyFrom: number,
   keyTo: number,
   errorAfterChunkNo?: number
-) {
+): (
+  stream: ServerWritableStream<
+    protos.google.bigtable.v2.IReadRowsRequest,
+    protos.google.bigtable.v2.IReadRowsResponse
+  >
+) => Promise<void> {
   return async (
     stream: ServerWritableStream<
       protos.google.bigtable.v2.IReadRowsRequest,
       protos.google.bigtable.v2.IReadRowsResponse
     >
-  ) => {
-    // pretty-printing important parts of the request.
-    // doing it field by field because we want to apply .toString() to all key fields
-    debugLog('received request: {');
-    debugLog(`  tableName: "${stream.request.tableName}",`);
-    if (stream.request.rows) {
-      debugLog('  rows: {');
-      if (stream.request.rows.rowKeys) {
-        debugLog('    rowKeys: [');
-        for (const key of stream.request.rows.rowKeys) {
-          debugLog(`      "${key.toString()}",`);
-        }
-        debugLog('    ],');
-      }
-      if (stream.request.rows.rowRanges) {
-        debugLog('    rowRanges: [');
-        for (const range of stream.request.rows.rowRanges) {
-          debugLog('      {');
-          if (range.startKeyOpen) {
-            debugLog(
-              `        startKeyOpen: "${range.startKeyOpen.toString()}",`
-            );
-          }
-          if (range.startKeyClosed) {
-            debugLog(
-              `        startKeyClosed: "${range.startKeyClosed.toString()}",`
-            );
-          }
-          if (range.endKeyOpen) {
-            debugLog(`        endKeyOpen: "${range.endKeyOpen.toString()}",`);
-          }
-          if (range.endKeyClosed) {
-            debugLog(
-              `        endKeyClosed: "${range.endKeyClosed.toString()}",`
-            );
-          }
-          debugLog('      },');
-        }
-        debugLog('    ],');
-      }
-      debugLog('  },');
-    }
-    debugLog('}');
+  ): Promise<void> => {
+    prettyPrintRequest(stream.request);
 
     let stopWaiting: () => void = () => {};
     let cancelled = false;
+    // an asynchronous function to write a response object to stream, reused several times below.
+    // captures `cancelled` variable
+    const sendResponse = async (
+      response: protos.google.bigtable.v2.IReadRowsResponse
+    ): Promise<void> => {
+      return new Promise<void>(resolve => {
+        setTimeout(async () => {
+          if (cancelled) {
+            resolve();
+            return;
+          }
+          const canSendMore = stream.write(response);
+          if (response.chunks && response.chunks.length > 0) {
+            debugLog(`sent ${response.chunks.length} chunks`);
+          }
+          if (response.lastScannedRowKey) {
+            const binaryKey = Buffer.from(
+              response.lastScannedRowKey as string,
+              'base64'
+            );
+            const stringKey = binaryKey.toString();
+            debugLog(`sent lastScannedRowKey = ${stringKey}`);
+          }
+          if (!canSendMore) {
+            debugLog('awaiting for back pressure');
+            await new Promise<void>(resolve => {
+              stopWaiting = resolve;
+              stream.once('drain', resolve);
+            });
+          }
+          resolve();
+        }, 0);
+      });
+    };
 
     stream.on('cancelled', () => {
       debugLog('gRPC server received cancel()');
@@ -183,68 +220,69 @@ export function readRowsImpl(
     });
 
     let chunksSent = 0;
-    const chunks = generateChunks(keyFrom, keyTo, stream);
+    const chunks = generateChunks(keyFrom, keyTo);
     let lastScannedRowKey: string | undefined;
     let currentResponseChunks: protos.google.bigtable.v2.ReadRowsResponse.ICellChunk[] =
       [];
     let chunkIdx = 0;
+    let skipThisRow = false;
     for (const chunk of chunks) {
       if (cancelled) {
         break;
       }
+
       if (chunk.rowKey) {
-        debugLog(
-          `starting row with key ${Buffer.from(
-            chunk.rowKey as string,
-            'base64'
-          ).toString()}`
-        );
+        const binaryKey = Buffer.from(chunk.rowKey as string, 'base64');
+        const stringKey = binaryKey.toString();
+
+        debugLog(`starting row with key ${stringKey}`);
+        if (isKeyInRowSet(stringKey, stream.request.rows)) {
+          skipThisRow = false;
+        } else {
+          debugLog(
+            `skipping row with key ${stringKey} because it's out of requested range or keys`
+          );
+          skipThisRow = true;
+          lastScannedRowKey = chunk.rowKey as string;
+        }
       }
+
       if (chunk.commitRow) {
-        lastScannedRowKey = chunk.rowKey as string;
         debugLog('commit row');
       }
-      currentResponseChunks.push(chunk);
-      ++chunkIdx;
+
+      if (!skipThisRow) {
+        currentResponseChunks.push(chunk);
+        ++chunkIdx;
+      }
       if (
-        currentResponseChunks.length === chunksPerResponse ||
-        chunkIdx === errorAfterChunkNo
+        currentResponseChunks.length === CHUNK_PER_RESPONSE ||
+        chunkIdx === errorAfterChunkNo ||
+        // if we skipped a row and set lastScannedRowKey, dump everything and send a separate message with lastScannedRowKey
+        lastScannedRowKey
       ) {
         const response: protos.google.bigtable.v2.IReadRowsResponse = {
           chunks: currentResponseChunks,
-          lastScannedRowKey,
         };
         chunksSent += currentResponseChunks.length;
-        await new Promise<void>(resolve => {
-          setTimeout(async () => {
-            if (cancelled) {
-              resolve();
-              return;
-            }
-            const canSendMore = stream.write(response);
-            debugLog(`sent ${currentResponseChunks.length} chunks`);
-            currentResponseChunks = [];
-            if (!canSendMore) {
-              debugLog(
-                `awaiting for back pressure after sending ${chunksSent} chunks`
-              );
-              await new Promise<void>(resolve => {
-                stopWaiting = resolve;
-                stream.once('drain', resolve);
-              });
-            }
-            resolve();
-          }, 0);
-        });
+        await sendResponse(response);
+        currentResponseChunks = [];
         if (chunkIdx === errorAfterChunkNo) {
           debugLog(`sending error after chunk #${chunkIdx}`);
           errorAfterChunkNo = undefined; // do not send error for the second time
           const error = new GoogleError('Uh oh');
           error.code = Status.ABORTED;
-          stream.emit('error', error);
+          stream.destroy(error);
           cancelled = true;
           break;
         }
+      }
+      if (lastScannedRowKey) {
+        const response: protos.google.bigtable.v2.IReadRowsResponse = {
+          lastScannedRowKey,
+        };
+        await sendResponse(response);
+        lastScannedRowKey = undefined;
       }
     }
     if (!cancelled && currentResponseChunks.length > 0) {
@@ -253,13 +291,7 @@ export function readRowsImpl(
         lastScannedRowKey,
       };
       chunksSent += currentResponseChunks.length;
-      await new Promise<void>(resolve => {
-        setTimeout(() => {
-          stream.write(response);
-          resolve();
-        }, 0);
-      });
-      debugLog(`sent ${currentResponseChunks.length} remaining chunks`);
+      await sendResponse(response);
     }
     debugLog(`in total, sent ${chunksSent} chunks`);
     stream.end();

--- a/test/utils/readRowsImpl.ts
+++ b/test/utils/readRowsImpl.ts
@@ -199,9 +199,9 @@ export function readRowsImpl(
             'base64'
           ).toString()}`
         );
-        lastScannedRowKey = chunk.rowKey as string;
       }
       if (chunk.commitRow) {
+        lastScannedRowKey = chunk.rowKey as string;
         debugLog('commit row');
       }
       currentResponseChunks.push(chunk);

--- a/test/utils/readRowsImpl.ts
+++ b/test/utils/readRowsImpl.ts
@@ -17,7 +17,8 @@ import {protos} from '../../src';
 import {GoogleError, Status} from 'google-gax';
 
 const valueSize = 1024 * 1024;
-const chunkSize = 1023 * 1024 - 1; // make it uneven
+// we want each row to be splitted into 2 chunks of different sizes
+const chunkSize = 1023 * 1024 - 1;
 const chunksPerResponse = 10;
 
 const debug = process.env.BIGTABLE_TEST_DEBUG === 'true';
@@ -40,6 +41,8 @@ function generateChunks(
 
   const chunks: protos.google.bigtable.v2.ReadRowsResponse.ICellChunk[] = [];
   for (let key = keyFrom; key < keyTo; ++key) {
+    // the keys must be increasing, but we also want to keep them readable,
+    // so we'll use keys 00000000, 00000001, 00000002, etc. stored as Buffers
     const binaryKey = Buffer.from(key.toString().padStart(8, '0'));
 
     // primitive support for row ranges

--- a/test/utils/readRowsImpl.ts
+++ b/test/utils/readRowsImpl.ts
@@ -1,0 +1,263 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {ServerWritableStream} from '@grpc/grpc-js';
+import {protos} from '../../src';
+import {GoogleError, Status} from 'google-gax';
+
+const valueSize = 1024 * 1024;
+const chunkSize = 1023 * 1024 - 1; // make it uneven
+const chunksPerResponse = 10;
+
+const debug = process.env.BIGTABLE_TEST_DEBUG === 'true';
+
+export function debugLog(text: string) {
+  if (debug) {
+    console.log(text);
+  }
+}
+
+function generateChunks(
+  keyFrom: number,
+  keyTo: number,
+  stream: ServerWritableStream<
+    protos.google.bigtable.v2.IReadRowsRequest,
+    protos.google.bigtable.v2.IReadRowsResponse
+  >
+) {
+  debugLog(`generating chunks from ${keyFrom} to ${keyTo}`);
+
+  const chunks: protos.google.bigtable.v2.ReadRowsResponse.ICellChunk[] = [];
+  for (let key = keyFrom; key < keyTo; ++key) {
+    const binaryKey = Buffer.from(key.toString().padStart(8, '0'));
+
+    // primitive support for row ranges
+    if (stream.request.rows?.rowRanges || stream.request.rows?.rowKeys) {
+      let take = false;
+      const stringKey = binaryKey.toString();
+      for (const requestKey of stream.request.rows?.rowKeys ?? []) {
+        if (stringKey === requestKey.toString()) {
+          take;
+          break;
+        }
+      }
+      for (const range of stream.request.rows?.rowRanges ?? []) {
+        let startOk = true;
+        let endOk = true;
+        if (range.startKeyOpen && range.startKeyOpen.toString() >= stringKey) {
+          startOk = false;
+        }
+        if (
+          range.startKeyClosed &&
+          range.startKeyClosed.toString() > stringKey
+        ) {
+          startOk = false;
+        }
+        if (range.endKeyOpen && range.endKeyOpen.toString() <= stringKey) {
+          endOk = false;
+        }
+        if (range.endKeyClosed && range.endKeyClosed.toString() < stringKey) {
+          endOk = false;
+        }
+        if (startOk && endOk) {
+          take = true;
+        }
+      }
+      if (!take) {
+        debugLog(
+          `skipping key ${key} because it's out of requested range or keys`
+        );
+        continue;
+      }
+    }
+
+    debugLog(`generating chunks for ${key}`);
+    const rowKey = binaryKey.toString('base64');
+    let remainingBytes = valueSize;
+    let chunkCounter = 0;
+    while (remainingBytes > 0) {
+      debugLog(`  remaining bytes: ${remainingBytes}`);
+      const chunk: protos.google.bigtable.v2.ReadRowsResponse.ICellChunk = {};
+      if (chunkCounter === 0) {
+        chunk.rowKey = rowKey;
+        chunk.familyName = {
+          value: 'family',
+        };
+        chunk.qualifier = {
+          value: Buffer.from('qualifier').toString('base64'),
+        };
+      }
+      const thisChunkSize =
+        remainingBytes >= chunkSize ? chunkSize : remainingBytes;
+      remainingBytes -= thisChunkSize;
+      const value = Buffer.from('a'.repeat(remainingBytes)).toString('base64');
+      chunk.value = value;
+      if (remainingBytes === 0) {
+        debugLog(`  setting commit flag for rowKey ${key}`);
+        chunk.commitRow = true;
+      }
+      chunks.push(chunk);
+      ++chunkCounter;
+    }
+  }
+  debugLog(`generated ${chunks.length} chunks between ${keyFrom} and ${keyTo}`);
+  return chunks;
+}
+
+export function readRowsImpl(
+  keyFrom: number,
+  keyTo: number,
+  errorAfterChunkNo?: number
+) {
+  return async (
+    stream: ServerWritableStream<
+      protos.google.bigtable.v2.IReadRowsRequest,
+      protos.google.bigtable.v2.IReadRowsResponse
+    >
+  ) => {
+    // pretty-printing important parts of the request.
+    // doing it field by field because we want to apply .toString() to all key fields
+    debugLog('received request: {');
+    debugLog(`  tableName: "${stream.request.tableName}",`);
+    if (stream.request.rows) {
+      debugLog('  rows: {');
+      if (stream.request.rows.rowKeys) {
+        debugLog('    rowKeys: [');
+        for (const key of stream.request.rows.rowKeys) {
+          debugLog(`      "${key.toString()}",`);
+        }
+        debugLog('    ],');
+      }
+      if (stream.request.rows.rowRanges) {
+        debugLog('    rowRanges: [');
+        for (const range of stream.request.rows.rowRanges) {
+          debugLog('      {');
+          if (range.startKeyOpen) {
+            debugLog(
+              `        startKeyOpen: "${range.startKeyOpen.toString()}",`
+            );
+          }
+          if (range.startKeyClosed) {
+            debugLog(
+              `        startKeyClosed: "${range.startKeyClosed.toString()}",`
+            );
+          }
+          if (range.endKeyOpen) {
+            debugLog(`        endKeyOpen: "${range.endKeyOpen.toString()}",`);
+          }
+          if (range.endKeyClosed) {
+            debugLog(
+              `        endKeyClosed: "${range.endKeyClosed.toString()}",`
+            );
+          }
+          debugLog('      },');
+        }
+        debugLog('    ],');
+      }
+      debugLog('  },');
+    }
+    debugLog('}');
+
+    let stopWaiting: () => void = () => {};
+    let cancelled = false;
+
+    stream.on('cancelled', () => {
+      debugLog('gRPC server received cancel()');
+      cancelled = true;
+      stopWaiting();
+      stream.emit('error', new Error('Cancelled'));
+    });
+
+    let chunksSent = 0;
+    const chunks = generateChunks(keyFrom, keyTo, stream);
+    let lastScannedRowKey: string | undefined;
+    let firstN: protos.google.bigtable.v2.ReadRowsResponse.ICellChunk[] = [];
+    let chunkIdx = 0;
+    for (const chunk of chunks) {
+      if (cancelled) {
+        break;
+      }
+      if (chunk.rowKey) {
+        debugLog(
+          `starting row with key ${Buffer.from(
+            chunk.rowKey as string,
+            'base64'
+          ).toString()}`
+        );
+        lastScannedRowKey = chunk.rowKey as string;
+      }
+      if (chunk.commitRow) {
+        debugLog('commit row');
+      }
+      firstN.push(chunk);
+      ++chunkIdx;
+      if (
+        firstN.length === chunksPerResponse ||
+        chunkIdx === errorAfterChunkNo
+      ) {
+        const response: protos.google.bigtable.v2.IReadRowsResponse = {
+          chunks: firstN,
+          lastScannedRowKey,
+        };
+        chunksSent += firstN.length;
+        await new Promise<void>(resolve => {
+          setTimeout(async () => {
+            if (cancelled) {
+              resolve();
+              return;
+            }
+            const canSendMore = stream.write(response);
+            debugLog(`sent ${firstN.length} chunks`);
+            firstN = [];
+            if (!canSendMore) {
+              debugLog(
+                `awaiting for back pressure after sending ${chunksSent} chunks`
+              );
+              await new Promise<void>(resolve => {
+                stopWaiting = resolve;
+                stream.once('drain', resolve);
+              });
+            }
+            resolve();
+          }, 0);
+        });
+        if (chunkIdx === errorAfterChunkNo) {
+          debugLog(`sending error after chunk #${chunkIdx}`);
+          errorAfterChunkNo = undefined; // do not send error for the second time
+          const error = new GoogleError('Uh oh');
+          error.code = Status.ABORTED;
+          stream.emit('error', error);
+          cancelled = true;
+          break;
+        }
+      }
+    }
+    if (!cancelled && firstN.length > 0) {
+      const response: protos.google.bigtable.v2.IReadRowsResponse = {
+        chunks: firstN,
+        lastScannedRowKey,
+      };
+      chunksSent += firstN.length;
+      await new Promise<void>(resolve => {
+        setTimeout(() => {
+          stream.write(response);
+          resolve();
+        }, 0);
+      });
+      debugLog(`sent ${firstN.length} remaining chunks`);
+    }
+    debugLog(`in total, sent ${chunksSent} chunks`);
+    stream.end();
+  };
+}


### PR DESCRIPTION
In this PR I'm adding some tests for `ReadRows` logic. This is a pretty straightforward but rather big PR, so please bear with me while I explain what's going on here.

I'm reusing @danieljbruce's awesome implementation of the local gRPC server (#1090) to present a reasonable mock for `ReadRows` in `test/utils/readRowsImpl.ts`. This new mock generates rows with incremental keys which are just numbers converted to strings and padded with zeros, e.g. for `readRowsImpl(0, 3)` the generated keys will be `00000000`, `00000001`, `00000002`. The rows are unevenly split into chunks, and chunks are grouped into response messages that are sent over the server stream.

There is some primitive support for range queries which is important for stream retries, and it's also possible to cancel the stream and request an error to be emitted.

The server implementation I suggest in this PR is backpressure-aware (checks return value of `stream.write(...)`), and - which is the most crucial part - is asynchronous, imitating the behavior of a remote gRPC server; by that I mean that all `stream.write(...)` calls are being sent after a zero `setTimeout` to move them to the next event loop iteration. This was the main missing piece to reliably reproduce an issue described in #607.

Now, the new test file I'm adding checks five basic use cases:

```
  it('should create read stream and read synchronously', ...)
  it('should create read stream and read synchronously using Transform stream', ...)
  it.skip('should create read stream and read asynchronously using Transform stream', ...)
  it('should be able to stop reading from the read stream', ...)
  it.skip('should silently resume after server or network error', ...)
```

The first test case runs the very basic scenario when the table scan is requested and the result is consumed using the regular `.on('data', ...)` event handler. It works.

The second test case pipes the read stream to a `Transform` stream, which then pipes it to a `PassThrough`, but all components run synchronously. It works as well.

The third test case does the same, but the `Transform` stream uses `setTimeout` to delay processing of each row, triggering the issue described in #607. Since this test currently fails, it's skipped.

The fourth test cases stops streaming from the user's code by calling `.end()` on a read stream; it works (with one caveat caused by https://github.com/grpc/grpc-node/issues/2446 which required me to set a custom timeout for that server call).

Now, the fifth test looks like a new issue for me. It tests the case when the server emits a retryable `error` event, and from what I see, this test case uncovers a problem in the `ChunkTransformer` implementation where it prematurely updates `lastRowKey` before this row is actually fully received and committed. We can discuss it offline and fix it if it's indeed a bug.

I suggest merging this PR which will help us fix the code (and un-skip the two tests in this PR whenever they start passing). As I said, it's a lot of code, but mostly straightforward, so I will really appreciate some extra 👀  :)

Thanks folks!