### PR TITLE
test: Add a test configuration for retries

### DIFF
--- a/.github/workflows/retries.yaml
+++ b/.github/workflows/retries.yaml
@@ -18,7 +18,7 @@ on:
     branches:
     - main
   pull_request:
-name: conformance
+name: retries
 jobs:
   conformance:
     runs-on: ubuntu-latest

--- a/.github/workflows/retries.yaml
+++ b/.github/workflows/retries.yaml
@@ -1,0 +1,44 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Github action job to test core java library features on
+# downstream client libraries before they are released.
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+name: conformance
+jobs:
+  conformance:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: [ 14, 16, 18, 20 ]
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/checkout@v4
+      with:
+        repository: googleapis/cloud-bigtable-clients-test
+        ref: main
+        path: cloud-bigtable-clients-test
+    - uses: actions/setup-node@v3
+      with:
+        node-version: ${{ matrix.node }}
+    - uses: actions/setup-go@v5
+      with:
+        go-version: '>=1.20.2'
+    - run: chmod +x .kokoro/retries.sh
+    - run: npm install
+    - run: go version
+    - run: .kokoro/retries.sh

--- a/.github/workflows/retries.yaml
+++ b/.github/workflows/retries.yaml
@@ -20,7 +20,7 @@ on:
   pull_request:
 name: retries
 jobs:
-  conformance:
+  retries:
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.kokoro/retries.sh
+++ b/.kokoro/retries.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eo pipefail
+
+export NPM_CONFIG_PREFIX=${HOME}/.npm-global
+
+## cd to the parent directory, i.e. the root of the git repo
+cd $(dirname $0)/..
+
+# Stop the testbench & cleanup environment variables
+function cleanup() {
+    echo "Cleanup testbench"
+    # Stop the proxy
+    kill $proxyPID
+}
+trap cleanup EXIT
+
+# Build and start the proxy in a separate process
+pushd .
+npm install
+nohup npm run testproxy &
+proxyPID=$!
+popd
+
+# Run the conformance test
+cd cloud-bigtable-clients-test/tests
+eval "go test -v -proxy_addr=:9999 -run TestReadRows_NoRetry_ErrorAfterLastRow\|TestReadRows_Retry_LastScannedRow\|TestReadRows_NoRetry_OutOfOrderError\|TestReadRows_Generic_MultiStreams\|TestReadRows_Generic_Headers"
+RETURN_CODE=$?
+
+echo "exiting with ${RETURN_CODE}"
+exit ${RETURN_CODE}

--- a/.kokoro/retries.sh
+++ b/.kokoro/retries.sh
@@ -38,7 +38,7 @@ popd
 
 # Run the conformance test
 cd cloud-bigtable-clients-test/tests
-eval "go test -v -proxy_addr=:9999 -run TestReadRows_NoRetry_ErrorAfterLastRow\|TestReadRows_Retry_LastScannedRow\|TestReadRows_NoRetry_OutOfOrderError\|TestReadRows_Generic_MultiStreams\|TestReadRows_Generic_Headers"
+eval "go test -v -proxy_addr=:9999 -run TestReadRows_NoRetry_ErrorAfterLastRow\\b\|TestReadRows_Retry_LastScannedRow\\b\|TestReadRows_NoRetry_OutOfOrderError\\b\|TestReadRows_Generic_MultiStreams\\b\|TestReadRows_Generic_Headers\\b"
 RETURN_CODE=$?
 
 echo "exiting with ${RETURN_CODE}"


### PR DESCRIPTION
This PR adds a Github action that intends to verify retries are working. It runs a subset of the conformance tests focused on retries that currently pass. The reason this is important thing is that as we develop, these tests should not suddenly start failing. If they do then we know that we have broken something. Some of the other conformance tests are failing due to other issues with the test proxy and the way those tests interact with some nodejs-bigtable dependencies so these tests are not included in this Github action. More retries tests will be added later.

The reason this Github action became necessary is because the custom mock server written in Node doesn't seem to be interacting properly with google-gax. The mock server in the conformance tests is a much more reliable mock server and so failing tests using this mock server will give us a much better indication that something is wrong with the retry logic.