### PR TITLE
fix: Update last row key in write function of user stream to avoid data loss and data duplication

### DIFF
--- a/src/table.ts
+++ b/src/table.ts
@@ -775,6 +775,16 @@ Please use the format 'prezzy' or '${instance.name}/tables/prezzy'.`);
         encodingOrCb?: BufferEncoding | ((error?: Error | null) => void),
         callback?: (error?: Error | null) => void
       ) {
+        /*
+        The last row key and rowsRead should be updated here because it is the
+        earliest point in the stream pipeline that a row is guaranteed to reach
+        the user. If this update is done further downstream then there is a
+        chance that a row makes it far enough to reach the user, but is
+        re-requested and causes data duplication because it has not updated the
+        lastRowKey yet. If this update is done further upstream then the
+        lastRowKey might get updated and then the row might get thrown away
+        causing data loss.
+         */
         lastRowKey = row.id;
         rowsRead++;
         if (callback) {

--- a/src/table.ts
+++ b/src/table.ts
@@ -772,16 +772,7 @@ Please use the format 'prezzy' or '${instance.name}/tables/prezzy'.`);
         });
       }
       write(
-        chunk: any,
-        encoding?: BufferEncoding,
-        cb?: (error: Error | null | undefined) => void
-      ): boolean;
-      write(
-        chunk: any,
-        cb?: (error: Error | null | undefined) => void
-      ): boolean;
-      write(
-        row: any, // TODO: Remove any
+        row: Row,
         encodingOrCb?: BufferEncoding | WriteCallback,
         callback?: WriteCallback
       ) {

--- a/src/table.ts
+++ b/src/table.ts
@@ -755,8 +755,7 @@ Please use the format 'prezzy' or '${instance.name}/tables/prezzy'.`);
     let lastRowKey = '';
     let rowsRead = 0;
 
-    type WriteCallback = (error?: Error | null) => void;
-    class UserStream extends Transform {
+    const userStream = new (class extends Transform {
       constructor() {
         super({
           objectMode: true,
@@ -773,18 +772,17 @@ Please use the format 'prezzy' or '${instance.name}/tables/prezzy'.`);
       }
       write(
         row: Row,
-        encodingOrCb?: BufferEncoding | WriteCallback,
-        callback?: WriteCallback
+        encodingOrCb?: BufferEncoding | ((error?: Error | null) => void),
+        callback?: (error?: Error | null) => void
       ) {
         lastRowKey = row.id;
         rowsRead++;
         if (callback) {
           return super.write(row, encodingOrCb as BufferEncoding, callback);
         }
-        return super.write(row, encodingOrCb as WriteCallback);
+        return super.write(row, encodingOrCb as (error?: Error | null) => void);
       }
-    }
-    const userStream = new UserStream() as Transform;
+    })() as Transform;
 
     // The caller should be able to call userStream.end() to stop receiving
     // more rows and cancel the stream prematurely. But also, the 'end' event

