### PR TITLE
test: Fix deadline exceeded error in readstream test

### DIFF
--- a/test/readrows.ts
+++ b/test/readrows.ts
@@ -192,12 +192,7 @@ describe('Bigtable/ReadRows', () => {
     let receivedRowCount = 0;
     let lastKeyReceived: number | undefined;
 
-    const readStream = table.createReadStream({
-      // workaround for https://github.com/grpc/grpc-node/issues/2446, remove when fixed
-      gaxOptions: {
-        timeout: 3000,
-      },
-    });
+    const readStream = table.createReadStream();
     readStream.on('error', (err: GoogleError) => {
       done(err);
     });

--- a/test/readrows.ts
+++ b/test/readrows.ts
@@ -242,12 +242,7 @@ describe('Bigtable/ReadRows', () => {
     let lastKeyReceived: number | undefined;
 
     // BigTable stream
-    const readStream = table.createReadStream({
-      // workaround for https://github.com/grpc/grpc-node/issues/2446, remove when fixed
-      gaxOptions: {
-        timeout: 3000,
-      },
-    });
+    const readStream = table.createReadStream();
 
     // Transform stream
     const transform = new Transform({

--- a/test/readrows.ts
+++ b/test/readrows.ts
@@ -220,7 +220,7 @@ describe('Bigtable/ReadRows', () => {
   // TODO: enable after https://github.com/googleapis/nodejs-bigtable/issues/1286 is fixed
   it('should be able to stop reading from the read stream when reading asynchronously', function (done) {
     if (process.platform === 'win32') {
-      this.timeout(60000); // it runs much slower on Windows!
+      this.timeout(600000); // it runs much slower on Windows!
     }
 
     // 1000 rows must be enough to reproduce issues with losing the data and to create backpressure


### PR DESCRIPTION
Remove workaround for the call to createreadstream because the issue mentioned in the comment is closed.

This PR just does something that a comment in code says we should do which may solve flakey test issues.