### PR TITLE
fix: Fix flakey test by extending timeout

### DIFF
--- a/system-test/bigtable.ts
+++ b/system-test/bigtable.ts
@@ -155,9 +155,8 @@ describe('Bigtable', () => {
 
     it('should test Iam permissions for the instance', async () => {
       const permissions = ['bigtable.tables.get', 'bigtable.tables.readRows'];
-      const [grantedPermissions] = await INSTANCE.testIamPermissions(
-        permissions
-      );
+      const [grantedPermissions] =
+        await INSTANCE.testIamPermissions(permissions);
       assert.strictEqual(grantedPermissions.length, permissions.length);
       permissions.forEach(permission => {
         assert.strictEqual(grantedPermissions.includes(permission), true);

--- a/test/readrows.ts
+++ b/test/readrows.ts
@@ -42,7 +42,11 @@ describe('Bigtable/ReadRows', () => {
     service = new BigtableClientMockService(server);
   });
 
-  it('should create read stream and read synchronously', done => {
+  it('should create read stream and read synchronously', function (done) {
+    if (process.platform === 'win32') {
+      this.timeout(60000); // it runs much slower on Windows!
+    }
+
     // 1000 rows must be enough to reproduce issues with losing the data and to create backpressure
     const keyFrom = 0;
     const keyTo = 1000;

--- a/test/readrows.ts
+++ b/test/readrows.ts
@@ -43,9 +43,7 @@ describe('Bigtable/ReadRows', () => {
   });
 
   it('should create read stream and read synchronously', function (done) {
-    if (process.platform === 'win32') {
-      this.timeout(60000); // it runs much slower on Windows!
-    }
+    this.timeout(60000);
 
     // 1000 rows must be enough to reproduce issues with losing the data and to create backpressure
     const keyFrom = 0;


### PR DESCRIPTION
Add timeout to the read syncronously test as it is blocking a few tests from being merged.