--- a/src/table.ts
+++ b/src/table.ts
@@ -785,26 +785,6 @@ Please use the format 'prezzy' or '${instance.name}/tables/prezzy'.`);
       }
     }
     const userStream = new UserStream() as Transform;
-    /*
-    const userStream = new PassThrough({
-      objectMode: true,
-      readableHighWaterMark: 0, // We need to disable readside buffering to allow for acceptable behavior when the end user cancels the stream early.
-      writableHighWaterMark: 0, // We need to disable writeside buffering because in nodejs 14 the call to _transform happens after write buffering. This creates problems for tracking the last seen row key.
-      transform(row, _encoding, callback) {
-        if (userCanceled) {
-          callback();
-          return;
-        }
-        if (TableUtils.lessThanOrEqualTo(row.id, lastRowKey)) {
-          callback();
-          return;
-        }
-        lastRowKey = row.id;
-        rowsRead++;
-        callback(null, row);
-      },
-    });
-    */
 
     // The caller should be able to call userStream.end() to stop receiving
     // more rows and cancel the stream prematurely. But also, the 'end' event

--- a/test/readrows.ts
+++ b/test/readrows.ts
@@ -368,7 +368,7 @@ describe('Bigtable/ReadRows', () => {
       }
     })();
   });
-  it.only('should return row data in the right order with a predictable sleep function', done => {
+  it('should return row data in the right order with a predictable sleep function', done => {
     // 150 rows must be enough to reproduce issues with losing the data and to create backpressure
     const keyFrom = undefined;
     const keyTo = undefined;

--- a/test/readrows.ts
+++ b/test/readrows.ts
@@ -375,7 +375,7 @@ describe('Bigtable/ReadRows', () => {
     // the server will error after sending this chunk (not row)
     const errorAfterChunkNo = 100;
     const dataResults = [];
-    
+
     service.setService({
       ReadRows: readRowsImpl2(
         keyFrom,

--- a/test/readrows.ts
+++ b/test/readrows.ts
@@ -408,7 +408,7 @@ describe('Bigtable/ReadRows', () => {
 
         for await (const row of stream) {
           dataResults.push(row.id);
-          // sleep parameter needs to be high enough to produce an error.
+          // sleep parameter needs to be high enough to produce backpressure.
           await sleep(4000);
         }
         const expectedResults = Array.from(Array(150).keys())

--- a/test/readrows.ts
+++ b/test/readrows.ts
@@ -368,7 +368,8 @@ describe('Bigtable/ReadRows', () => {
       }
     })();
   });
-  it('should return row data in the right order with a predictable sleep function', done => {
+  it.only('should return row data in the right order with a predictable sleep function', function (done) {
+    this.timeout(600000);
     const keyFrom = undefined;
     const keyTo = undefined;
     // the server will error after sending this chunk (not row)

--- a/test/readrows.ts
+++ b/test/readrows.ts
@@ -369,7 +369,6 @@ describe('Bigtable/ReadRows', () => {
     })();
   });
   it('should return row data in the right order with a predictable sleep function', done => {
-    // 150 rows must be enough to reproduce issues with losing the data and to create backpressure
     const keyFrom = undefined;
     const keyTo = undefined;
     // the server will error after sending this chunk (not row)
@@ -401,6 +400,7 @@ describe('Bigtable/ReadRows', () => {
     };
     (async () => {
       try {
+        // 150 rows must be enough to reproduce issues with losing the data and to create backpressure
         const stream = table.createReadStream({
           start: '00000000',
           end: '00000150',

--- a/test/readrows.ts
+++ b/test/readrows.ts
@@ -384,14 +384,14 @@ describe('Bigtable/ReadRows', () => {
         errorAfterChunkNo
       ) as ServerImplementationInterface,
     });
-    const sleep = (ms: number) => {
+    const sleep = (ticks: number) => {
       return new Promise(resolve => {
         const nextEventLoop = () => {
-          if (ms > 0) {
-            ms = ms - 1;
+          if (ticks > 0) {
+            ticks = ticks - 1;
             setImmediate(nextEventLoop);
           } else {
-            resolve(ms);
+            resolve(ticks);
           }
         };
         nextEventLoop();
@@ -406,7 +406,8 @@ describe('Bigtable/ReadRows', () => {
 
         for await (const row of stream) {
           dataResults.push(row.id);
-          await sleep(10000);
+          // sleep parameter needs to be high enough to produce an error.
+          await sleep(4000);
         }
         const expectedResults = Array.from(Array(150).keys())
           .map(i => '00000000' + i.toString())

--- a/test/readrows.ts
+++ b/test/readrows.ts
@@ -384,6 +384,9 @@ describe('Bigtable/ReadRows', () => {
       ) as ServerImplementationInterface,
     });
     const sleep = (ticks: number) => {
+      // Adds an event to the end of the event loop `ticks` times
+      // This creates a predictable delay using the event loop and
+      // allows the streams to create a predictable amount of back pressure.
       return new Promise(resolve => {
         const nextEventLoop = () => {
           if (ticks > 0) {

--- a/test/readrows.ts
+++ b/test/readrows.ts
@@ -368,7 +368,7 @@ describe('Bigtable/ReadRows', () => {
       }
     })();
   });
-  it.only('should return row data in the right order with a predictable sleep function', function (done) {
+  it('should return row data in the right order with a predictable sleep function', function (done) {
     this.timeout(600000);
     const keyFrom = undefined;
     const keyTo = undefined;

--- a/test/readrows.ts
+++ b/test/readrows.ts
@@ -375,8 +375,7 @@ describe('Bigtable/ReadRows', () => {
     // the server will error after sending this chunk (not row)
     const errorAfterChunkNo = 100;
     const dataResults = [];
-
-    // TODO: Do not use `any` here, make it a more specific type and address downstream implications on the mock server.
+    
     service.setService({
       ReadRows: readRowsImpl2(
         keyFrom,


### PR DESCRIPTION
**Summary:**

This PR offers a long term fix ensuring that when retryable errors occur that the user will not experience data loss nor will duplicate data be delivered to them. It replaces the patch that is currently in place that is preventing data duplication.

**Background**

In [this PR](https://github.com/googleapis/nodejs-bigtable/pull/1444) a fix was applied to prevent data loss in the client for readRows calls. Data duplication was also mostly addressed by adjusting watermarks except for a special case that occurred from time to time in Node v14. The patch in [this PR](https://github.com/googleapis/nodejs-bigtable/pull/1453) was then applied to ensure the user didn't receive duplicate data by throwing away duplicate data just before it reached the user. Throwing away the duplicate data solves the problem, but it isn't the best permanent solution because it involves two changes to solve just one fundamental problem. This current PR replaces the patch with a simpler change that will also solve the data duplication and data loss issues.

**Root cause analysis**

While investigating the issue it was found that duplicated data was delivered when a row made it to the write function of the user stream, but not to the transform function of the user stream when the retry request was being formed. It was being stored [here](https://github.com/nodejs/node/blob/v14.x/lib/internal/streams/transform.js#L186) in the stream waiting to be processed by transform. Since the transform function was where the last row key was being updated and this hadn't happened yet for the row, the row was re-requested. By pushing the row key update back to the write function we ensure the row doesn't get re-requested.

**Changes**

- The old test for data duplication would only fail sometimes on Node v14. This PR adds a test that always fails on Node v14 when the patch isn't in place. This will make it easier to detect data duplication and data loss if it ever happens again
- Moved the lastRowKey and rowsRead updates to the write function instead of the transform function. When observing the call stack we can see that the emit function of the row stream directly calls the write function in the user stream demonstrating that the write function is the earliest point in time the row is guaranteed to make it to the user and therefore is where the update should occur.
- Removed the patch in the user stream transform function as it is no longer required there.

**Alternatives considered**

Instead of overriding write we could pass in a write function to the constructor, but we don't want to do that because it will override [_write](https://github.com/nodejs/node/blob/e9e68b942d2242de7f8ef7697cf5f62dd5f325d6/lib/internal/streams/transform.js#L183) and stop calling `_transform` if the Transform is ready for reading. Other options in the `Transform` constructor don't allow us to achieve our goal of updating the last row key earlier. Therefore, overriding write is our best option.