### PR TITLE
fix: Do not allow gaxOptions to be modified downstream

### DIFF
--- a/src/table.ts
+++ b/src/table.ts
@@ -894,7 +894,7 @@ Please use the format 'prezzy' or '${instance.name}/tables/prezzy'.`);
         reqOpts.rowsLimit = rowsLimit - rowsRead;
       }
 
-      options.gaxOptions = populateAttemptHeader(
+      const gaxOpts = populateAttemptHeader(
         numRequestsMade,
         options.gaxOptions
       );
@@ -903,7 +903,7 @@ Please use the format 'prezzy' or '${instance.name}/tables/prezzy'.`);
         client: 'BigtableClient',
         method: 'readRows',
         reqOpts,
-        gaxOpts: options.gaxOptions,
+        gaxOpts,
         retryOpts,
       });
 


### PR DESCRIPTION
Currently, https://github.com/googleapis/nodejs-bigtable/pull/1372 has a failing test that produces an error that says `Uncaught Error: Only one of retry or retryRequestOptions may be set`. This code change allows that test to pass on the `gcf-owl-bot` PR branch.

**Here is what currently happens:**

The failing test uses a mock server that aborts the stream simulating a network error. This causes the client to retry. However, on the first call the client makes, `options.gaxOptions` gets passed down the stack at https://github.com/googleapis/nodejs-bigtable/blob/8cc17aa2acb2540b4c2b233c4245021815a7b030/src/table.ts#L906 and then modified so that the retry parameter of `options.gaxOptions` is defined having settings that match `https://github.com/googleapis/nodejs-bigtable/blob/8cc17aa2acb2540b4c2b233c4245021815a7b030/src/v2/bigtable_client_config.json#L12-L20.`. On the second call, `options.gaxOptions` is passed down the stack with the `retry` parameter defined this time and with the retryRequestOptions parameter attached at https://github.com/googleapis/nodejs-bigtable/blob/8cc17aa2acb2540b4c2b233c4245021815a7b030/src/index.ts#L859 as well. This causes the error to be thrown that says `Uncaught Error: Only one of retry or retryRequestOptions may be set`.

**What this fix does:**

With this fix a copy of `options.gaxOptions` is passed down the call stack instead of `options.gaxOptions` itself. This means when the client retries, `options.gaxOptions` does not contain the `retry` parameter in the createReadStream function as this parameter is normally filled out much further down the stack. This means the error `Uncaught Error: Only one of retry or retryRequestOptions may be set` is not thrown.

**Additional effects:**

For retries, this means `options.gaxOptions?.retry?.backoffSettings` will be `undefined` at https://github.com/googleapis/nodejs-bigtable/blob/8cc17aa2acb2540b4c2b233c4245021815a7b030/src/table.ts#L960-L962 and retries will now use `DEFAULT_BACKOFF_SETTINGS` if backoff settings are not provided by the user. This is exactly what we want and is also the intent of the current code.