### PR TITLE
test: rewrite createreadstream tests

### DIFF
--- a/src/util/mock-servers/mock-server.ts
+++ b/src/util/mock-servers/mock-server.ts
@@ -37,7 +37,6 @@ export class MockServer {
       `localhost:${this.port}`,
       grpc.ServerCredentials.createInsecure(),
       () => {
-        server.start();
         callback ? callback(portString) : undefined;
       }
     );

--- a/system-test/read-rows.ts
+++ b/system-test/read-rows.ts
@@ -38,7 +38,13 @@ function rowResponseFromServer(rowKey: string) {
   };
 }
 
-function getRequestOptions(request: any): google.bigtable.v2.IRowSet {
+function getRequestOptions(request: {
+  rows: {
+    rowRanges: google.bigtable.v2.RowRange[];
+    rowKeys: Uint8Array[];
+  };
+  rowsLimit: string;
+}): google.bigtable.v2.IRowSet {
   const requestOptions = {} as google.bigtable.v2.IRowSet;
   if (request.rows && request.rows.rowRanges) {
     requestOptions.rowRanges = request.rows.rowRanges.map(

--- a/system-test/read-rows.ts
+++ b/system-test/read-rows.ts
@@ -154,7 +154,7 @@ describe('Bigtable/Table', () => {
         // in checkResults at the end of the test for correctness.
         const requestedOptions: google.bigtable.v2.IRowSet[] = [];
         const responses = test.responses;
-        const rowKeysRead: any[] = [];
+        const rowKeysRead: string[][] = [];
         let endCalled = false;
         let error: ServiceError | null = null;
         function checkResults() {

--- a/system-test/read-rows.ts
+++ b/system-test/read-rows.ts
@@ -16,7 +16,6 @@ import {Bigtable, Cluster, protos, Table} from '../src';
 const {tests} = require('../../system-test/data/read-rows-retry-test.json') as {
   tests: ReadRowsTest[];
 };
-import {google} from '../protos/protos';
 import * as assert from 'assert';
 import {describe, it, before} from 'mocha';
 import {CreateReadStreamRequest, ReadRowsTest} from './testTypes';

--- a/system-test/read-rows.ts
+++ b/system-test/read-rows.ts
@@ -147,6 +147,10 @@ describe('Bigtable/Table', () => {
       service = new BigtableClientMockService(server);
     });
 
+    after(async () => {
+      server.shutdown(() => {});
+    });
+
     tests.forEach(test => {
       it(test.name, done => {
         // These variables store request/response data capturing data sent

--- a/system-test/read-rows.ts
+++ b/system-test/read-rows.ts
@@ -43,7 +43,7 @@ function getRequestOptions(request: any): google.bigtable.v2.IRowSet {
   if (request.rows && request.rows.rowRanges) {
     requestOptions.rowRanges = request.rows.rowRanges.map(
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (range: any) => {
+      (range: google.bigtable.v2.RowRange) => {
         const convertedRowRange = {} as {[index: string]: string};
         {
           // startKey and endKey get filled in during the grpc request.
@@ -56,8 +56,8 @@ function getRequestOptions(request: any): google.bigtable.v2.IRowSet {
             delete range.endKey;
           }
         }
-        Object.keys(range).forEach(
-          key => (convertedRowRange[key] = range[key].asciiSlice())
+        Object.entries(range).forEach(
+          ([key, value]) => (convertedRowRange[key] = value.asciiSlice())
         );
         return convertedRowRange;
       }

--- a/system-test/read-rows.ts
+++ b/system-test/read-rows.ts
@@ -71,7 +71,6 @@ function getRequestOptions(request: {
   const requestOptions = {} as CreateReadStreamRequest;
   if (request.rows && request.rows.rowRanges) {
     requestOptions.rowRanges = request.rows.rowRanges.map(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (range: TestRowRange) => {
         const convertedRowRange = {} as {[index: string]: string};
         {
@@ -112,7 +111,6 @@ function getRequestOptions(request: {
     request.rowsLimit !== '0' &&
     typeof request.rowsLimit === 'string'
   ) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     requestOptions.rowsLimit = parseInt(request.rowsLimit);
   }
   return requestOptions;
@@ -232,7 +230,6 @@ describe('Bigtable/Table', () => {
               });
             }
             if (response.end_with_error) {
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
               const error: GoogleError = new GoogleError();
               error.code = response.end_with_error;
               stream.emit('error', error);

--- a/system-test/read-rows.ts
+++ b/system-test/read-rows.ts
@@ -130,7 +130,7 @@ describe('Bigtable/Table', () => {
     });
   });
 
-  describe.only('createReadStream using mock server', () => {
+  describe('createReadStream using mock server', () => {
     let server: MockServer;
     let service: MockService;
     let bigtable = new Bigtable();

--- a/system-test/testTypes.ts
+++ b/system-test/testTypes.ts
@@ -53,7 +53,7 @@ interface CreateReadStreamResponse {
   end_with_error?: 4;
 }
 
-interface CreateReadStreamRequest {
+export interface CreateReadStreamRequest {
   rowKeys: string[];
   rowRanges: google.bigtable.v2.IRowRange[];
   rowsLimit?: number;

--- a/system-test/testTypes.ts
+++ b/system-test/testTypes.ts
@@ -56,7 +56,7 @@ interface CreateReadStreamResponse {
 interface CreateReadStreamRequest {
   rowKeys: string[];
   rowRanges: google.bigtable.v2.IRowRange[];
-  rowsLimit: number;
+  rowsLimit?: number;
 }
 export interface ReadRowsTest {
   createReadStream_options?: GetRowsOptions;

--- a/system-test/testTypes.ts
+++ b/system-test/testTypes.ts
@@ -14,6 +14,7 @@
 
 import {ServiceError} from 'google-gax';
 import {GetRowsOptions} from '../src/table';
+import {google} from '../protos/protos';
 
 export interface Test {
   name: string;
@@ -45,4 +46,24 @@ export interface Test {
   request_options: {};
   row_keys_read: {};
   createReadStream_options: GetRowsOptions;
+}
+
+interface CreateReadStreamResponse {
+  row_keys?: string[];
+  end_with_error?: 4;
+}
+
+interface CreateReadStreamRequest {
+  rowKeys: string[];
+  rowRanges: google.bigtable.v2.IRowRange[];
+  rowsLimit: number;
+}
+export interface ReadRowsTest {
+  createReadStream_options?: GetRowsOptions;
+  max_retries: number;
+  responses: CreateReadStreamResponse[];
+  request_options: CreateReadStreamRequest[];
+  error: number;
+  row_keys_read: string[][];
+  name: string;
 }


### PR DESCRIPTION
When retries are moved to google-gax from the handwritten layer of `nodejs-bigtable` then the current tests mentioned in the PR will not work. They need to be rewritten to still test retry behavior, but account for the fact that the retries will be done in a different layer.

Here is what is done to modify [`Tests in [read-rows.ts]`](https://github.com/googleapis/nodejs-bigtable/blob/17838eda19b001e322765c33a83a756eeeb68963/system-test/read-rows.ts#L126) just to clarify further:
1. This [sinon stub mock](https://github.com/googleapis/nodejs-bigtable/blob/17838eda19b001e322765c33a83a756eeeb68963/system-test/read-rows.ts#L153) currently mocks out the request function and sends responses back to createreadstream where retries are currently done. Since retries will not be done in `createreadstream` anymore and this test intends to test retries then responses must be mocked in a layer below where retries are going to be done in google-gax in a later change. The current sinon stub mock should be removed and instead the [mock grpc server](https://github.com/googleapis/nodejs-bigtable/blob/main/src/util/mock-servers/mock-server.ts) should send [responses](https://github.com/googleapis/nodejs-bigtable/blob/17838eda19b001e322765c33a83a756eeeb68963/system-test/data/read-rows-retry-test.json#L33-L36) back in order to test retry behavior.
2. As is done with the current mock, the new mock server mock should check each request to ensure it matches [request_options](https://github.com/googleapis/nodejs-bigtable/blob/17838eda19b001e322765c33a83a756eeeb68963/system-test/data/read-rows-retry-test.json#L27-L32)