### PR TITLE
feat: Create a view on the instance, not on the table

### DIFF
--- a/src/authorized-view.ts
+++ b/src/authorized-view.ts
@@ -28,6 +28,7 @@ import {RowDataUtils, RowProperties} from './row-data-utils';
 import {RawFilter} from './filter';
 import {Table} from './table';
 import {Family} from './chunktransformer';
+import {Instance} from './instance';
 
 interface FilterInformation {
   filter: RawFilter;
@@ -56,8 +57,8 @@ interface IncrementInformation {
 export class AuthorizedView extends TabularApiSurface {
   private readonly rowData: {[id: string]: {[index: string]: Family}};
 
-  constructor(table: Table, viewName: string) {
-    super(table.instance, table.id, viewName);
+  constructor(instance: Instance, tableName: string, viewName: string) {
+    super(instance, tableName, viewName);
     this.rowData = {};
   }
 

--- a/src/authorized-view.ts
+++ b/src/authorized-view.ts
@@ -26,7 +26,6 @@ import {
 } from './row';
 import {RowDataUtils, RowProperties} from './row-data-utils';
 import {RawFilter} from './filter';
-import {Table} from './table';
 import {Family} from './chunktransformer';
 import {Instance} from './instance';
 

--- a/src/instance.ts
+++ b/src/instance.ts
@@ -1480,6 +1480,7 @@ Please use the format 'my-instance' or '${bigtable.projectName}/instances/my-ins
   /**
    * Gets an Authorized View object for making authorized view grpc calls.
    *
+   * @param {string} tableName The name for the Table
    * @param {string} viewName The name for the Authorized view
    */
   view(tableName: string, viewName: string): AuthorizedView {

--- a/src/instance.ts
+++ b/src/instance.ts
@@ -68,6 +68,7 @@ import {Bigtable} from '.';
 import {google} from '../protos/protos';
 import {Backup, RestoreTableCallback, RestoreTableResponse} from './backup';
 import {ClusterUtils} from './utils/cluster';
+import {AuthorizedView} from './authorized-view';
 
 export interface ClusterInfo extends BasicClusterConfig {
   id: string;
@@ -1474,6 +1475,15 @@ Please use the format 'my-instance' or '${bigtable.projectName}/instances/my-ins
         callback!(null, resp.permissions);
       }
     );
+  }
+
+  /**
+   * Gets an Authorized View object for making authorized view grpc calls.
+   *
+   * @param {string} viewName The name for the Authorized view
+   */
+  view(tableName: string, viewName: string): AuthorizedView {
+    return new AuthorizedView(this, tableName, viewName);
   }
 }
 

--- a/src/table.ts
+++ b/src/table.ts
@@ -1164,15 +1164,6 @@ export class Table extends TabularApiSurface {
     );
   }
 
-  /**
-   * Gets an Authorized View object for making authorized view grpc calls.
-   *
-   * @param {string} viewName The name for the Authorized view
-   */
-  view(viewName: string): AuthorizedView {
-    return new AuthorizedView(this, viewName);
-  }
-
   waitForReplication(): Promise<WaitForReplicationResponse>;
   waitForReplication(callback: WaitForReplicationCallback): void;
   /**


### PR DESCRIPTION
**Summary:**

This PR is being added to address a recent minor change suggested in the [design document for Bigtable Authorized Views](https://docs.google.com/document/d/19mUJn_OIGH366n3lh17NujW7gAgqWHyDPN2xziMwQkY/edit?resourcekey=0-OTnuVDgx6lSCbCzTJBqqMw&tab=t.0#heading=h.xzptrog8pyxf). To support future feature work, the views should be decoupled from tables and therefore created using a Bigtable instance object instead of a table object.

**Background:**

This PR is part of a series of PRs for introducing the Bigtable Authorized Views feature. So far [this PR](https://github.com/googleapis/nodejs-bigtable/pull/1464) and [this PR](https://github.com/googleapis/nodejs-bigtable/pull/1463) have been merged.

**Changes**

1. Add the `view` method to `Instance`.
2. Remove the `view` method from `Table`.
3. Modify the authorized view constructor not to require the whole table

**Next Steps**

(Verbatim from the previous PR)
1. Write some tests that use the new `increment`, `createRules` and `filter` methods now available on `AuthorizedView`. Make sure that these methods pass the proper parameters along and that they target an authorized view.
2. Write a PR for supporting authorized views calls for all methods of the `TabularApiSurface` class.