### PR TITLE
fix: Remove watermarks

### DIFF
--- a/src/table.ts
+++ b/src/table.ts
@@ -751,6 +751,8 @@ Please use the format 'prezzy' or '${instance.name}/tables/prezzy'.`);
     let userCanceled = false;
     const userStream = new PassThrough({
       objectMode: true,
+      writableHighWaterMark: 0,
+      readableHighWaterMark: 0,
       transform(row, _encoding, callback) {
         if (userCanceled) {
           callback();
@@ -797,7 +799,11 @@ Please use the format 'prezzy' or '${instance.name}/tables/prezzy'.`);
 
       const lastRowKey = chunkTransformer ? chunkTransformer.lastRowKey : '';
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      chunkTransformer = new ChunkTransformer({decode: options.decode} as any);
+      chunkTransformer = new ChunkTransformer({
+        writableHighWaterMark: 0,
+        readableHighWaterMark: 0,
+        decode: options.decode,
+      } as any);
 
       const reqOpts = {
         tableName: this.name,
@@ -909,6 +915,8 @@ Please use the format 'prezzy' or '${instance.name}/tables/prezzy'.`);
       activeRequestStream = requestStream!;
 
       const toRowStream = new Transform({
+        readableHighWaterMark: 0,
+        writableHighWaterMark: 0,
         transform: (rowData, _, next) => {
           if (
             userCanceled ||

--- a/test/readrows.ts
+++ b/test/readrows.ts
@@ -222,7 +222,7 @@ describe('Bigtable/ReadRows', () => {
   });
 
   // TODO: enable after https://github.com/googleapis/nodejs-bigtable/issues/1286 is fixed
-  it.only('should be able to stop reading from the read stream when reading asynchronously', function (done) {
+  it('should be able to stop reading from the read stream when reading asynchronously', function (done) {
     if (process.platform === 'win32') {
       this.timeout(60000); // it runs much slower on Windows!
     }

--- a/test/readrows.ts
+++ b/test/readrows.ts
@@ -222,7 +222,7 @@ describe('Bigtable/ReadRows', () => {
   });
 
   // TODO: enable after https://github.com/googleapis/nodejs-bigtable/issues/1286 is fixed
-  it.skip('should be able to stop reading from the read stream when reading asynchronously', function (done) {
+  it.only('should be able to stop reading from the read stream when reading asynchronously', function (done) {
     if (process.platform === 'win32') {
       this.timeout(60000); // it runs much slower on Windows!
     }


### PR DESCRIPTION
Remove the watermarks so that row data doesn't get stuck at any point in the pipeline. This way, we can easily be sure that each buffer is flushed so that no extra data will leak through when the stream is ended.

Fixes #1286
