### PR TITLE
test: Createreadstream with mock server add console logs

### DIFF
--- a/src/table.ts
+++ b/src/table.ts
@@ -943,6 +943,7 @@ Please use the format 'prezzy' or '${instance.name}/tables/prezzy'.`);
 
       rowStream
         .on('error', (error: ServiceError) => {
+          console.log('error in handwritten');
           rowStreamUnpipe(rowStream, userStream);
           activeRequestStream = null;
           if (IGNORED_STATUS_CODES.has(error.code)) {

--- a/src/util/mock-servers/mock-server.ts
+++ b/src/util/mock-servers/mock-server.ts
@@ -37,7 +37,6 @@ export class MockServer {
       `localhost:${this.port}`,
       grpc.ServerCredentials.createInsecure(),
       () => {
-        server.start();
         callback ? callback(portString) : undefined;
       }
     );

--- a/system-test/read-rows.ts
+++ b/system-test/read-rows.ts
@@ -154,7 +154,7 @@ describe('Bigtable/Table', () => {
         // in checkResults at the end of the test for correctness.
         const requestedOptions: google.bigtable.v2.IRowSet[] = [];
         const responses = test.responses;
-        const rowKeysRead: any[] = [];
+        const rowKeysRead: string[][] = [];
         let endCalled = false;
         let error: ServiceError | null = null;
         function checkResults() {

--- a/system-test/read-rows.ts
+++ b/system-test/read-rows.ts
@@ -147,6 +147,10 @@ describe('Bigtable/Table', () => {
       service = new BigtableClientMockService(server);
     });
 
+    after(async () => {
+      server.shutdown(() => {});
+    });
+
     tests.forEach(test => {
       it(test.name, done => {
         // These variables store request/response data capturing data sent

--- a/system-test/read-rows.ts
+++ b/system-test/read-rows.ts
@@ -130,7 +130,7 @@ describe('Bigtable/Table', () => {
     });
   });
 
-  describe.only('createReadStream using mock server', () => {
+  describe('createReadStream using mock server', () => {
     let server: MockServer;
     let service: MockService;
     let bigtable = new Bigtable();

--- a/system-test/read-rows.ts
+++ b/system-test/read-rows.ts
@@ -130,7 +130,7 @@ describe('Bigtable/Table', () => {
     });
   });
 
-  describe('createReadStream using mock server', () => {
+  describe.only('createReadStream using mock server', () => {
     let server: MockServer;
     let service: MockService;
     let bigtable = new Bigtable();
@@ -187,6 +187,7 @@ describe('Bigtable/Table', () => {
               protos.google.bigtable.v2.IReadRowsResponse
             >
           ) => {
+            console.log('reached service');
             const response = responses!.shift();
             assert(response);
             rowKeysRead.push([]);

--- a/system-test/testTypes.ts
+++ b/system-test/testTypes.ts
@@ -56,7 +56,7 @@ interface CreateReadStreamResponse {
 interface CreateReadStreamRequest {
   rowKeys: string[];
   rowRanges: google.bigtable.v2.IRowRange[];
-  rowsLimit: number;
+  rowsLimit?: number;
 }
 export interface ReadRowsTest {
   createReadStream_options?: GetRowsOptions;

--- a/system-test/testTypes.ts
+++ b/system-test/testTypes.ts
@@ -14,6 +14,7 @@
 
 import {ServiceError} from 'google-gax';
 import {GetRowsOptions} from '../src/table';
+import {google} from '../protos/protos';
 
 export interface Test {
   name: string;
@@ -45,4 +46,24 @@ export interface Test {
   request_options: {};
   row_keys_read: {};
   createReadStream_options: GetRowsOptions;
+}
+
+interface CreateReadStreamResponse {
+  row_keys?: string[];
+  end_with_error?: 4;
+}
+
+interface CreateReadStreamRequest {
+  rowKeys: string[];
+  rowRanges: google.bigtable.v2.IRowRange[];
+  rowsLimit: number;
+}
+export interface ReadRowsTest {
+  createReadStream_options?: GetRowsOptions;
+  max_retries: number;
+  responses: CreateReadStreamResponse[];
+  request_options: CreateReadStreamRequest[];
+  error: number;
+  row_keys_read: string[][];
+  name: string;
 }


### PR DESCRIPTION
This PR is not meant to be merged. In this PR we add a console.log to the mock server and a console log inside the retry logic of createreadstream. If gax is not doing any retrying then these console logs should alternate `reached service` and then `error in handwritten`. We shouldn't see two of the same message in a row for a particular test.
