### PR TITLE
test: begin to refactor the mock service

### DIFF
--- a/test/readrows.ts
+++ b/test/readrows.ts
@@ -75,7 +75,9 @@ describe('Bigtable/ReadRows', () => {
     this.timeout(60000);
 
     service.setService({
-      ReadRows: readRowsImpl(STANDARD_SERVICE_WITHOUT_ERRORS) as any,
+      ReadRows: readRowsImpl(
+        STANDARD_SERVICE_WITHOUT_ERRORS
+      ) as ServerImplementationInterface,
     });
 
     let receivedRowCount = 0;
@@ -103,7 +105,9 @@ describe('Bigtable/ReadRows', () => {
 
   it('should create read stream and read synchronously using Transform stream', done => {
     service.setService({
-      ReadRows: readRowsImpl(STANDARD_SERVICE_WITHOUT_ERRORS) as any,
+      ReadRows: readRowsImpl(
+        STANDARD_SERVICE_WITHOUT_ERRORS
+      ) as ServerImplementationInterface,
     });
 
     let receivedRowCount = 0;
@@ -151,7 +155,9 @@ describe('Bigtable/ReadRows', () => {
       this.timeout(60000); // it runs much slower on Windows!
     }
     service.setService({
-      ReadRows: readRowsImpl(STANDARD_SERVICE_WITHOUT_ERRORS) as any,
+      ReadRows: readRowsImpl(
+        STANDARD_SERVICE_WITHOUT_ERRORS
+      ) as ServerImplementationInterface,
     });
 
     let receivedRowCount = 0;
@@ -201,7 +207,9 @@ describe('Bigtable/ReadRows', () => {
     const stopAfter = 42;
 
     service.setService({
-      ReadRows: readRowsImpl(STANDARD_SERVICE_WITHOUT_ERRORS) as any,
+      ReadRows: readRowsImpl(
+        STANDARD_SERVICE_WITHOUT_ERRORS
+      ) as ServerImplementationInterface,
     });
 
     let receivedRowCount = 0;
@@ -241,7 +249,9 @@ describe('Bigtable/ReadRows', () => {
     const stopAfter = 420;
 
     service.setService({
-      ReadRows: readRowsImpl(STANDARD_SERVICE_WITHOUT_ERRORS) as any,
+      ReadRows: readRowsImpl(
+        STANDARD_SERVICE_WITHOUT_ERRORS
+      ) as ServerImplementationInterface,
     });
 
     let receivedRowCount = 0;
@@ -301,7 +311,7 @@ describe('Bigtable/ReadRows', () => {
         chunkSize: CHUNK_SIZE,
         chunksPerResponse: CHUNKS_PER_RESPONSE,
         errorAfterChunkNo: 423,
-      }) as any,
+      }) as ServerImplementationInterface,
     });
 
     let receivedRowCount = 0;

--- a/test/readrows.ts
+++ b/test/readrows.ts
@@ -27,6 +27,7 @@ import {readRowsImpl2} from './utils/readRowsImpl2';
 
 import {ReadRowsServiceParameters} from '../test/utils/readRowsServiceParameters';
 
+// Define parameters for a standard Bigtable Mock service
 const VALUE_SIZE = 1024 * 1024;
 // we want each row to be splitted into 2 chunks of different sizes
 const CHUNK_SIZE = 1023 * 1024 - 1;
@@ -34,7 +35,6 @@ const CHUNKS_PER_RESPONSE = 10;
 const STANDARD_KEY_FROM = 0;
 // 1000 rows must be enough to reproduce issues with losing the data and to create backpressure
 const STANDARD_KEY_TO = 1000;
-
 const STANDARD_SERVICE_WITHOUT_ERRORS: ReadRowsServiceParameters = {
   keyFrom: STANDARD_KEY_FROM,
   keyTo: STANDARD_KEY_TO,

--- a/test/readrows.ts
+++ b/test/readrows.ts
@@ -29,7 +29,7 @@ import {ReadRowsServiceParameters} from '../test/utils/readRowsServiceParameters
 
 // Define parameters for a standard Bigtable Mock service
 const VALUE_SIZE = 1024 * 1024;
-// we want each row to be splitted into 2 chunks of different sizes
+// we want each row to be split into 2 chunks of different sizes
 const CHUNK_SIZE = 1023 * 1024 - 1;
 const CHUNKS_PER_RESPONSE = 10;
 const STANDARD_KEY_FROM = 0;

--- a/test/readrows.ts
+++ b/test/readrows.ts
@@ -22,7 +22,7 @@ import {MockServer} from '../src/util/mock-servers/mock-server';
 import {BigtableClientMockService} from '../src/util/mock-servers/service-implementations/bigtable-client-mock-service';
 import {MockService} from '../src/util/mock-servers/mock-service';
 import {debugLog, readRowsImpl} from './utils/readRowsImpl';
-import {ServerWritableStream, UntypedHandleCall} from '@grpc/grpc-js';
+import {ServerWritableStream} from '@grpc/grpc-js';
 import {readRowsImpl2} from './utils/readRowsImpl2';
 
 import {ReadRowsServiceParameters} from '../test/utils/readRowsServiceParameters';

--- a/test/readrows.ts
+++ b/test/readrows.ts
@@ -42,14 +42,6 @@ const STANDARD_SERVICE_WITHOUT_ERRORS: ReadRowsServiceParameters = {
   chunkSize: CHUNK_SIZE,
   chunksPerResponse: CHUNKS_PER_RESPONSE,
 };
-const STANDARD_SERVICE_WITH_ERRORS: ReadRowsServiceParameters = {
-  keyFrom: STANDARD_KEY_FROM,
-  keyTo: STANDARD_KEY_TO,
-  valueSize: VALUE_SIZE,
-  chunkSize: CHUNK_SIZE,
-  chunksPerResponse: CHUNKS_PER_RESPONSE,
-  errorAfterChunkNo: 423,
-};
 
 type PromiseVoid = Promise<void>;
 interface ServerImplementationInterface {
@@ -302,7 +294,14 @@ describe('Bigtable/ReadRows', () => {
 
   it('should silently resume after server or network error', done => {
     service.setService({
-      ReadRows: readRowsImpl(STANDARD_SERVICE_WITH_ERRORS) as any,
+      ReadRows: readRowsImpl({
+        keyFrom: STANDARD_KEY_FROM,
+        keyTo: STANDARD_KEY_TO,
+        valueSize: VALUE_SIZE,
+        chunkSize: CHUNK_SIZE,
+        chunksPerResponse: CHUNKS_PER_RESPONSE,
+        errorAfterChunkNo: 423,
+      }) as any,
     });
 
     let receivedRowCount = 0;

--- a/test/readrows.ts
+++ b/test/readrows.ts
@@ -81,8 +81,6 @@ describe('Bigtable/ReadRows', () => {
 
   it('should create read stream and read synchronously', function (done) {
     this.timeout(60000);
-    const keyFrom = 0;
-    const keyTo = 1000;
 
     service.setService({
       ReadRows: readRowsImpl(STANDARD_SERVICE_WITHOUT_ERRORS) as any,
@@ -105,14 +103,13 @@ describe('Bigtable/ReadRows', () => {
       debugLog(`received row key ${key}`);
     });
     readStream.on('end', () => {
-      assert.strictEqual(receivedRowCount, keyTo - keyFrom);
-      assert.strictEqual(lastKeyReceived, keyTo - 1);
+      assert.strictEqual(receivedRowCount, STANDARD_KEY_TO - STANDARD_KEY_FROM);
+      assert.strictEqual(lastKeyReceived, STANDARD_KEY_TO - 1);
       done();
     });
   });
 
   it('should create read stream and read synchronously using Transform stream', done => {
-    // 1000 rows must be enough to reproduce issues with losing the data and to create backpressure
     service.setService({
       ReadRows: readRowsImpl(STANDARD_SERVICE_WITHOUT_ERRORS) as any,
     });
@@ -161,8 +158,6 @@ describe('Bigtable/ReadRows', () => {
     if (process.platform === 'win32') {
       this.timeout(60000); // it runs much slower on Windows!
     }
-
-    // 1000 rows must be enough to reproduce issues with losing the data and to create backpressure
     service.setService({
       ReadRows: readRowsImpl(STANDARD_SERVICE_WITHOUT_ERRORS) as any,
     });
@@ -210,9 +205,6 @@ describe('Bigtable/ReadRows', () => {
   });
 
   it('should be able to stop reading from the read stream', done => {
-    // 1000 rows must be enough to reproduce issues with losing the data and to create backpressure
-    const keyFrom = 0;
-    const keyTo = 1000;
     // pick any key to stop after
     const stopAfter = 42;
 
@@ -253,10 +245,6 @@ describe('Bigtable/ReadRows', () => {
     if (process.platform === 'win32') {
       this.timeout(600000); // it runs much slower on Windows!
     }
-
-    // 1000 rows must be enough to reproduce issues with losing the data and to create backpressure
-    const keyFrom = 0;
-    const keyTo = 1000;
     // pick any key to stop after
     const stopAfter = 420;
 
@@ -313,12 +301,6 @@ describe('Bigtable/ReadRows', () => {
   });
 
   it('should silently resume after server or network error', done => {
-    // 1000 rows must be enough to reproduce issues with losing the data and to create backpressure
-    const keyFrom = 0;
-    const keyTo = 1000;
-    // the server will error after sending this chunk (not row)
-    const errorAfterChunkNo = 423;
-
     service.setService({
       ReadRows: readRowsImpl(STANDARD_SERVICE_WITH_ERRORS) as any,
     });
@@ -340,8 +322,8 @@ describe('Bigtable/ReadRows', () => {
       debugLog(`received row key ${key}`);
     });
     readStream.on('end', () => {
-      assert.strictEqual(receivedRowCount, keyTo - keyFrom);
-      assert.strictEqual(lastKeyReceived, keyTo - 1);
+      assert.strictEqual(receivedRowCount, STANDARD_KEY_TO - STANDARD_KEY_FROM);
+      assert.strictEqual(lastKeyReceived, STANDARD_KEY_TO - 1);
       done();
     });
   });

--- a/test/utils/readRowsImpl.ts
+++ b/test/utils/readRowsImpl.ts
@@ -30,7 +30,6 @@ export function debugLog(text: string) {
   }
 }
 
-// TODO: Simplify this, perhaps use shared code from readRowsImpl.
 export function prettyPrintRequest(
   request: protos.google.bigtable.v2.IReadRowsRequest
 ) {

--- a/test/utils/readRowsImpl.ts
+++ b/test/utils/readRowsImpl.ts
@@ -28,6 +28,10 @@ export function debugLog(text: string) {
   }
 }
 
+// Generate documentation for this function
+/** Pretty prints the request object.
+ * @param request The request object to pretty print.
+ */
 export function prettyPrintRequest(
   request: protos.google.bigtable.v2.IReadRowsRequest
 ) {

--- a/test/utils/readRowsImpl.ts
+++ b/test/utils/readRowsImpl.ts
@@ -79,16 +79,12 @@ export function prettyPrintRequest(
  * in the range [keyFrom, keyTo).
  */
 function generateChunks(chunkGeneratorParameters: ChunkGeneratorParameters) {
-  debugLog(
-    `generating chunks from ${chunkGeneratorParameters.keyFrom} to ${chunkGeneratorParameters.keyTo}`
-  );
+  const keyFrom = chunkGeneratorParameters.keyFrom;
+  const keyTo = chunkGeneratorParameters.keyTo;
+  debugLog(`generating chunks from ${keyFrom} to ${keyTo}`);
 
   const chunks: protos.google.bigtable.v2.ReadRowsResponse.ICellChunk[] = [];
-  for (
-    let key = chunkGeneratorParameters.keyFrom;
-    key < chunkGeneratorParameters.keyTo;
-    ++key
-  ) {
+  for (let key = keyFrom; key < keyTo; ++key) {
     // the keys must be increasing, but we also want to keep them readable,
     // so we'll use keys 00000000, 00000001, 00000002, etc. stored as Buffers
     const binaryKey = Buffer.from(key.toString().padStart(8, '0'));
@@ -123,9 +119,7 @@ function generateChunks(chunkGeneratorParameters: ChunkGeneratorParameters) {
       ++chunkCounter;
     }
   }
-  debugLog(
-    `generated ${chunks.length} chunks between ${chunkGeneratorParameters.keyFrom} and ${chunkGeneratorParameters.keyTo}`
-  );
+  debugLog(`generated ${chunks.length} chunks between ${keyFrom} and ${keyTo}`);
   return chunks;
 }
 

--- a/test/utils/readRowsImpl.ts
+++ b/test/utils/readRowsImpl.ts
@@ -29,7 +29,8 @@ export function debugLog(text: string) {
   }
 }
 
-function prettyPrintRequest(
+// TODO: Simplify this, perhaps use shared code from readRowsImpl.
+export function prettyPrintRequest(
   request: protos.google.bigtable.v2.IReadRowsRequest
 ) {
   // pretty-printing important parts of the request.

--- a/test/utils/readRowsImpl.ts
+++ b/test/utils/readRowsImpl.ts
@@ -20,8 +20,6 @@ import {
   ReadRowsServiceParameters,
 } from './readRowsServiceParameters';
 
-const CHUNK_PER_RESPONSE = 10;
-
 const DEBUG = process.env.BIGTABLE_TEST_DEBUG === 'true';
 
 export function debugLog(text: string) {
@@ -261,7 +259,7 @@ export function readRowsImpl(
         ++chunkIdx;
       }
       if (
-        currentResponseChunks.length === CHUNK_PER_RESPONSE ||
+        currentResponseChunks.length === serviceParameters.chunksPerResponse ||
         chunkIdx === errorAfterChunkNo ||
         // if we skipped a row and set lastScannedRowKey, dump everything and send a separate message with lastScannedRowKey
         lastScannedRowKey

--- a/test/utils/readRowsImpl.ts
+++ b/test/utils/readRowsImpl.ts
@@ -78,6 +78,7 @@ export function prettyPrintRequest(
 /** Generates chunks for rows in a fake table that match the provided RowSet.
  * The fake table contains monotonically increasing zero padded rows
  * in the range [keyFrom, keyTo).
+ * @param chunkGeneratorParameters The parameters for generating chunks.
  */
 function generateChunks(chunkGeneratorParameters: ChunkGeneratorParameters) {
   const keyFrom = chunkGeneratorParameters.keyFrom;

--- a/test/utils/readRowsImpl2.ts
+++ b/test/utils/readRowsImpl2.ts
@@ -15,6 +15,7 @@
 import {ServerWritableStream} from '@grpc/grpc-js';
 import {protos} from '../../src';
 import {GoogleError, Status} from 'google-gax';
+import {prettyPrintRequest} from './readRowsImpl';
 
 const VALUE_SIZE = 1;
 // we want each row to be splitted into 2 chunks of different sizes
@@ -27,50 +28,6 @@ export function debugLog(text: string) {
   if (DEBUG) {
     console.log(text);
   }
-}
-
-// TODO: Simplify this, perhaps use shared code from readRowsImpl.
-function prettyPrintRequest(
-  request: protos.google.bigtable.v2.IReadRowsRequest
-) {
-  // pretty-printing important parts of the request.
-  // doing it field by field because we want to apply .toString() to all key fields
-  debugLog('received request: {');
-  debugLog(`  tableName: "${request.tableName}",`);
-  if (request.rows) {
-    debugLog('  rows: {');
-    if (request.rows.rowKeys) {
-      debugLog('    rowKeys: [');
-      for (const key of request.rows.rowKeys) {
-        debugLog(`      "${key.toString()}",`);
-      }
-      debugLog('    ],');
-    }
-    if (request.rows.rowRanges) {
-      debugLog('    rowRanges: [');
-      for (const range of request.rows.rowRanges) {
-        debugLog('      {');
-        if (range.startKeyOpen) {
-          debugLog(`        startKeyOpen: "${range.startKeyOpen.toString()}",`);
-        }
-        if (range.startKeyClosed) {
-          debugLog(
-            `        startKeyClosed: "${range.startKeyClosed.toString()}",`
-          );
-        }
-        if (range.endKeyOpen) {
-          debugLog(`        endKeyOpen: "${range.endKeyOpen.toString()}",`);
-        }
-        if (range.endKeyClosed) {
-          debugLog(`        endKeyClosed: "${range.endKeyClosed.toString()}",`);
-        }
-        debugLog('      },');
-      }
-      debugLog('    ],');
-    }
-    debugLog('  },');
-  }
-  debugLog('}');
 }
 
 /** Generates chunks for rows in a fake table that match the provided RowSet.

--- a/test/utils/readRowsServiceParameters.ts
+++ b/test/utils/readRowsServiceParameters.ts
@@ -16,18 +16,19 @@
  * This file contains the parameters for the readRowsService.
  */
 
-export interface ReadRowsServiceParameters {
-  keyFrom: number;
-  keyTo: number;
-  errorAfterChunkNo?: number;
-  chunkSize: number;
-  valueSize: number;
-  chunksPerResponse: number;
+interface SharedReadRowsParameters {
+  chunkSize: number; // The size of each chunk that the server pushes back
+  valueSize: number; // An upper bound on the amount of data included in the chunks
 }
 
-export interface ChunkGeneratorParameters {
-  keyFrom: number;
-  keyTo: number;
-  chunkSize: number;
-  valueSize: number;
+export interface ReadRowsServiceParameters extends SharedReadRowsParameters {
+  keyFrom?: number; // The key the data coming from the service will start from
+  keyTo?: number; // The key the data coming from the service will end at
+  errorAfterChunkNo?: number; // The chunk that the error should come after
+  chunksPerResponse: number; // The total number of chunks the server should send
+}
+
+export interface ChunkGeneratorParameters extends SharedReadRowsParameters {
+  keyFrom: number; // The first row in the generated chunks will start with this key
+  keyTo: number; // The last row in the generated chunks will start with this key
 }

--- a/test/utils/readRowsServiceParameters.ts
+++ b/test/utils/readRowsServiceParameters.ts
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/**
+ * This file contains the parameters for the readRowsService.
+ */
+
 export interface ReadRowsServiceParameters {
   keyFrom: number;
   keyTo: number;

--- a/test/utils/readRowsServiceParameters.ts
+++ b/test/utils/readRowsServiceParameters.ts
@@ -1,3 +1,17 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 export interface ReadRowsServiceParameters {
   keyFrom: number;
   keyTo: number;

--- a/test/utils/readRowsServiceParameters.ts
+++ b/test/utils/readRowsServiceParameters.ts
@@ -1,0 +1,15 @@
+export interface ReadRowsServiceParameters {
+  keyFrom: number;
+  keyTo: number;
+  errorAfterChunkNo?: number;
+  chunkSize: number;
+  valueSize: number;
+  chunksPerResponse: number;
+}
+
+export interface ChunkGeneratorParameters {
+  keyFrom: number;
+  keyTo: number;
+  chunkSize: number;
+  valueSize: number;
+}

--- a/test/utils/readRowsServiceParameters.ts
+++ b/test/utils/readRowsServiceParameters.ts
@@ -22,8 +22,8 @@ interface SharedReadRowsParameters {
 }
 
 export interface ReadRowsServiceParameters extends SharedReadRowsParameters {
-  keyFrom?: number; // The key the data coming from the service will start from
-  keyTo?: number; // The key the data coming from the service will end at
+  keyFrom: number; // The key the data coming from the service will start from
+  keyTo: number; // The key the data coming from the service will end at
   errorAfterChunkNo?: number; // The chunk that the error should come after
   chunksPerResponse: number; // The total number of chunks the server should send
 }


### PR DESCRIPTION
**Summary:**

The ultimate goal is to address the TODOs mentioned in https://github.com/googleapis/nodejs-bigtable/blob/34d138dc5424f428d9569e62c0d05f6443dd63c4/test/utils/readRowsImpl2.ts#L161-L163. That is, we want to make the ReadRows mock service more modular and first there should ideally just be one copy of it. This PR contains initial steps towards that goal with the intent of merging more PRs in the future to arrive at a more modular mock service that is unit tested.

We are going to stack PRs onto [this branch](https://github.com/googleapis/nodejs-bigtable/tree/3527322442-to-main) and then make one final merge into main.

**Plan:**

Currently there are 2 ReadRows mock services with a bunch of code that is duplicated. Before we address the excessive amount of if statements we need to take steps to eliminate similar services `ReadRowsImpl1` and `ReadRowsImpl2`. And before we eliminate duplicate code in `ReadRowsImpl` and `ReadRowsImpl2` we should take some basic steps toward trying to eliminate `ReadRowsImpl2` entirely by allowing for additional configurations to be made to `ReadRowsImpl` so that it can be reused.

**In this PR:**

1. Change the existing mock service so that it accepts parameters for chunk size, value size and chunks per response and pass these parameters in each time a service is defined. The two services `ReadRowsImpl`, `ReadRowsImpl2` each rely on a different set of constants for chunk size, value size and chunks per response. Allowing them to be configurable in `ReadRowsImpl` generalizes `ReadRowsImpl` and is one step toward our plan of replacing `ReadRowsImpl2` with a generalized version of `ReadRowsImpl`.
2. To achieve 1 without having functions with 3+ parameters which is bad engineering practice we need to create new interfaces `ReadRowsServiceParameters` and `ChunkGeneratorParameters` so that `readRowsImpl` and  `generateChunks` only need one parameter passed in.
3. In the tests we define `const keyFrom = 0;` and `const keyTo = 1000;` many times and we can just rely on a constant for these defined at the top of the file.
4. We begin to trim code from `ReadRowsImpl2` by removing `prettyPrintRequest` because it is an exact duplicate of the `prettyPrintRequest` function in `ReadRowsImpl`.

**Next steps:**

1. Eliminate more duplicate code in `ReadRowsImpl2`.
2. Try to replace all usages of `ReadRowsImpl2` with a generalized version of `ReadRowsImpl`.
3. Address issue with too many `if` statements in `ReadRowsImpl`. Introduce classes, generate unit tests, make the service more modular.