### PR TITLE
feat: Append gaxServerStreamingRetries to the data client

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -445,6 +445,7 @@ export class Bigtable {
       {},
       baseOptions,
       {
+        gaxServerStreamingRetries: true,
         servicePath: customEndpointBaseUrl || defaultBaseUrl,
         'grpc.callInvocationTransformer': grpcGcp.gcpCallInvocationTransformer,
         'grpc.channelFactoryOverride': grpcGcp.gcpChannelFactoryOverride,


### PR DESCRIPTION
This change makes it so that with new changes coming to the Gapic layer, the [Bigtable Data client](https://github.com/googleapis/nodejs-bigtable/blob/main/src/v2/bigtable_client.ts) will do retries in gax for streaming calls. New changes to the Gapic layer are coming so that streaming calls will read from [opts.gaxServerStreamingRetries when it is generated here](https://github.com/googleapis/nodejs-bigtable/blob/3f5db964062502cd70235714eb7b5fb62a211d4f/src/v2/bigtable_client.ts#L217). The change in this PR ensures [opts.gaxServerStreamingRetries when it is generated here](https://github.com/googleapis/nodejs-bigtable/blob/3f5db964062502cd70235714eb7b5fb62a211d4f/src/v2/bigtable_client.ts#L217) will be set to true so that retries in gax are used for streaming calls in the [data client](https://github.com/googleapis/nodejs-bigtable/blob/main/src/v2/bigtable_client.ts). This won't change the behaviour of `createreadstream` making `readrows` calls yet because [createreadstream currently tells gax never to retry](https://github.com/googleapis/nodejs-bigtable/blob/3f5db964062502cd70235714eb7b5fb62a211d4f/src/table.ts#L808-L816) anyway. But in `createreadstream` if we change `shouldRetryFn` to return true sometimes then we should see gax attempt to retry in those cases.

This PR should not be merged until the new changes in Gapic are available to read from the `opts.gaxServerStreamingRetries` option passed into the Gapic client.