### PR TITLE
test: Make the mock server test async

### DIFF
--- a/test/errors.ts
+++ b/test/errors.ts
@@ -38,14 +38,15 @@ describe('Bigtable/Errors', () => {
   let bigtable: Bigtable;
   let table: any;
 
-  before(done => {
-    server = new MockServer(() => {
-      bigtable = new Bigtable({
-        apiEndpoint: `localhost:${server.port}`,
-      });
-      table = bigtable.instance('fake-instance').table('fake-table');
-      done();
+  before(async () => {
+    // make sure we have everything initialized before starting tests
+    const port = await new Promise<string>(resolve => {
+      server = new MockServer(resolve);
     });
+    bigtable = new Bigtable({
+      apiEndpoint: `localhost:${port}`,
+    });
+    table = bigtable.instance('fake-instance').table('fake-table');
   });
 
   describe('with the bigtable data client', () => {

--- a/test/errors.ts
+++ b/test/errors.ts
@@ -37,6 +37,7 @@ describe('Bigtable/Errors', () => {
   let server: MockServer;
   let bigtable: Bigtable;
   let table: any;
+  let service: MockService;
 
   before(async () => {
     // make sure we have everything initialized before starting tests
@@ -46,15 +47,11 @@ describe('Bigtable/Errors', () => {
     bigtable = new Bigtable({
       apiEndpoint: `localhost:${port}`,
     });
+    service = new BigtableClientMockService(server);
     table = bigtable.instance('fake-instance').table('fake-table');
   });
 
   describe('with the bigtable data client', () => {
-    let service: MockService;
-    before(async () => {
-      service = new BigtableClientMockService(server);
-    });
-
     describe('sends errors through a streaming request', () => {
       const errorDetails =
         'Table not found: projects/my-project/instances/my-instance/tables/my-table';


### PR DESCRIPTION
This test uses the done callback which looks confusing. We should make the test async for readability.
