### PR TITLE
Add time and timeEnd logs to the code

### DIFF
--- a/src/table.ts
+++ b/src/table.ts
@@ -719,6 +719,7 @@ Please use the format 'prezzy' or '${instance.name}/tables/prezzy'.`);
    * region_tag:bigtable_api_table_readstream
    */
   createReadStream(opts?: GetRowsOptions) {
+    console.time('before-gapic');
     const options = opts || {};
     const maxRetries = is.number(this.maxRetries) ? this.maxRetries! : 10;
     let activeRequestStream: AbortableDuplex | null;
@@ -943,6 +944,7 @@ Please use the format 'prezzy' or '${instance.name}/tables/prezzy'.`);
 
       rowStream
         .on('error', (error: ServiceError) => {
+          console.log('some error');
           rowStreamUnpipe(rowStream, userStream);
           activeRequestStream = null;
           if (IGNORED_STATUS_CODES.has(error.code)) {
@@ -975,6 +977,8 @@ Please use the format 'prezzy' or '${instance.name}/tables/prezzy'.`);
           numConsecutiveErrors = 0;
         })
         .on('end', () => {
+          console.timeEnd('to-end');
+          console.time('from-end');
           activeRequestStream = null;
         });
       rowStreamPipe(rowStream, userStream);
@@ -1427,6 +1431,8 @@ Please use the format 'prezzy' or '${instance.name}/tables/prezzy'.`);
       .on('error', callback)
       .pipe(
         concat((rows: Row[]) => {
+          console.log(rows);
+          console.timeEnd('receive-time');
           callback(null, rows);
         })
       );

--- a/src/v2/bigtable_client.ts
+++ b/src/v2/bigtable_client.ts
@@ -896,6 +896,7 @@ export class BigtableClient {
     request?: protos.google.bigtable.v2.IReadRowsRequest,
     options?: CallOptions
   ): gax.CancellableStream {
+    console.timeEnd('before-gapic');
     request = request || {};
     options = options || {};
     options.otherArgs = options.otherArgs || {};

--- a/testproxy/services/read-rows.js
+++ b/testproxy/services/read-rows.js
@@ -66,7 +66,11 @@ const readRows = ({clientMap}) =>
     const table = getTableInfo(bigtable, tableName);
     const rowsOptions = getRowsOptions(readRowsRequest);
     try {
+      console.time('to-end');
+      console.time('readRows');
       const [rows] = await table.getRows(rowsOptions);
+      console.timeEnd('from-end');
+      console.timeEnd('readRows');
       return {
         status: {code: grpc.status.OK, details: []},
         rows: rows.map(getRowResponse),


### PR DESCRIPTION
Show that there is latency in the client without any changes to gax. This will provide a useful benchmark against the gax changes for measuring latency.
