### PR TITLE
test: Add tests and comments to better document `any` typed data structures

### DIFF
--- a/src/mutation.ts
+++ b/src/mutation.ts
@@ -25,6 +25,24 @@ export type ISetCell = btTypes.bigtable.v2.Mutation.ISetCell;
 export type Bytes = string | Buffer;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type Data = any;
+/*
+The Data type is expected to be in the following format:
+{
+  columnFamily1: {
+    column1: Cell,
+    column2: Cell
+  },
+  columnFamily2: {
+    otherColumn1: Cell,
+    otherColumn2: Cell
+  }
+}
+Where the Cell data type has the following structure:
+Uint8Array | string | {
+  value: Uint8Array|string,
+  timestamp: number|Long|string,
+}
+*/
 export interface JsonObj {
   [k: string]: string | JsonObj;
 }

--- a/src/table.ts
+++ b/src/table.ts
@@ -287,15 +287,14 @@ export interface MutateOptions {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type Entry = any;
-// TODO: Check these types
 /*
 The Entry type is expected to be in the following format:
 {
   columnFamily: {
-    column: string | number | { value: string | number, timestamp: number}
+    column: Data // Data is the expected type passed into Mutation.encodeSetCell
   }
 }
- */
+*/
 
 export type DeleteTableCallback = (
   err: ServiceError | null,

--- a/src/table.ts
+++ b/src/table.ts
@@ -287,6 +287,15 @@ export interface MutateOptions {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type Entry = any;
+// TODO: Check these types
+/*
+The Entry type is expected to be in the following format:
+{
+  columnFamily: {
+    column: string | number | { value: string | number, timestamp: number}
+  }
+}
+ */
 
 export type DeleteTableCallback = (
   err: ServiceError | null,

--- a/system-test/bigtable.ts
+++ b/system-test/bigtable.ts
@@ -1712,6 +1712,36 @@ describe('Bigtable', () => {
       });
     });
   });
+
+  describe('mutate', () => {
+    const table = INSTANCE.table(generateId('table'));
+    beforeEach(async () => {
+      const tableOptions = {
+        families: ['follows'],
+      };
+      const rows = [
+        {
+          key: 'alincoln',
+          data: {
+            follows: {
+              jadams: 1,
+            },
+          },
+        },
+      ];
+      await table.create(tableOptions);
+      await table.insert(rows);
+    });
+
+    afterEach(async () => {
+      await table.delete();
+    });
+
+    it('should get one row from the table', async () => {
+      const [rows] = await table.getRows();
+      assert.strictEqual(rows.length, 1);
+    });
+  });
 });
 
 function createInstanceConfig(

--- a/system-test/bigtable.ts
+++ b/system-test/bigtable.ts
@@ -33,6 +33,7 @@ import {Row} from '../src/row.js';
 import {Table} from '../src/table.js';
 import {RawFilter} from '../src/filter';
 import {generateId, PREFIX} from './common';
+import {Mutation} from '../src/mutation';
 
 describe.only('Bigtable', () => {
   const bigtable = new Bigtable();
@@ -1719,18 +1720,22 @@ describe.only('Bigtable', () => {
       const tableOptions = {
         families: ['follows'],
       };
-      const rows = [
-        {
-          key: 'alincoln',
-          data: {
-            follows: {
-              jadams: 1,
-            },
+      const entry = {
+        key: 'alincoln',
+        data: {
+          follows: {
+            tjefferson: 1,
           },
         },
-      ];
+      };
+      const mutation = {
+        key: 'some-id',
+        data: entry,
+        method: Mutation.methods.INSERT,
+      };
       await table.create(tableOptions);
-      await table.insert(rows);
+      const gaxOptions = {maxRetries: 4};
+      await table.mutate(mutation, {gaxOptions});
     });
 
     afterEach(async () => {

--- a/system-test/bigtable.ts
+++ b/system-test/bigtable.ts
@@ -122,1597 +122,1597 @@ describe.only('Bigtable', () => {
     );
   });
 
-  // describe('instances', () => {
-  //   it('should get a list of instances', async () => {
-  //     const [instances, failedLocations] = await bigtable.getInstances();
-  //     assert(instances.length > 0);
-  //     assert(Array.isArray(failedLocations));
-  //   });
-  //
-  //   it('should check if an instance exists', async () => {
-  //     const [exists] = await INSTANCE.exists();
-  //     assert.strictEqual(exists, true);
-  //   });
-  //
-  //   it('should check if an instance does not exist', async () => {
-  //     const instance = bigtable.instance('fake-instance');
-  //     const [exists] = await instance.exists();
-  //     assert.strictEqual(exists, false);
-  //   });
-  //
-  //   it('should get a single instance', async () => {
-  //     await INSTANCE.get();
-  //   });
-  //
-  //   it('should update an instance', async () => {
-  //     const metadata = {
-  //       displayName: 'metadata-test',
-  //     };
-  //     await INSTANCE.setMetadata(metadata);
-  //     const [metadata_] = await INSTANCE.getMetadata();
-  //     assert.strictEqual(metadata.displayName, metadata_.displayName);
-  //   });
-  //
-  //   it('should get an Iam Policy for the instance', async () => {
-  //     const policyProperties = ['version', 'bindings', 'etag'];
-  //     const [policy] = await INSTANCE.getIamPolicy();
-  //     policyProperties.forEach(property => {
-  //       assert(property in policy);
-  //     });
-  //   });
-  //
-  //   it('should test Iam permissions for the instance', async () => {
-  //     const permissions = ['bigtable.tables.get', 'bigtable.tables.readRows'];
-  //     const [grantedPermissions] =
-  //       await INSTANCE.testIamPermissions(permissions);
-  //     assert.strictEqual(grantedPermissions.length, permissions.length);
-  //     permissions.forEach(permission => {
-  //       assert.strictEqual(grantedPermissions.includes(permission), true);
-  //     });
-  //   });
-  //
-  //   it('should set Iam Policy on the instance', async () => {
-  //     const instance = bigtable.instance(generateId('instance'));
-  //     const clusteId = generateId('cluster');
-  //     const [, operation] = await instance.create({
-  //       clusters: [
-  //         {
-  //           id: clusteId,
-  //           location: 'us-central1-c',
-  //           nodes: 3,
-  //         },
-  //       ],
-  //       labels: {
-  //         time_created: Date.now(),
-  //       },
-  //     });
-  //     await operation.promise();
-  //
-  //     const [policy] = await instance.getIamPolicy();
-  //     const [updatedPolicy] = await instance.setIamPolicy(policy);
-  //     Object.keys(policy).forEach(key => assert(key in updatedPolicy));
-  //
-  //     await instance.delete();
-  //   });
-  // });
-  //
-  // describe('CMEK', () => {
-  //   let kmsKeyName: string;
-  //
-  //   const CMEK_CLUSTER = CMEK_INSTANCE.cluster(generateId('cluster'));
-  //
-  //   const cryptoKeyId = generateId('key');
-  //   const keyRingId = generateId('key-ring');
-  //   let keyRingsBaseUrl: string;
-  //   let cryptoKeyVersionName: string;
-  //
-  //   before(async () => {
-  //     const projectId = await bigtable.auth.getProjectId();
-  //     kmsKeyName = `projects/${projectId}/locations/us-central1/keyRings/${keyRingId}/cryptoKeys/${cryptoKeyId}`;
-  //     keyRingsBaseUrl = `https://cloudkms.googleapis.com/v1/projects/${projectId}/locations/us-central1/keyRings`;
-  //
-  //     await bigtable.auth.request({
-  //       method: 'POST',
-  //       url: keyRingsBaseUrl,
-  //       params: {keyRingId},
-  //     });
-  //
-  //     const resp = await bigtable.auth.request({
-  //       method: 'POST',
-  //       url: `${keyRingsBaseUrl}/${keyRingId}/cryptoKeys`,
-  //       params: {cryptoKeyId},
-  //       data: {purpose: 'ENCRYPT_DECRYPT'},
-  //     });
-  //     cryptoKeyVersionName = resp.data.primary.name;
-  //
-  //     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  //     const [_, operation] = await CMEK_INSTANCE.create({
-  //       clusters: [
-  //         {
-  //           id: CMEK_CLUSTER.id,
-  //           location: 'us-central1-a',
-  //           nodes: 3,
-  //           key: kmsKeyName,
-  //         },
-  //       ],
-  //       labels: {
-  //         time_created: Date.now(),
-  //       },
-  //     });
-  //     await operation.promise();
-  //   });
-  //
-  //   after(async () => {
-  //     await bigtable.auth.request({
-  //       method: 'POST',
-  //       url: `${keyRingsBaseUrl}/${keyRingId}/cryptoKeys/${cryptoKeyId}/cryptoKeyVersions/${cryptoKeyVersionName
-  //         .split('/')
-  //         .pop()}:destroy`,
-  //       params: {name: cryptoKeyVersionName},
-  //     });
-  //   });
-  //
-  //   it('should have created an instance', async () => {
-  //     const [metadata] = await CMEK_CLUSTER.getMetadata();
-  //     assert.deepStrictEqual(metadata.encryptionConfig, {kmsKeyName});
-  //   });
-  //
-  //   it('should create a cluster', async () => {
-  //     const cluster = CMEK_INSTANCE.cluster(generateId('cluster'));
-  //
-  //     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  //     const [_, operation] = await cluster.create({
-  //       location: 'us-central1-b',
-  //       nodes: 3,
-  //       key: kmsKeyName,
-  //     });
-  //     await operation.promise();
-  //
-  //     const [metadata] = await cluster.getMetadata();
-  //     assert.deepStrictEqual(metadata.encryptionConfig, {kmsKeyName});
-  //   });
-  //
-  //   it('should fail if key not provided', async () => {
-  //     const cluster = CMEK_INSTANCE.cluster(generateId('cluster'));
-  //
-  //     try {
-  //       // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  //       const [_, operation] = await cluster.create({
-  //         location: 'us-central1-b',
-  //         nodes: 3,
-  //       });
-  //       await operation.promise();
-  //       throw new Error('Cluster creation should not have succeeded');
-  //     } catch (e) {
-  //       assert(
-  //         (e as Error).message.includes(
-  //           'default keys and CMEKs are not allowed'
-  //         )
-  //       );
-  //     }
-  //   });
-  // });
-  //
-  // describe('appProfiles', () => {
-  //   it('should retrieve a list of app profiles', async () => {
-  //     const [appProfiles] = await INSTANCE.getAppProfiles();
-  //     assert(appProfiles[0] instanceof AppProfile);
-  //     assert(appProfiles.length > 0);
-  //   });
-  //
-  //   it('should retrieve a list of app profiles in stream mode', done => {
-  //     const appProfiles: AppProfile[] = [];
-  //     INSTANCE.getAppProfilesStream()
-  //       .on('error', done)
-  //       .on('data', appProfile => {
-  //         assert(appProfile instanceof AppProfile);
-  //         appProfiles.push(appProfile);
-  //       })
-  //       .on('end', () => {
-  //         assert(appProfiles.length > 0);
-  //         done();
-  //       });
-  //   });
-  //
-  //   it('should check if an app profile exists', async () => {
-  //     const [exists] = await APP_PROFILE.exists();
-  //     assert.strictEqual(exists, true);
-  //   });
-  //
-  //   it('should check if an app profile does not exist', async () => {
-  //     const appProfile = INSTANCE.appProfile('should-not-exist');
-  //     const [exists] = await appProfile.exists();
-  //     assert.strictEqual(exists, false);
-  //   });
-  //
-  //   it('should get an app profile', async () => {
-  //     await APP_PROFILE.get();
-  //   });
-  //
-  //   it('should delete an app profile', async () => {
-  //     const appProfile = INSTANCE.appProfile(generateId('app-profile'));
-  //     await appProfile.create({
-  //       routing: 'any',
-  //       ignoreWarnings: true,
-  //     });
-  //     await appProfile.delete({ignoreWarnings: true});
-  //   });
-  //
-  //   it('should get the app profiles metadata', async () => {
-  //     const [metadata] = await APP_PROFILE.getMetadata();
-  //     assert.strictEqual(
-  //       metadata.name,
-  //       APP_PROFILE.name.replace('{{projectId}}', bigtable.projectId)
-  //     );
-  //   });
-  //
-  //   it('should update an app profile', async () => {
-  //     const cluster = INSTANCE.cluster(CLUSTER_ID);
-  //     const options = {
-  //       routing: cluster,
-  //       allowTransactionalWrites: true,
-  //       description: 'My Updated App Profile',
-  //     };
-  //     await APP_PROFILE.setMetadata(options);
-  //     const [updatedAppProfile] = await APP_PROFILE.get();
-  //     assert.strictEqual(
-  //       updatedAppProfile.metadata!.description,
-  //       options.description
-  //     );
-  //     assert.deepStrictEqual(updatedAppProfile.metadata!.singleClusterRouting, {
-  //       clusterId: CLUSTER_ID,
-  //       allowTransactionalWrites: true,
-  //     });
-  //   });
-  // });
-  //
-  // describe('clusters', () => {
-  //   let CLUSTER: Cluster;
-  //
-  //   beforeEach(() => {
-  //     CLUSTER = INSTANCE.cluster(CLUSTER_ID);
-  //   });
-  //
-  //   it('should retrieve a list of clusters', async () => {
-  //     const [clusters] = await INSTANCE.getClusters();
-  //     assert(clusters[0] instanceof Cluster);
-  //   });
-  //
-  //   it('should check if a cluster exists', async () => {
-  //     const [exists] = await CLUSTER.exists();
-  //     assert.strictEqual(exists, true);
-  //   });
-  //
-  //   it('should check if a cluster does not exist', async () => {
-  //     const cluster = INSTANCE.cluster('fake-cluster');
-  //     const [exists] = await cluster.exists();
-  //     assert.strictEqual(exists, false);
-  //   });
-  //
-  //   it('should get a cluster', async () => {
-  //     await CLUSTER.get();
-  //   });
-  //
-  //   it('should update a cluster', async () => {
-  //     const metadata = {
-  //       nodes: 4,
-  //     };
-  //     const [operation] = await CLUSTER.setMetadata(metadata);
-  //     await operation.promise();
-  //     const [_metadata] = await CLUSTER.getMetadata();
-  //     assert.strictEqual(metadata.nodes, _metadata.serveNodes);
-  //   });
-  // });
-  //
-  // describe('tables', () => {
-  //   it('should retrieve a list of tables', async () => {
-  //     const [tables] = await INSTANCE.getTables();
-  //     assert(tables[0] instanceof Table);
-  //   });
-  //
-  //   it('should retrieve a list of tables in stream mode', done => {
-  //     const tables: Table[] = [];
-  //     INSTANCE.getTablesStream()
-  //       .on('error', done)
-  //       .on('data', table => {
-  //         assert(table instanceof Table);
-  //         tables.push(table);
-  //       })
-  //       .on('end', () => {
-  //         assert(tables.length > 0);
-  //         done();
-  //       });
-  //   });
-  //
-  //   it('should check if a table exists', async () => {
-  //     const [exists] = await TABLE.exists();
-  //     assert.strictEqual(exists, true);
-  //   });
-  //
-  //   it('should check if a table does not exist', async () => {
-  //     const table = INSTANCE.table('should-not-exist');
-  //     const [exists] = await table.exists();
-  //     assert.strictEqual(exists, false);
-  //   });
-  //
-  //   it('should get a table', async () => {
-  //     await TABLE.get();
-  //   });
-  //
-  //   it('should get an Iam Policy for the table', async () => {
-  //     const policyProperties = ['version', 'bindings', 'etag'];
-  //     const [policy] = await TABLE.getIamPolicy();
-  //     policyProperties.forEach(property => {
-  //       assert(property in policy);
-  //     });
-  //   });
-  //
-  //   it('should test Iam permissions for the table', async () => {
-  //     const permissions = ['bigtable.tables.get', 'bigtable.tables.readRows'];
-  //     const [grantedPermissions] = await TABLE.testIamPermissions(permissions);
-  //     assert.strictEqual(grantedPermissions.length, permissions.length);
-  //     permissions.forEach(permission => {
-  //       assert.strictEqual(grantedPermissions.includes(permission), true);
-  //     });
-  //   });
-  //
-  //   it('should set Iam Policy on the table', async () => {
-  //     const table = INSTANCE.table(generateId('table'));
-  //     await table.create();
-  //
-  //     const [policy] = await table.getIamPolicy();
-  //     const [updatedPolicy] = await table.setIamPolicy(policy);
-  //     Object.keys(policy).forEach(key => assert(key in updatedPolicy));
-  //
-  //     await table.delete();
-  //   });
-  //
-  //   it('should delete a table', async () => {
-  //     const table = INSTANCE.table(generateId('table'));
-  //     await table.create();
-  //     await table.delete();
-  //   });
-  //
-  //   it('should get the tables metadata', async () => {
-  //     const [metadata] = await TABLE.getMetadata();
-  //     assert.strictEqual(
-  //       metadata.name,
-  //       TABLE.name.replace('{{projectId}}', bigtable.projectId)
-  //     );
-  //   });
-  //
-  //   it('should create a table with column family data', async () => {
-  //     const name = generateId('table');
-  //     const options = {
-  //       families: ['test'],
-  //     };
-  //     const [table] = await INSTANCE.createTable(name, options);
-  //     assert(table.metadata!.columnFamilies!.test);
-  //   });
-  //
-  //   it('should create a table if autoCreate is true', async () => {
-  //     const table = INSTANCE.table(generateId('table'));
-  //     await table.get({autoCreate: true});
-  //     await table.delete();
-  //   });
-  // });
-  //
-  // describe('consistency tokens', () => {
-  //   it('should generate consistency token', async () => {
-  //     const [token] = await TABLE.generateConsistencyToken();
-  //     assert.strictEqual(typeof token, 'string');
-  //   });
-  //
-  //   it('should return error for checkConsistency of invalid token', done => {
-  //     TABLE.checkConsistency('dummy-token', err => {
-  //       assert.strictEqual(err!.code, 3);
-  //       done();
-  //     });
-  //   });
-  //
-  //   it('should return boolean for checkConsistency of token', async () => {
-  //     const [token] = await TABLE.generateConsistencyToken();
-  //     const [res] = await TABLE.checkConsistency(token);
-  //     assert.strictEqual(typeof res, 'boolean');
-  //   });
-  //
-  //   it('should return boolean for waitForReplication', async () => {
-  //     const [res] = await TABLE.waitForReplication();
-  //     assert.strictEqual(typeof res, 'boolean');
-  //   });
-  // });
-  //
-  // describe('replication states', () => {
-  //   it('should get a map of clusterId and state', async () => {
-  //     const [clusterStates] = await TABLE.getReplicationStates();
-  //     assert(clusterStates instanceof Map);
-  //     assert(clusterStates.has(CLUSTER_ID));
-  //   });
-  // });
-  //
-  // describe('column families', () => {
-  //   const FAMILY_ID = 'presidents';
-  //   let FAMILY: Family;
-  //
-  //   before(async () => {
-  //     FAMILY = TABLE.family(FAMILY_ID);
-  //     await FAMILY.create();
-  //   });
-  //
-  //   it('should get a list of families', async () => {
-  //     const [families] = await TABLE.getFamilies();
-  //     assert.strictEqual(families.length, 3);
-  //     assert(families[0] instanceof Family);
-  //     assert.notStrictEqual(-1, families.map(f => f.id).indexOf(FAMILY.id));
-  //   });
-  //
-  //   it('should get a family', async () => {
-  //     const family = TABLE.family(FAMILY_ID);
-  //     await family.get();
-  //     assert(family instanceof Family);
-  //     assert.strictEqual(family.name, FAMILY.name);
-  //     assert.strictEqual(family.id, FAMILY.id);
-  //   });
-  //
-  //   it('should check if a family exists', async () => {
-  //     const [exists] = await FAMILY.exists();
-  //     assert.strictEqual(exists, true);
-  //   });
-  //
-  //   it('should check if a family does not exist', async () => {
-  //     const family = TABLE.family('prezzies');
-  //     const [exists] = await family.exists();
-  //     assert.strictEqual(exists, false);
-  //   });
-  //
-  //   it('should create a family if autoCreate is true', async () => {
-  //     const family = TABLE.family('prezzies');
-  //     await family.get({autoCreate: true});
-  //     await family.delete();
-  //   });
-  //
-  //   it('should create a family with nested gc rules', async () => {
-  //     const family = TABLE.family('prezzies');
-  //     const options = {
-  //       rule: {
-  //         union: true,
-  //         versions: 10,
-  //         rule: {
-  //           versions: 2,
-  //           age: {seconds: 60 * 60 * 24 * 30},
-  //         },
-  //       },
-  //     };
-  //     await family.create(options);
-  //     const [metadata] = await family.getMetadata();
-  //     assert.deepStrictEqual(metadata.gcRule, {
-  //       union: {
-  //         rules: [
-  //           {
-  //             maxNumVersions: 10,
-  //             rule: 'maxNumVersions',
-  //           },
-  //           {
-  //             intersection: {
-  //               rules: [
-  //                 {
-  //                   maxAge: {
-  //                     seconds: '2592000',
-  //                     nanos: 0,
-  //                   },
-  //                   rule: 'maxAge',
-  //                 },
-  //                 {
-  //                   maxNumVersions: 2,
-  //                   rule: 'maxNumVersions',
-  //                 },
-  //               ],
-  //             },
-  //             rule: 'intersection',
-  //           },
-  //         ],
-  //       },
-  //       rule: 'union',
-  //     });
-  //     await family.delete();
-  //   });
-  //
-  //   it('should get the column family metadata', async () => {
-  //     const [metadata] = await FAMILY.getMetadata();
-  //     assert.strictEqual(FAMILY.metadata, metadata);
-  //   });
-  //
-  //   it('should update a column family', async () => {
-  //     const rule = {
-  //       age: {
-  //         seconds: 10000,
-  //         nanos: 10000,
-  //       },
-  //     };
-  //     const [metadata] = await FAMILY.setMetadata({rule});
-  //     const maxAge = metadata.gcRule!.maxAge;
-  //     assert.strictEqual(maxAge!.seconds, rule.age.seconds.toString());
-  //     assert.strictEqual(maxAge!.nanos, rule.age.nanos);
-  //   });
-  //
-  //   it('should delete a column family', async () => {
-  //     await FAMILY.delete();
-  //   });
-  // });
-  //
-  // describe('rows', () => {
-  //   describe('.exists()', () => {
-  //     const row = TABLE.row('alincoln');
-  //
-  //     beforeEach(async () => {
-  //       await row.create({
-  //         entry: {
-  //           follows: {
-  //             gwashington: 1,
-  //             jadams: 1,
-  //             tjefferson: 1,
-  //           },
-  //         },
-  //       });
-  //     });
-  //
-  //     afterEach(async () => row.delete());
-  //
-  //     it('should check if a row exists', async () => {
-  //       const [exists] = await row.exists();
-  //       assert.strictEqual(exists, true);
-  //     });
-  //
-  //     it('should check if a row does not exist', async () => {
-  //       const row = TABLE.row('gwashington');
-  //       const [exists] = await row.exists();
-  //       assert.strictEqual(exists, false);
-  //     });
-  //   });
-  //
-  //   describe('inserting data', () => {
-  //     it('should insert rows', async () => {
-  //       const rows = [
-  //         {
-  //           key: 'gwashington',
-  //           data: {
-  //             follows: {
-  //               jadams: 1,
-  //             },
-  //           },
-  //         },
-  //         {
-  //           key: 'tjefferson',
-  //           data: {
-  //             follows: {
-  //               gwashington: 1,
-  //               jadams: 1,
-  //             },
-  //           },
-  //         },
-  //         {
-  //           key: 'jadams',
-  //           data: {
-  //             follows: {
-  //               gwashington: 1,
-  //               tjefferson: 1,
-  //             },
-  //           },
-  //         },
-  //       ];
-  //       await TABLE.insert(rows);
-  //     });
-  //
-  //     it('should insert a large row', async () => {
-  //       await TABLE.insert({
-  //         key: 'gwashington',
-  //         data: {
-  //           follows: {
-  //             jadams: Buffer.alloc(5000000),
-  //           },
-  //         },
-  //       });
-  //     });
-  //
-  //     it('should create an individual row', async () => {
-  //       const row = TABLE.row('alincoln');
-  //       const rowData = {
-  //         follows: {
-  //           gwashington: 1,
-  //           jadams: 1,
-  //           tjefferson: 1,
-  //         },
-  //       };
-  //       await row.create({entry: rowData});
-  //     });
-  //
-  //     it('should insert individual cells', async () => {
-  //       const row = TABLE.row('gwashington');
-  //       const rowData = {
-  //         follows: {
-  //           jadams: 1,
-  //         },
-  //       };
-  //       await row.save(rowData);
-  //     });
-  //
-  //     it('should allow for user specified timestamps', async () => {
-  //       const row = TABLE.row('gwashington');
-  //       const rowData = {
-  //         follows: {
-  //           jadams: {
-  //             value: 1,
-  //             timestamp: new Date('March 22, 1986'),
-  //           },
-  //         },
-  //       };
-  //       await row.save(rowData);
-  //     });
-  //
-  //     it('should increment a column value', async () => {
-  //       const row = TABLE.row('gwashington');
-  //       const increment = 5;
-  //       const [value] = await row.increment('follows:increment', increment);
-  //       assert.strictEqual(value, increment);
-  //     });
-  //
-  //     it('should apply read/modify/write rules to a row', async () => {
-  //       const row = TABLE.row('gwashington');
-  //       const rule = {
-  //         column: 'traits:teeth',
-  //         append: '-wood',
-  //       };
-  //       await row.save({
-  //         traits: {
-  //           teeth: 'shiny',
-  //         },
-  //       });
-  //       await row.createRules(rule);
-  //       const [data] = await row.get(['traits:teeth']);
-  //       assert.strictEqual(data.traits.teeth[0].value, 'shiny-wood');
-  //     });
-  //
-  //     it('should check and mutate a row', async () => {
-  //       const row = TABLE.row('gwashington');
-  //       const filter: RawFilter = {
-  //         family: 'follows',
-  //         value: 'alincoln',
-  //       };
-  //       const mutations = [
-  //         {
-  //           method: 'delete',
-  //           data: ['follows:alincoln'],
-  //         },
-  //       ];
-  //       const [matched] = await row.filter(filter, {onMatch: mutations});
-  //       assert(matched);
-  //     });
-  //   });
-  //
-  //   describe('fetching data', () => {
-  //     it('should get rows', async () => {
-  //       const [rows] = await TABLE.getRows();
-  //       assert.strictEqual(rows.length, 4);
-  //       assert(rows[0] instanceof Row);
-  //     });
-  //
-  //     it('should get rows via stream', done => {
-  //       const rows: Row[] = [];
-  //       TABLE.createReadStream()
-  //         .on('error', done)
-  //         .on('data', row => {
-  //           assert(row instanceof Row);
-  //           rows.push(row);
-  //         })
-  //         .on('end', () => {
-  //           assert.strictEqual(rows.length, 4);
-  //           done();
-  //         });
-  //     });
-  //
-  //     it('should should cancel request if stream ended early', done => {
-  //       const rows: Row[] = [];
-  //       const stream = TABLE.createReadStream()
-  //         .on('error', done)
-  //         .on('data', row => {
-  //           stream.end();
-  //           rows.push(row);
-  //         })
-  //         .on('end', () => {
-  //           assert.strictEqual(rows.length, 1);
-  //           done();
-  //         });
-  //     });
-  //
-  //     it('should fetch an individual row', async () => {
-  //       const row = TABLE.row('alincoln');
-  //       const [row_] = await row.get();
-  //       assert.strictEqual(row, row_);
-  //     });
-  //
-  //     it('should limit the number of rows', async () => {
-  //       const [rows] = await TABLE.getRows({
-  //         limit: 1,
-  //       });
-  //       assert.strictEqual(rows.length, 1);
-  //     });
-  //
-  //     it('should fetch a range of rows', async () => {
-  //       const options = {
-  //         start: 'alincoln',
-  //         end: 'jadams',
-  //       };
-  //       const [rows] = await TABLE.getRows(options);
-  //       assert.strictEqual(rows.length, 3);
-  //     });
-  //
-  //     it('should fetch a range of rows via prefix', async () => {
-  //       const options = {
-  //         prefix: 'g',
-  //       };
-  //       const [rows] = await TABLE.getRows(options);
-  //       assert.strictEqual(rows.length, 1);
-  //       assert.strictEqual(rows[0].id, 'gwashington');
-  //     });
-  //
-  //     it('should fetch individual cells of a row', async () => {
-  //       const row = TABLE.row('alincoln');
-  //       const [data] = await row.get(['follows:gwashington']);
-  //       assert.strictEqual(data.follows.gwashington[0].value, 1);
-  //     });
-  //
-  //     it('should not decode the values', async () => {
-  //       const row = TABLE.row('gwashington');
-  //       const options = {
-  //         decode: false,
-  //       };
-  //       await row.get(options);
-  //       const teeth = row.data.traits.teeth;
-  //       const value = teeth[0].value;
-  //       assert(value instanceof Buffer);
-  //       assert.strictEqual(value.toString(), 'shiny-wood');
-  //     });
-  //
-  //     it('should get sample row keys', async () => {
-  //       const [keys] = await TABLE.sampleRowKeys();
-  //       assert(keys.length > 0);
-  //     });
-  //
-  //     it('should get sample row keys via stream', done => {
-  //       const keys: string[] = [];
-  //       TABLE.sampleRowKeysStream()
-  //         .on('error', done)
-  //         .on('data', (rowKey: string) => {
-  //           keys.push(rowKey);
-  //         })
-  //         .on('end', () => {
-  //           assert(keys.length > 0);
-  //           done();
-  //         });
-  //     });
-  //
-  //     it('should end stream early', async () => {
-  //       const entries = [
-  //         {
-  //           key: 'gwashington',
-  //           data: {
-  //             follows: {
-  //               jadams: 1,
-  //             },
-  //           },
-  //         },
-  //         {
-  //           key: 'tjefferson',
-  //           data: {
-  //             follows: {
-  //               gwashington: 1,
-  //               jadams: 1,
-  //             },
-  //           },
-  //         },
-  //         {
-  //           key: 'jadams',
-  //           data: {
-  //             follows: {
-  //               gwashington: 1,
-  //               tjefferson: 1,
-  //             },
-  //           },
-  //         },
-  //       ];
-  //       await TABLE.insert(entries);
-  //       const rows: Row[] = [];
-  //       await new Promise<void>((resolve, reject) => {
-  //         const stream = TABLE.createReadStream()
-  //           .on('error', reject)
-  //           .on('data', row => {
-  //             rows.push(row);
-  //             stream.end();
-  //           })
-  //           .on('end', () => {
-  //             assert.strictEqual(rows.length, 1);
-  //             resolve();
-  //           });
-  //       });
-  //     });
-  //
-  //     describe('filters', () => {
-  //       it('should get rows via column data', async () => {
-  //         const filter = {
-  //           column: 'gwashington',
-  //         };
-  //         const [rows] = await TABLE.getRows({filter});
-  //         assert.strictEqual(rows.length, 3);
-  //         const keys = rows.map(row => row.id).sort();
-  //         assert.deepStrictEqual(keys, ['alincoln', 'jadams', 'tjefferson']);
-  //       });
-  //
-  //       it('should get rows that satisfy the cell limit', async () => {
-  //         const entry = {
-  //           key: 'alincoln',
-  //           data: {
-  //             follows: {
-  //               tjefferson: 1,
-  //             },
-  //           },
-  //         };
-  //         const filter = [
-  //           {
-  //             row: 'alincoln',
-  //           },
-  //           {
-  //             column: {
-  //               name: 'tjefferson',
-  //               cellLimit: 1,
-  //             },
-  //           },
-  //         ];
-  //         await TABLE.insert(entry);
-  //         const [rows] = await TABLE.getRows({filter});
-  //         const rowData = rows[0].data;
-  //         assert.strictEqual(rowData.follows.tjefferson.length, 1);
-  //       });
-  //
-  //       it('should get a range of columns', async () => {
-  //         const filter = [
-  //           {
-  //             row: 'tjefferson',
-  //           },
-  //           {
-  //             column: {
-  //               family: 'follows',
-  //               start: 'gwashington',
-  //               end: 'jadams',
-  //             },
-  //           },
-  //         ];
-  //
-  //         const [rows] = await TABLE.getRows({filter});
-  //         rows.forEach(row => {
-  //           const keys = Object.keys(row.data.follows).sort();
-  //           assert.deepStrictEqual(keys, ['gwashington', 'jadams']);
-  //         });
-  //       });
-  //
-  //       it('should run a conditional filter', async () => {
-  //         const filter = {
-  //           condition: {
-  //             test: [
-  //               {
-  //                 row: 'gwashington',
-  //               },
-  //               {
-  //                 family: 'follows',
-  //               },
-  //               {
-  //                 column: 'tjefferson',
-  //               },
-  //             ],
-  //             pass: {
-  //               row: 'gwashington',
-  //             },
-  //             fail: {
-  //               row: 'tjefferson',
-  //             },
-  //           },
-  //         };
-  //         const [rows] = await TABLE.getRows({filter});
-  //         assert.strictEqual(rows.length, 1);
-  //         assert.strictEqual(rows[0].id, 'tjefferson');
-  //       });
-  //
-  //       it('should run a conditional filter with pass only', async () => {
-  //         const filter = {
-  //           condition: {
-  //             test: [
-  //               {
-  //                 row: 'gwashington',
-  //               },
-  //             ],
-  //             pass: [
-  //               {
-  //                 all: true,
-  //               },
-  //             ],
-  //           },
-  //         };
-  //         const [rows] = await TABLE.getRows({filter});
-  //         assert(rows.length > 0);
-  //       });
-  //
-  //       it('should only get cells for a specific family', async () => {
-  //         const entries = [
-  //           {
-  //             key: 'gwashington',
-  //             data: {
-  //               traits: {
-  //                 teeth: 'wood',
-  //               },
-  //             },
-  //           },
-  //         ];
-  //         await TABLE.insert(entries);
-  //         const filter = {
-  //           family: 'traits',
-  //         };
-  //         const [rows] = await TABLE.getRows({filter});
-  //         assert(rows.length > 0);
-  //         const families = Object.keys(rows[0].data);
-  //         assert.deepStrictEqual(families, ['traits']);
-  //       });
-  //
-  //       it('should interleave filters', async () => {
-  //         const filter = [
-  //           {
-  //             interleave: [
-  //               [
-  //                 {
-  //                   row: 'gwashington',
-  //                 },
-  //               ],
-  //               [
-  //                 {
-  //                   row: 'tjefferson',
-  //                 },
-  //               ],
-  //             ],
-  //           },
-  //         ];
-  //         const [rows] = await TABLE.getRows({filter});
-  //         assert.strictEqual(rows.length, 2);
-  //         const ids = rows.map(row => row.id).sort();
-  //         assert.deepStrictEqual(ids, ['gwashington', 'tjefferson']);
-  //       });
-  //
-  //       it('should apply labels to the results', async () => {
-  //         const filter = {
-  //           label: 'test-label',
-  //         };
-  //         const [rows] = await TABLE.getRows({filter});
-  //         rows.forEach(row => {
-  //           const follows = row.data.follows;
-  //           Object.keys(follows).forEach(column => {
-  //             // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  //             follows[column].forEach((cell: any) => {
-  //               assert.deepStrictEqual(cell.labels, [filter.label]);
-  //             });
-  //           });
-  //         });
-  //       });
-  //
-  //       it('should run a regex against the row id', async () => {
-  //         const filter = {
-  //           row: /[a-z]+on$/,
-  //         };
-  //         const [rows] = await TABLE.getRows({filter});
-  //         const keys = rows.map(row => row.id).sort();
-  //         assert.deepStrictEqual(keys, ['gwashington', 'tjefferson']);
-  //       });
-  //
-  //       it('should run a sink filter', async () => {
-  //         const filter = [
-  //           {
-  //             row: 'alincoln',
-  //           },
-  //           {
-  //             family: 'follows',
-  //           },
-  //           {
-  //             interleave: [
-  //               [
-  //                 {
-  //                   all: true,
-  //                 },
-  //               ],
-  //               [
-  //                 {
-  //                   label: 'prezzy',
-  //                 },
-  //                 {
-  //                   sink: true,
-  //                 },
-  //               ],
-  //             ],
-  //           },
-  //           {
-  //             column: 'gwashington',
-  //           },
-  //         ];
-  //         const [rows] = await TABLE.getRows({filter});
-  //         const columns = Object.keys(rows[0].data.follows).sort();
-  //         assert.deepStrictEqual(columns, [
-  //           'gwashington',
-  //           'jadams',
-  //           'tjefferson',
-  //         ]);
-  //       });
-  //     });
-  //
-  //     it('should accept a date range', async () => {
-  //       const filter = {
-  //         time: {
-  //           start: new Date('March 21, 1986'),
-  //           end: new Date('March 23, 1986'),
-  //         },
-  //       };
-  //       const [rows] = await TABLE.getRows({filter});
-  //       assert(rows.length > 0);
-  //     });
-  //   });
-  // });
-  //
-  // describe('deleting rows', () => {
-  //   it('should delete specific cells', async () => {
-  //     const row = TABLE.row('alincoln');
-  //     await row.deleteCells(['follows:gwashington']);
-  //   });
-  //
-  //   it('should delete a family', async () => {
-  //     const row = TABLE.row('gwashington');
-  //     await row.deleteCells(['traits']);
-  //   });
-  //
-  //   it('should delete all the cells', async () => {
-  //     const row = TABLE.row('alincoln');
-  //     await row.delete();
-  //   });
-  // });
-  //
-  // describe('.deleteRows()', () => {
-  //   const table = INSTANCE.table(generateId('table'));
-  //   beforeEach(async () => {
-  //     const tableOptions = {
-  //       families: ['cf1'],
-  //     };
-  //     const data = {
-  //       cf1: {
-  //         foo: 1,
-  //       },
-  //     };
-  //     const rows = [
-  //       {
-  //         key: 'aaa',
-  //         data,
-  //       },
-  //       {
-  //         key: 'abc',
-  //         data,
-  //       },
-  //       {
-  //         key: 'def',
-  //         data,
-  //       },
-  //     ];
-  //     await table.create(tableOptions);
-  //     await table.insert(rows);
-  //   });
-  //
-  //   afterEach(async () => {
-  //     await table.delete();
-  //   });
-  //
-  //   it('should delete the prefixes', async () => {
-  //     await table.deleteRows('a');
-  //     const [rows] = await table.getRows();
-  //     assert.strictEqual(rows.length, 1);
-  //   });
-  // });
-  //
-  // describe('.truncate()', () => {
-  //   const table = INSTANCE.table(generateId('table'));
-  //   beforeEach(async () => {
-  //     const tableOptions = {
-  //       families: ['follows'],
-  //     };
-  //     const rows = [
-  //       {
-  //         key: 'gwashington',
-  //         data: {
-  //           follows: {
-  //             jadams: 1,
-  //           },
-  //         },
-  //       },
-  //     ];
-  //     await table.create(tableOptions);
-  //     await table.insert(rows);
-  //   });
-  //
-  //   afterEach(async () => {
-  //     await table.delete();
-  //   });
-  //
-  //   it('should truncate a table', async () => {
-  //     await table.truncate();
-  //     const [rows] = await table.getRows();
-  //     assert.strictEqual(rows.length, 0);
-  //   });
-  // });
-  //
-  // describe('backups', () => {
-  //   const CLUSTER = INSTANCE.cluster(CLUSTER_ID);
-  //   let BACKUP: Backup;
-  //
-  //   // For these tests, two backups are needed. The backups are labeled for what
-  //   // they are intended to originate/interact from/with, but this is just for
-  //   // testing and the naming convention used here does not actually influence
-  //   // the real functionality - it is just a way to keep things organized!
-  //   const backupIdFromCluster = generateId('backup');
-  //   let backupNameFromCluster: string;
-  //   const restoreTableIdFromCluster = generateId('table');
-  //
-  //   const backupIdFromTable = generateId('backup');
-  //   let backupNameFromTable: string;
-  //
-  //   // The minimum backup expiry time is 6 hours. The times here each have a 2
-  //   // hour padding to tolerate latency and clock drift. Also, while the time
-  //   // implementation for backups in this client accepts any of a Timestamp
-  //   // Struct, Date, or PreciseDate, to keep things easy this uses PreciseDate.
-  //   const expireTime = new PreciseDate(PreciseDate.now() + 8 * 60 * 60 * 1000);
-  //   const updateExpireTime = new PreciseDate(
-  //     expireTime.getTime() + 2 + 60 * 60 * 1000
-  //   );
-  //
-  //   before(async () => {
-  //     const [backup, op] = await CLUSTER.createBackup(backupIdFromCluster, {
-  //       table: TABLE,
-  //       expireTime,
-  //     });
-  //     BACKUP = backup;
-  //     await op.promise();
-  //     backupNameFromCluster = replaceProjectIdToken(
-  //       `${CLUSTER.name}/backups/${backupIdFromCluster}`,
-  //       bigtable.projectId
-  //     );
-  //     backupNameFromTable = replaceProjectIdToken(
-  //       `${CLUSTER.name}/backups/${backupIdFromTable}`,
-  //       bigtable.projectId
-  //     );
-  //   });
-  //
-  //   it('should create backup of a table (from cluster)', async () => {
-  //     await BACKUP.getMetadata();
-  //
-  //     assert.strictEqual(BACKUP.metadata!.name, backupNameFromCluster);
-  //
-  //     assert.deepStrictEqual(BACKUP.expireDate, expireTime);
-  //   });
-  //
-  //   it('should create backup of a table (from table)', async () => {
-  //     const [backup, op] = await TABLE.createBackup(backupIdFromTable, {
-  //       expireTime,
-  //     });
-  //     await op.promise();
-  //     await backup.getMetadata();
-  //
-  //     assert.strictEqual(backup.metadata!.name, backupNameFromTable);
-  //
-  //     assert.deepStrictEqual(backup.expireDate, expireTime);
-  //   });
-  //
-  //   it('should get a specific backup (cluster)', async () => {
-  //     const [backup] = await CLUSTER.backup(backupIdFromCluster).get();
-  //     assert.strictEqual(backup.metadata!.name, backupNameFromCluster);
-  //     assert.strictEqual(backup.metadata!.state, 'READY');
-  //   });
-  //
-  //   it('should get backups in an instance', async () => {
-  //     const [backups] = await INSTANCE.getBackups();
-  //     assert(Array.isArray(backups));
-  //     assert(backups.length > 0);
-  //     assert(backups.some(backup => backup.id === BACKUP.id));
-  //   });
-  //
-  //   it('should get backups in an instance as a stream', done => {
-  //     const backups: Backup[] = [];
-  //
-  //     INSTANCE.getBackupsStream()
-  //       .on('error', done)
-  //       .on('data', backup => {
-  //         backups.push(backup);
-  //       })
-  //       .on('end', () => {
-  //         assert(backups.length > 0);
-  //         done();
-  //       });
-  //   });
-  //
-  //   it('should get backups in a cluster', async () => {
-  //     const [backups] = await CLUSTER.getBackups();
-  //     assert(Array.isArray(backups));
-  //     assert(backups.length > 0);
-  //     assert(backups.some(backup => backup.id === BACKUP.id));
-  //   });
-  //
-  //   it('should get backups in a cluster as a stream', done => {
-  //     const backups: Backup[] = [];
-  //
-  //     CLUSTER.getBackupsStream()
-  //       .on('error', done)
-  //       .on('data', backup => {
-  //         backups.push(backup);
-  //       })
-  //       .on('end', () => {
-  //         assert(backups.length > 0);
-  //         done();
-  //       });
-  //   });
-  //
-  //   it('should restore a backup (cluster)', async () => {
-  //     const backup = CLUSTER.backup(backupIdFromCluster);
-  //     const [table, op] = await backup.restore(restoreTableIdFromCluster);
-  //     await op.promise();
-  //
-  //     const restoredTableId = table.name?.split('/').pop();
-  //     assert.strictEqual(restoredTableId, restoreTableIdFromCluster);
-  //   });
-  //
-  //   it('should restore a backup to a different instance', async () => {
-  //     const [, operation] = await DIFF_INSTANCE.create(
-  //       createInstanceConfig(generateId('d-clust'), 'us-east1-c', 3, Date.now())
-  //     );
-  //     await operation.promise();
-  //     const [iExists] = await DIFF_INSTANCE.exists();
-  //     assert.strictEqual(iExists, true);
-  //
-  //     const backup = CLUSTER.backup(backupIdFromCluster);
-  //     const [table, op] = await backup.restoreTo({
-  //       tableId: restoreTableIdFromCluster,
-  //       instance: DIFF_INSTANCE,
-  //     });
-  //     await op.promise();
-  //     const [tExists] = await table.exists();
-  //     assert.strictEqual(tExists, true);
-  //     assert.strictEqual(table.id, restoreTableIdFromCluster);
-  //   });
-  //
-  //   it('should update a backup (cluster)', async () => {
-  //     const backup = CLUSTER.backup(backupIdFromCluster);
-  //     const [metadata] = await backup.setMetadata({
-  //       expireTime: updateExpireTime,
-  //     });
-  //
-  //     assert.strictEqual(metadata.name, backupNameFromCluster);
-  //     assert.deepStrictEqual(backup.expireDate, updateExpireTime);
-  //   });
-  //
-  //   it('should get an Iam Policy for the backup', async () => {
-  //     const policyProperties = ['version', 'bindings', 'etag'];
-  //     const [policy] = await BACKUP.getIamPolicy();
-  //
-  //     policyProperties.forEach(property => {
-  //       assert(property in policy);
-  //     });
-  //   });
-  //
-  //   it('should test Iam permissions for the backup', async () => {
-  //     const permissions = ['bigtable.backups.get', 'bigtable.backups.delete'];
-  //     const [grantedPermissions] = await BACKUP.testIamPermissions(permissions);
-  //     assert.strictEqual(grantedPermissions.length, permissions.length);
-  //     permissions.forEach(permission => {
-  //       assert.strictEqual(grantedPermissions.includes(permission), true);
-  //     });
-  //   });
-  //
-  //   it('should set Iam Policy on the backup', async () => {
-  //     const backup = CLUSTER.backup(backupIdFromCluster);
-  //
-  //     const [policy] = await backup.getIamPolicy();
-  //     const [updatedPolicy] = await backup.setIamPolicy(policy);
-  //
-  //     Object.keys(policy).forEach(key => assert(key in updatedPolicy));
-  //   });
-  //   describe('copying backups', () => {
-  //     // The server requires the copy backup time to be sufficiently ahead of
-  //     // the create backup time to avoid an error.
-  //     // Set it to 308 hours ahead
-  //     const sourceExpireTimeMilliseconds =
-  //       PreciseDate.now() + (8 + 300) * 60 * 60 * 1000;
-  //     const sourceExpireTime = new PreciseDate(sourceExpireTimeMilliseconds);
-  //     // 608 hours ahead of now, 300 hours ahead of sourceExpireTimeMilliseconds
-  //     const copyExpireTimeMilliseconds =
-  //       PreciseDate.now() + (8 + 600) * 60 * 60 * 1000;
-  //     const copyExpireTime = new PreciseDate(copyExpireTimeMilliseconds);
-  //
-  //     /*
-  //       This function checks that when a backup is copied using the provided
-  //       config that a new backup is created on the instance.
-  //      */
-  //     async function testCopyBackup(
-  //       backup: Backup,
-  //       config: CopyBackupConfig,
-  //       instance: Instance
-  //     ) {
-  //       // Get a list of backup ids before the copy
-  //       const [backupsBeforeCopy] = await instance.getBackups();
-  //       const backupIdsBeforeCopy = backupsBeforeCopy.map(backup => backup.id);
-  //       // Copy the backup
-  //       const [newBackup, operation] = await backup.copy(config);
-  //       try {
-  //         assert.strictEqual(config.id, newBackup.id);
-  //         await operation.promise();
-  //         const id = config.id;
-  //         const backupPath = `${config.cluster.name}/backups/${id}`;
-  //         {
-  //           // Ensure that the backup specified by the config and id match the backup name for the operation returned by the server.
-  //           // the split/map/join functions replace the project name with the {{projectId}} string
-  //           assert(operation);
-  //           assert(operation.metadata);
-  //           assert.strictEqual(
-  //             operation.metadata.name
-  //               .split('/')
-  //               .map((item, index) => (index === 1 ? '{{projectId}}' : item))
-  //               .join('/'),
-  //             backupPath
-  //               .split('/')
-  //               .map((item, index) => (index === 1 ? '{{projectId}}' : item))
-  //               .join('/')
-  //           );
-  //         }
-  //         // Check that there is now one more backup
-  //         const [backupsAfterCopy] = await instance.getBackups();
-  //         const newBackups = backupsAfterCopy.filter(
-  //           backup => !backupIdsBeforeCopy.includes(backup.id)
-  //         );
-  //         assert.strictEqual(newBackups.length, 1);
-  //         const [fetchedNewBackup] = newBackups;
-  //         // Ensure the fetched backup matches the config
-  //         assert.strictEqual(fetchedNewBackup.id, id);
-  //         assert.strictEqual(fetchedNewBackup.name, backupPath);
-  //         // Delete the copied backup
-  //       } finally {
-  //         await config.cluster.backup(newBackup.id).delete();
-  //       }
-  //     }
-  //
-  //     describe('should create backup of a table and copy it in the same cluster', async () => {
-  //       async function testWithExpiryTimes(
-  //         sourceTestExpireTime: BackupTimestamp,
-  //         copyTestExpireTime: BackupTimestamp
-  //       ) {
-  //         const [backup, op] = await TABLE.createBackup(generateId('backup'), {
-  //           expireTime: sourceTestExpireTime,
-  //         });
-  //         try {
-  //           {
-  //             await op.promise();
-  //             // Check expiry time for running operation.
-  //             await backup.getMetadata();
-  //             assert.deepStrictEqual(backup.expireDate, sourceExpireTime);
-  //           }
-  //           await testCopyBackup(
-  //             backup,
-  //             {
-  //               cluster: backup.cluster,
-  //               id: generateId('backup'),
-  //               expireTime: copyTestExpireTime,
-  //             },
-  //             INSTANCE
-  //           );
-  //         } finally {
-  //           await backup.delete();
-  //         }
-  //       }
-  //       it('should copy to the same cluster with precise date expiry times', async () => {
-  //         await testWithExpiryTimes(sourceExpireTime, copyExpireTime);
-  //       });
-  //       it('should copy to the same cluster with timestamp expiry times', async () => {
-  //         // Calling toStruct converts times to a timestamp object.
-  //         // For example: sourceExpireTime.toStruct() = {seconds: 1706659851, nanos: 981000000}
-  //         await testWithExpiryTimes(
-  //           sourceExpireTime.toStruct(),
-  //           copyExpireTime.toStruct()
-  //         );
-  //       });
-  //       it('should copy to the same cluster with date expiry times', async () => {
-  //         await testWithExpiryTimes(
-  //           new Date(sourceExpireTimeMilliseconds),
-  //           new Date(copyExpireTimeMilliseconds)
-  //         );
-  //       });
-  //     });
-  //     it('should create backup of a table and copy it on another cluster of another instance', async () => {
-  //       const [backup, op] = await TABLE.createBackup(generateId('backup'), {
-  //         expireTime: sourceExpireTime,
-  //       });
-  //       try {
-  //         {
-  //           await op.promise();
-  //           // Check the expiry time.
-  //           await backup.getMetadata();
-  //           assert.deepStrictEqual(backup.expireDate, sourceExpireTime);
-  //         }
-  //         // Create another instance
-  //         const instance = bigtable.instance(generateId('instance'));
-  //         const destinationClusterId = generateId('cluster');
-  //         {
-  //           // Create production instance with given options
-  //           const instanceOptions: InstanceOptions = {
-  //             clusters: [
-  //               {
-  //                 id: destinationClusterId,
-  //                 nodes: 3,
-  //                 location: 'us-central1-f',
-  //                 storage: 'ssd',
-  //               },
-  //             ],
-  //             labels: {'prod-label': 'prod-label'},
-  //             type: 'production',
-  //           };
-  //           const [, operation] = await instance.create(instanceOptions);
-  //           await operation.promise();
-  //         }
-  //         // Create the copy and test the copied backup
-  //         await testCopyBackup(
-  //           backup,
-  //           {
-  //             cluster: new Cluster(instance, destinationClusterId),
-  //             id: generateId('backup'),
-  //             expireTime: copyExpireTime,
-  //           },
-  //           instance
-  //         );
-  //         await instance.delete();
-  //       } finally {
-  //         await backup.delete();
-  //       }
-  //     });
-  //     it('should create backup of a table and copy it on another cluster of the same instance', async () => {
-  //       const [backup, op] = await TABLE.createBackup(generateId('backup'), {
-  //         expireTime: sourceExpireTime,
-  //       });
-  //       try {
-  //         {
-  //           await op.promise();
-  //           // Check the expiry time.
-  //           await backup.getMetadata();
-  //           assert.deepStrictEqual(backup.expireDate, sourceExpireTime);
-  //         }
-  //         const destinationClusterId = generateId('cluster');
-  //         {
-  //           // Create destination cluster with given options
-  //           const [, operation] = await INSTANCE.cluster(
-  //             destinationClusterId
-  //           ).create({
-  //             location: 'us-central1-b',
-  //             nodes: 3,
-  //           });
-  //           await operation.promise();
-  //         }
-  //         // Create the copy and test the copied backup
-  //         await testCopyBackup(
-  //           backup,
-  //           {
-  //             cluster: new Cluster(INSTANCE, destinationClusterId),
-  //             id: generateId('backup'),
-  //             expireTime: copyExpireTime,
-  //           },
-  //           INSTANCE
-  //         );
-  //       } finally {
-  //         await backup.delete();
-  //       }
-  //     });
-  //     it('should create backup of a table and copy it on another project', async () => {
-  //       const [backup, op] = await TABLE.createBackup(generateId('backup'), {
-  //         expireTime: sourceExpireTime,
-  //       });
-  //       try {
-  //         {
-  //           await op.promise();
-  //           // Check the expiry time.
-  //           await backup.getMetadata();
-  //           assert.deepStrictEqual(backup.expireDate, sourceExpireTime);
-  //         }
-  //         // Create client, instance, cluster for second project
-  //         const bigtableSecondaryProject = new Bigtable(
-  //           process.env.GCLOUD_PROJECT2
-  //             ? {projectId: process.env.GCLOUD_PROJECT2}
-  //             : {}
-  //         );
-  //         const secondInstance = bigtableSecondaryProject.instance(
-  //           generateId('instance')
-  //         );
-  //         const destinationClusterId = generateId('cluster');
-  //         {
-  //           // Create production instance with given options
-  //           const instanceOptions: InstanceOptions = {
-  //             clusters: [
-  //               {
-  //                 id: destinationClusterId,
-  //                 nodes: 3,
-  //                 location: 'us-central1-f',
-  //                 storage: 'ssd',
-  //               },
-  //             ],
-  //             labels: {'prod-label': 'prod-label'},
-  //             type: 'production',
-  //           };
-  //           const [, operation] = await secondInstance.create(instanceOptions);
-  //           await operation.promise();
-  //         }
-  //         // Create the copy and test the copied backup
-  //         await testCopyBackup(
-  //           backup,
-  //           {
-  //             cluster: new Cluster(secondInstance, destinationClusterId),
-  //             id: generateId('backup'),
-  //             expireTime: copyExpireTime,
-  //           },
-  //           secondInstance
-  //         );
-  //         await secondInstance.delete();
-  //       } finally {
-  //         await backup.delete();
-  //       }
-  //     });
-  //     it('should restore a copied backup', async () => {
-  //       const backupId = generateId('backup');
-  //       const table = INSTANCE.table('old-table');
-  //       {
-  //         // Create a table and insert data into it.
-  //         await table.create();
-  //         await table.createFamily('follows');
-  //         await table.insert([
-  //           {
-  //             key: 'some-data-to-copy-key',
-  //             data: {
-  //               follows: {
-  //                 copyData: 'data-to-copy',
-  //               },
-  //             },
-  //           },
-  //         ]);
-  //       }
-  //       // Create the backup
-  //       const [backup, createBackupOperation] = await table.createBackup(
-  //         backupId,
-  //         {
-  //           expireTime: sourceExpireTime,
-  //         }
-  //       );
-  //       try {
-  //         await createBackupOperation.promise();
-  //         // Copy the backup
-  //         const config = {
-  //           cluster: backup.cluster,
-  //           id: generateId('backup'),
-  //           expireTime: copyExpireTime,
-  //         };
-  //         const [newBackup, copyOperation] = await backup.copy(config);
-  //         await copyOperation.promise();
-  //         // Restore a table from the copied backup
-  //         const [newTable, restoreOperation] =
-  //           await newBackup.restore('new-table');
-  //         await restoreOperation.promise();
-  //         const rows = await newTable.getRows();
-  //         assert.deepStrictEqual(rows[0][0].id, 'some-data-to-copy-key');
-  //       } finally {
-  //         await backup.delete();
-  //       }
-  //     });
-  //   });
-  // });
+  describe('instances', () => {
+    it('should get a list of instances', async () => {
+      const [instances, failedLocations] = await bigtable.getInstances();
+      assert(instances.length > 0);
+      assert(Array.isArray(failedLocations));
+    });
+
+    it('should check if an instance exists', async () => {
+      const [exists] = await INSTANCE.exists();
+      assert.strictEqual(exists, true);
+    });
+
+    it('should check if an instance does not exist', async () => {
+      const instance = bigtable.instance('fake-instance');
+      const [exists] = await instance.exists();
+      assert.strictEqual(exists, false);
+    });
+
+    it('should get a single instance', async () => {
+      await INSTANCE.get();
+    });
+
+    it('should update an instance', async () => {
+      const metadata = {
+        displayName: 'metadata-test',
+      };
+      await INSTANCE.setMetadata(metadata);
+      const [metadata_] = await INSTANCE.getMetadata();
+      assert.strictEqual(metadata.displayName, metadata_.displayName);
+    });
+
+    it('should get an Iam Policy for the instance', async () => {
+      const policyProperties = ['version', 'bindings', 'etag'];
+      const [policy] = await INSTANCE.getIamPolicy();
+      policyProperties.forEach(property => {
+        assert(property in policy);
+      });
+    });
+
+    it('should test Iam permissions for the instance', async () => {
+      const permissions = ['bigtable.tables.get', 'bigtable.tables.readRows'];
+      const [grantedPermissions] =
+        await INSTANCE.testIamPermissions(permissions);
+      assert.strictEqual(grantedPermissions.length, permissions.length);
+      permissions.forEach(permission => {
+        assert.strictEqual(grantedPermissions.includes(permission), true);
+      });
+    });
+
+    it('should set Iam Policy on the instance', async () => {
+      const instance = bigtable.instance(generateId('instance'));
+      const clusteId = generateId('cluster');
+      const [, operation] = await instance.create({
+        clusters: [
+          {
+            id: clusteId,
+            location: 'us-central1-c',
+            nodes: 3,
+          },
+        ],
+        labels: {
+          time_created: Date.now(),
+        },
+      });
+      await operation.promise();
+
+      const [policy] = await instance.getIamPolicy();
+      const [updatedPolicy] = await instance.setIamPolicy(policy);
+      Object.keys(policy).forEach(key => assert(key in updatedPolicy));
+
+      await instance.delete();
+    });
+  });
+
+  describe('CMEK', () => {
+    let kmsKeyName: string;
+
+    const CMEK_CLUSTER = CMEK_INSTANCE.cluster(generateId('cluster'));
+
+    const cryptoKeyId = generateId('key');
+    const keyRingId = generateId('key-ring');
+    let keyRingsBaseUrl: string;
+    let cryptoKeyVersionName: string;
+
+    before(async () => {
+      const projectId = await bigtable.auth.getProjectId();
+      kmsKeyName = `projects/${projectId}/locations/us-central1/keyRings/${keyRingId}/cryptoKeys/${cryptoKeyId}`;
+      keyRingsBaseUrl = `https://cloudkms.googleapis.com/v1/projects/${projectId}/locations/us-central1/keyRings`;
+
+      await bigtable.auth.request({
+        method: 'POST',
+        url: keyRingsBaseUrl,
+        params: {keyRingId},
+      });
+
+      const resp = await bigtable.auth.request({
+        method: 'POST',
+        url: `${keyRingsBaseUrl}/${keyRingId}/cryptoKeys`,
+        params: {cryptoKeyId},
+        data: {purpose: 'ENCRYPT_DECRYPT'},
+      });
+      cryptoKeyVersionName = resp.data.primary.name;
+
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const [_, operation] = await CMEK_INSTANCE.create({
+        clusters: [
+          {
+            id: CMEK_CLUSTER.id,
+            location: 'us-central1-a',
+            nodes: 3,
+            key: kmsKeyName,
+          },
+        ],
+        labels: {
+          time_created: Date.now(),
+        },
+      });
+      await operation.promise();
+    });
+
+    after(async () => {
+      await bigtable.auth.request({
+        method: 'POST',
+        url: `${keyRingsBaseUrl}/${keyRingId}/cryptoKeys/${cryptoKeyId}/cryptoKeyVersions/${cryptoKeyVersionName
+          .split('/')
+          .pop()}:destroy`,
+        params: {name: cryptoKeyVersionName},
+      });
+    });
+
+    it('should have created an instance', async () => {
+      const [metadata] = await CMEK_CLUSTER.getMetadata();
+      assert.deepStrictEqual(metadata.encryptionConfig, {kmsKeyName});
+    });
+
+    it('should create a cluster', async () => {
+      const cluster = CMEK_INSTANCE.cluster(generateId('cluster'));
+
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const [_, operation] = await cluster.create({
+        location: 'us-central1-b',
+        nodes: 3,
+        key: kmsKeyName,
+      });
+      await operation.promise();
+
+      const [metadata] = await cluster.getMetadata();
+      assert.deepStrictEqual(metadata.encryptionConfig, {kmsKeyName});
+    });
+
+    it('should fail if key not provided', async () => {
+      const cluster = CMEK_INSTANCE.cluster(generateId('cluster'));
+
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const [_, operation] = await cluster.create({
+          location: 'us-central1-b',
+          nodes: 3,
+        });
+        await operation.promise();
+        throw new Error('Cluster creation should not have succeeded');
+      } catch (e) {
+        assert(
+          (e as Error).message.includes(
+            'default keys and CMEKs are not allowed'
+          )
+        );
+      }
+    });
+  });
+
+  describe('appProfiles', () => {
+    it('should retrieve a list of app profiles', async () => {
+      const [appProfiles] = await INSTANCE.getAppProfiles();
+      assert(appProfiles[0] instanceof AppProfile);
+      assert(appProfiles.length > 0);
+    });
+
+    it('should retrieve a list of app profiles in stream mode', done => {
+      const appProfiles: AppProfile[] = [];
+      INSTANCE.getAppProfilesStream()
+        .on('error', done)
+        .on('data', appProfile => {
+          assert(appProfile instanceof AppProfile);
+          appProfiles.push(appProfile);
+        })
+        .on('end', () => {
+          assert(appProfiles.length > 0);
+          done();
+        });
+    });
+
+    it('should check if an app profile exists', async () => {
+      const [exists] = await APP_PROFILE.exists();
+      assert.strictEqual(exists, true);
+    });
+
+    it('should check if an app profile does not exist', async () => {
+      const appProfile = INSTANCE.appProfile('should-not-exist');
+      const [exists] = await appProfile.exists();
+      assert.strictEqual(exists, false);
+    });
+
+    it('should get an app profile', async () => {
+      await APP_PROFILE.get();
+    });
+
+    it('should delete an app profile', async () => {
+      const appProfile = INSTANCE.appProfile(generateId('app-profile'));
+      await appProfile.create({
+        routing: 'any',
+        ignoreWarnings: true,
+      });
+      await appProfile.delete({ignoreWarnings: true});
+    });
+
+    it('should get the app profiles metadata', async () => {
+      const [metadata] = await APP_PROFILE.getMetadata();
+      assert.strictEqual(
+        metadata.name,
+        APP_PROFILE.name.replace('{{projectId}}', bigtable.projectId)
+      );
+    });
+
+    it('should update an app profile', async () => {
+      const cluster = INSTANCE.cluster(CLUSTER_ID);
+      const options = {
+        routing: cluster,
+        allowTransactionalWrites: true,
+        description: 'My Updated App Profile',
+      };
+      await APP_PROFILE.setMetadata(options);
+      const [updatedAppProfile] = await APP_PROFILE.get();
+      assert.strictEqual(
+        updatedAppProfile.metadata!.description,
+        options.description
+      );
+      assert.deepStrictEqual(updatedAppProfile.metadata!.singleClusterRouting, {
+        clusterId: CLUSTER_ID,
+        allowTransactionalWrites: true,
+      });
+    });
+  });
+
+  describe('clusters', () => {
+    let CLUSTER: Cluster;
+
+    beforeEach(() => {
+      CLUSTER = INSTANCE.cluster(CLUSTER_ID);
+    });
+
+    it('should retrieve a list of clusters', async () => {
+      const [clusters] = await INSTANCE.getClusters();
+      assert(clusters[0] instanceof Cluster);
+    });
+
+    it('should check if a cluster exists', async () => {
+      const [exists] = await CLUSTER.exists();
+      assert.strictEqual(exists, true);
+    });
+
+    it('should check if a cluster does not exist', async () => {
+      const cluster = INSTANCE.cluster('fake-cluster');
+      const [exists] = await cluster.exists();
+      assert.strictEqual(exists, false);
+    });
+
+    it('should get a cluster', async () => {
+      await CLUSTER.get();
+    });
+
+    it('should update a cluster', async () => {
+      const metadata = {
+        nodes: 4,
+      };
+      const [operation] = await CLUSTER.setMetadata(metadata);
+      await operation.promise();
+      const [_metadata] = await CLUSTER.getMetadata();
+      assert.strictEqual(metadata.nodes, _metadata.serveNodes);
+    });
+  });
+
+  describe('tables', () => {
+    it('should retrieve a list of tables', async () => {
+      const [tables] = await INSTANCE.getTables();
+      assert(tables[0] instanceof Table);
+    });
+
+    it('should retrieve a list of tables in stream mode', done => {
+      const tables: Table[] = [];
+      INSTANCE.getTablesStream()
+        .on('error', done)
+        .on('data', table => {
+          assert(table instanceof Table);
+          tables.push(table);
+        })
+        .on('end', () => {
+          assert(tables.length > 0);
+          done();
+        });
+    });
+
+    it('should check if a table exists', async () => {
+      const [exists] = await TABLE.exists();
+      assert.strictEqual(exists, true);
+    });
+
+    it('should check if a table does not exist', async () => {
+      const table = INSTANCE.table('should-not-exist');
+      const [exists] = await table.exists();
+      assert.strictEqual(exists, false);
+    });
+
+    it('should get a table', async () => {
+      await TABLE.get();
+    });
+
+    it('should get an Iam Policy for the table', async () => {
+      const policyProperties = ['version', 'bindings', 'etag'];
+      const [policy] = await TABLE.getIamPolicy();
+      policyProperties.forEach(property => {
+        assert(property in policy);
+      });
+    });
+
+    it('should test Iam permissions for the table', async () => {
+      const permissions = ['bigtable.tables.get', 'bigtable.tables.readRows'];
+      const [grantedPermissions] = await TABLE.testIamPermissions(permissions);
+      assert.strictEqual(grantedPermissions.length, permissions.length);
+      permissions.forEach(permission => {
+        assert.strictEqual(grantedPermissions.includes(permission), true);
+      });
+    });
+
+    it('should set Iam Policy on the table', async () => {
+      const table = INSTANCE.table(generateId('table'));
+      await table.create();
+
+      const [policy] = await table.getIamPolicy();
+      const [updatedPolicy] = await table.setIamPolicy(policy);
+      Object.keys(policy).forEach(key => assert(key in updatedPolicy));
+
+      await table.delete();
+    });
+
+    it('should delete a table', async () => {
+      const table = INSTANCE.table(generateId('table'));
+      await table.create();
+      await table.delete();
+    });
+
+    it('should get the tables metadata', async () => {
+      const [metadata] = await TABLE.getMetadata();
+      assert.strictEqual(
+        metadata.name,
+        TABLE.name.replace('{{projectId}}', bigtable.projectId)
+      );
+    });
+
+    it('should create a table with column family data', async () => {
+      const name = generateId('table');
+      const options = {
+        families: ['test'],
+      };
+      const [table] = await INSTANCE.createTable(name, options);
+      assert(table.metadata!.columnFamilies!.test);
+    });
+
+    it('should create a table if autoCreate is true', async () => {
+      const table = INSTANCE.table(generateId('table'));
+      await table.get({autoCreate: true});
+      await table.delete();
+    });
+  });
+
+  describe('consistency tokens', () => {
+    it('should generate consistency token', async () => {
+      const [token] = await TABLE.generateConsistencyToken();
+      assert.strictEqual(typeof token, 'string');
+    });
+
+    it('should return error for checkConsistency of invalid token', done => {
+      TABLE.checkConsistency('dummy-token', err => {
+        assert.strictEqual(err!.code, 3);
+        done();
+      });
+    });
+
+    it('should return boolean for checkConsistency of token', async () => {
+      const [token] = await TABLE.generateConsistencyToken();
+      const [res] = await TABLE.checkConsistency(token);
+      assert.strictEqual(typeof res, 'boolean');
+    });
+
+    it('should return boolean for waitForReplication', async () => {
+      const [res] = await TABLE.waitForReplication();
+      assert.strictEqual(typeof res, 'boolean');
+    });
+  });
+
+  describe('replication states', () => {
+    it('should get a map of clusterId and state', async () => {
+      const [clusterStates] = await TABLE.getReplicationStates();
+      assert(clusterStates instanceof Map);
+      assert(clusterStates.has(CLUSTER_ID));
+    });
+  });
+
+  describe('column families', () => {
+    const FAMILY_ID = 'presidents';
+    let FAMILY: Family;
+
+    before(async () => {
+      FAMILY = TABLE.family(FAMILY_ID);
+      await FAMILY.create();
+    });
+
+    it('should get a list of families', async () => {
+      const [families] = await TABLE.getFamilies();
+      assert.strictEqual(families.length, 3);
+      assert(families[0] instanceof Family);
+      assert.notStrictEqual(-1, families.map(f => f.id).indexOf(FAMILY.id));
+    });
+
+    it('should get a family', async () => {
+      const family = TABLE.family(FAMILY_ID);
+      await family.get();
+      assert(family instanceof Family);
+      assert.strictEqual(family.name, FAMILY.name);
+      assert.strictEqual(family.id, FAMILY.id);
+    });
+
+    it('should check if a family exists', async () => {
+      const [exists] = await FAMILY.exists();
+      assert.strictEqual(exists, true);
+    });
+
+    it('should check if a family does not exist', async () => {
+      const family = TABLE.family('prezzies');
+      const [exists] = await family.exists();
+      assert.strictEqual(exists, false);
+    });
+
+    it('should create a family if autoCreate is true', async () => {
+      const family = TABLE.family('prezzies');
+      await family.get({autoCreate: true});
+      await family.delete();
+    });
+
+    it('should create a family with nested gc rules', async () => {
+      const family = TABLE.family('prezzies');
+      const options = {
+        rule: {
+          union: true,
+          versions: 10,
+          rule: {
+            versions: 2,
+            age: {seconds: 60 * 60 * 24 * 30},
+          },
+        },
+      };
+      await family.create(options);
+      const [metadata] = await family.getMetadata();
+      assert.deepStrictEqual(metadata.gcRule, {
+        union: {
+          rules: [
+            {
+              maxNumVersions: 10,
+              rule: 'maxNumVersions',
+            },
+            {
+              intersection: {
+                rules: [
+                  {
+                    maxAge: {
+                      seconds: '2592000',
+                      nanos: 0,
+                    },
+                    rule: 'maxAge',
+                  },
+                  {
+                    maxNumVersions: 2,
+                    rule: 'maxNumVersions',
+                  },
+                ],
+              },
+              rule: 'intersection',
+            },
+          ],
+        },
+        rule: 'union',
+      });
+      await family.delete();
+    });
+
+    it('should get the column family metadata', async () => {
+      const [metadata] = await FAMILY.getMetadata();
+      assert.strictEqual(FAMILY.metadata, metadata);
+    });
+
+    it('should update a column family', async () => {
+      const rule = {
+        age: {
+          seconds: 10000,
+          nanos: 10000,
+        },
+      };
+      const [metadata] = await FAMILY.setMetadata({rule});
+      const maxAge = metadata.gcRule!.maxAge;
+      assert.strictEqual(maxAge!.seconds, rule.age.seconds.toString());
+      assert.strictEqual(maxAge!.nanos, rule.age.nanos);
+    });
+
+    it('should delete a column family', async () => {
+      await FAMILY.delete();
+    });
+  });
+
+  describe('rows', () => {
+    describe('.exists()', () => {
+      const row = TABLE.row('alincoln');
+
+      beforeEach(async () => {
+        await row.create({
+          entry: {
+            follows: {
+              gwashington: 1,
+              jadams: 1,
+              tjefferson: 1,
+            },
+          },
+        });
+      });
+
+      afterEach(async () => row.delete());
+
+      it('should check if a row exists', async () => {
+        const [exists] = await row.exists();
+        assert.strictEqual(exists, true);
+      });
+
+      it('should check if a row does not exist', async () => {
+        const row = TABLE.row('gwashington');
+        const [exists] = await row.exists();
+        assert.strictEqual(exists, false);
+      });
+    });
+
+    describe('inserting data', () => {
+      it('should insert rows', async () => {
+        const rows = [
+          {
+            key: 'gwashington',
+            data: {
+              follows: {
+                jadams: 1,
+              },
+            },
+          },
+          {
+            key: 'tjefferson',
+            data: {
+              follows: {
+                gwashington: 1,
+                jadams: 1,
+              },
+            },
+          },
+          {
+            key: 'jadams',
+            data: {
+              follows: {
+                gwashington: 1,
+                tjefferson: 1,
+              },
+            },
+          },
+        ];
+        await TABLE.insert(rows);
+      });
+
+      it('should insert a large row', async () => {
+        await TABLE.insert({
+          key: 'gwashington',
+          data: {
+            follows: {
+              jadams: Buffer.alloc(5000000),
+            },
+          },
+        });
+      });
+
+      it('should create an individual row', async () => {
+        const row = TABLE.row('alincoln');
+        const rowData = {
+          follows: {
+            gwashington: 1,
+            jadams: 1,
+            tjefferson: 1,
+          },
+        };
+        await row.create({entry: rowData});
+      });
+
+      it('should insert individual cells', async () => {
+        const row = TABLE.row('gwashington');
+        const rowData = {
+          follows: {
+            jadams: 1,
+          },
+        };
+        await row.save(rowData);
+      });
+
+      it('should allow for user specified timestamps', async () => {
+        const row = TABLE.row('gwashington');
+        const rowData = {
+          follows: {
+            jadams: {
+              value: 1,
+              timestamp: new Date('March 22, 1986'),
+            },
+          },
+        };
+        await row.save(rowData);
+      });
+
+      it('should increment a column value', async () => {
+        const row = TABLE.row('gwashington');
+        const increment = 5;
+        const [value] = await row.increment('follows:increment', increment);
+        assert.strictEqual(value, increment);
+      });
+
+      it('should apply read/modify/write rules to a row', async () => {
+        const row = TABLE.row('gwashington');
+        const rule = {
+          column: 'traits:teeth',
+          append: '-wood',
+        };
+        await row.save({
+          traits: {
+            teeth: 'shiny',
+          },
+        });
+        await row.createRules(rule);
+        const [data] = await row.get(['traits:teeth']);
+        assert.strictEqual(data.traits.teeth[0].value, 'shiny-wood');
+      });
+
+      it('should check and mutate a row', async () => {
+        const row = TABLE.row('gwashington');
+        const filter: RawFilter = {
+          family: 'follows',
+          value: 'alincoln',
+        };
+        const mutations = [
+          {
+            method: 'delete',
+            data: ['follows:alincoln'],
+          },
+        ];
+        const [matched] = await row.filter(filter, {onMatch: mutations});
+        assert(matched);
+      });
+    });
+
+    describe('fetching data', () => {
+      it('should get rows', async () => {
+        const [rows] = await TABLE.getRows();
+        assert.strictEqual(rows.length, 4);
+        assert(rows[0] instanceof Row);
+      });
+
+      it('should get rows via stream', done => {
+        const rows: Row[] = [];
+        TABLE.createReadStream()
+          .on('error', done)
+          .on('data', row => {
+            assert(row instanceof Row);
+            rows.push(row);
+          })
+          .on('end', () => {
+            assert.strictEqual(rows.length, 4);
+            done();
+          });
+      });
+
+      it('should should cancel request if stream ended early', done => {
+        const rows: Row[] = [];
+        const stream = TABLE.createReadStream()
+          .on('error', done)
+          .on('data', row => {
+            stream.end();
+            rows.push(row);
+          })
+          .on('end', () => {
+            assert.strictEqual(rows.length, 1);
+            done();
+          });
+      });
+
+      it('should fetch an individual row', async () => {
+        const row = TABLE.row('alincoln');
+        const [row_] = await row.get();
+        assert.strictEqual(row, row_);
+      });
+
+      it('should limit the number of rows', async () => {
+        const [rows] = await TABLE.getRows({
+          limit: 1,
+        });
+        assert.strictEqual(rows.length, 1);
+      });
+
+      it('should fetch a range of rows', async () => {
+        const options = {
+          start: 'alincoln',
+          end: 'jadams',
+        };
+        const [rows] = await TABLE.getRows(options);
+        assert.strictEqual(rows.length, 3);
+      });
+
+      it('should fetch a range of rows via prefix', async () => {
+        const options = {
+          prefix: 'g',
+        };
+        const [rows] = await TABLE.getRows(options);
+        assert.strictEqual(rows.length, 1);
+        assert.strictEqual(rows[0].id, 'gwashington');
+      });
+
+      it('should fetch individual cells of a row', async () => {
+        const row = TABLE.row('alincoln');
+        const [data] = await row.get(['follows:gwashington']);
+        assert.strictEqual(data.follows.gwashington[0].value, 1);
+      });
+
+      it('should not decode the values', async () => {
+        const row = TABLE.row('gwashington');
+        const options = {
+          decode: false,
+        };
+        await row.get(options);
+        const teeth = row.data.traits.teeth;
+        const value = teeth[0].value;
+        assert(value instanceof Buffer);
+        assert.strictEqual(value.toString(), 'shiny-wood');
+      });
+
+      it('should get sample row keys', async () => {
+        const [keys] = await TABLE.sampleRowKeys();
+        assert(keys.length > 0);
+      });
+
+      it('should get sample row keys via stream', done => {
+        const keys: string[] = [];
+        TABLE.sampleRowKeysStream()
+          .on('error', done)
+          .on('data', (rowKey: string) => {
+            keys.push(rowKey);
+          })
+          .on('end', () => {
+            assert(keys.length > 0);
+            done();
+          });
+      });
+
+      it('should end stream early', async () => {
+        const entries = [
+          {
+            key: 'gwashington',
+            data: {
+              follows: {
+                jadams: 1,
+              },
+            },
+          },
+          {
+            key: 'tjefferson',
+            data: {
+              follows: {
+                gwashington: 1,
+                jadams: 1,
+              },
+            },
+          },
+          {
+            key: 'jadams',
+            data: {
+              follows: {
+                gwashington: 1,
+                tjefferson: 1,
+              },
+            },
+          },
+        ];
+        await TABLE.insert(entries);
+        const rows: Row[] = [];
+        await new Promise<void>((resolve, reject) => {
+          const stream = TABLE.createReadStream()
+            .on('error', reject)
+            .on('data', row => {
+              rows.push(row);
+              stream.end();
+            })
+            .on('end', () => {
+              assert.strictEqual(rows.length, 1);
+              resolve();
+            });
+        });
+      });
+
+      describe('filters', () => {
+        it('should get rows via column data', async () => {
+          const filter = {
+            column: 'gwashington',
+          };
+          const [rows] = await TABLE.getRows({filter});
+          assert.strictEqual(rows.length, 3);
+          const keys = rows.map(row => row.id).sort();
+          assert.deepStrictEqual(keys, ['alincoln', 'jadams', 'tjefferson']);
+        });
+
+        it('should get rows that satisfy the cell limit', async () => {
+          const entry = {
+            key: 'alincoln',
+            data: {
+              follows: {
+                tjefferson: 1,
+              },
+            },
+          };
+          const filter = [
+            {
+              row: 'alincoln',
+            },
+            {
+              column: {
+                name: 'tjefferson',
+                cellLimit: 1,
+              },
+            },
+          ];
+          await TABLE.insert(entry);
+          const [rows] = await TABLE.getRows({filter});
+          const rowData = rows[0].data;
+          assert.strictEqual(rowData.follows.tjefferson.length, 1);
+        });
+
+        it('should get a range of columns', async () => {
+          const filter = [
+            {
+              row: 'tjefferson',
+            },
+            {
+              column: {
+                family: 'follows',
+                start: 'gwashington',
+                end: 'jadams',
+              },
+            },
+          ];
+
+          const [rows] = await TABLE.getRows({filter});
+          rows.forEach(row => {
+            const keys = Object.keys(row.data.follows).sort();
+            assert.deepStrictEqual(keys, ['gwashington', 'jadams']);
+          });
+        });
+
+        it('should run a conditional filter', async () => {
+          const filter = {
+            condition: {
+              test: [
+                {
+                  row: 'gwashington',
+                },
+                {
+                  family: 'follows',
+                },
+                {
+                  column: 'tjefferson',
+                },
+              ],
+              pass: {
+                row: 'gwashington',
+              },
+              fail: {
+                row: 'tjefferson',
+              },
+            },
+          };
+          const [rows] = await TABLE.getRows({filter});
+          assert.strictEqual(rows.length, 1);
+          assert.strictEqual(rows[0].id, 'tjefferson');
+        });
+
+        it('should run a conditional filter with pass only', async () => {
+          const filter = {
+            condition: {
+              test: [
+                {
+                  row: 'gwashington',
+                },
+              ],
+              pass: [
+                {
+                  all: true,
+                },
+              ],
+            },
+          };
+          const [rows] = await TABLE.getRows({filter});
+          assert(rows.length > 0);
+        });
+
+        it('should only get cells for a specific family', async () => {
+          const entries = [
+            {
+              key: 'gwashington',
+              data: {
+                traits: {
+                  teeth: 'wood',
+                },
+              },
+            },
+          ];
+          await TABLE.insert(entries);
+          const filter = {
+            family: 'traits',
+          };
+          const [rows] = await TABLE.getRows({filter});
+          assert(rows.length > 0);
+          const families = Object.keys(rows[0].data);
+          assert.deepStrictEqual(families, ['traits']);
+        });
+
+        it('should interleave filters', async () => {
+          const filter = [
+            {
+              interleave: [
+                [
+                  {
+                    row: 'gwashington',
+                  },
+                ],
+                [
+                  {
+                    row: 'tjefferson',
+                  },
+                ],
+              ],
+            },
+          ];
+          const [rows] = await TABLE.getRows({filter});
+          assert.strictEqual(rows.length, 2);
+          const ids = rows.map(row => row.id).sort();
+          assert.deepStrictEqual(ids, ['gwashington', 'tjefferson']);
+        });
+
+        it('should apply labels to the results', async () => {
+          const filter = {
+            label: 'test-label',
+          };
+          const [rows] = await TABLE.getRows({filter});
+          rows.forEach(row => {
+            const follows = row.data.follows;
+            Object.keys(follows).forEach(column => {
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              follows[column].forEach((cell: any) => {
+                assert.deepStrictEqual(cell.labels, [filter.label]);
+              });
+            });
+          });
+        });
+
+        it('should run a regex against the row id', async () => {
+          const filter = {
+            row: /[a-z]+on$/,
+          };
+          const [rows] = await TABLE.getRows({filter});
+          const keys = rows.map(row => row.id).sort();
+          assert.deepStrictEqual(keys, ['gwashington', 'tjefferson']);
+        });
+
+        it('should run a sink filter', async () => {
+          const filter = [
+            {
+              row: 'alincoln',
+            },
+            {
+              family: 'follows',
+            },
+            {
+              interleave: [
+                [
+                  {
+                    all: true,
+                  },
+                ],
+                [
+                  {
+                    label: 'prezzy',
+                  },
+                  {
+                    sink: true,
+                  },
+                ],
+              ],
+            },
+            {
+              column: 'gwashington',
+            },
+          ];
+          const [rows] = await TABLE.getRows({filter});
+          const columns = Object.keys(rows[0].data.follows).sort();
+          assert.deepStrictEqual(columns, [
+            'gwashington',
+            'jadams',
+            'tjefferson',
+          ]);
+        });
+      });
+
+      it('should accept a date range', async () => {
+        const filter = {
+          time: {
+            start: new Date('March 21, 1986'),
+            end: new Date('March 23, 1986'),
+          },
+        };
+        const [rows] = await TABLE.getRows({filter});
+        assert(rows.length > 0);
+      });
+    });
+  });
+
+  describe('deleting rows', () => {
+    it('should delete specific cells', async () => {
+      const row = TABLE.row('alincoln');
+      await row.deleteCells(['follows:gwashington']);
+    });
+
+    it('should delete a family', async () => {
+      const row = TABLE.row('gwashington');
+      await row.deleteCells(['traits']);
+    });
+
+    it('should delete all the cells', async () => {
+      const row = TABLE.row('alincoln');
+      await row.delete();
+    });
+  });
+
+  describe('.deleteRows()', () => {
+    const table = INSTANCE.table(generateId('table'));
+    beforeEach(async () => {
+      const tableOptions = {
+        families: ['cf1'],
+      };
+      const data = {
+        cf1: {
+          foo: 1,
+        },
+      };
+      const rows = [
+        {
+          key: 'aaa',
+          data,
+        },
+        {
+          key: 'abc',
+          data,
+        },
+        {
+          key: 'def',
+          data,
+        },
+      ];
+      await table.create(tableOptions);
+      await table.insert(rows);
+    });
+
+    afterEach(async () => {
+      await table.delete();
+    });
+
+    it('should delete the prefixes', async () => {
+      await table.deleteRows('a');
+      const [rows] = await table.getRows();
+      assert.strictEqual(rows.length, 1);
+    });
+  });
+
+  describe('.truncate()', () => {
+    const table = INSTANCE.table(generateId('table'));
+    beforeEach(async () => {
+      const tableOptions = {
+        families: ['follows'],
+      };
+      const rows = [
+        {
+          key: 'gwashington',
+          data: {
+            follows: {
+              jadams: 1,
+            },
+          },
+        },
+      ];
+      await table.create(tableOptions);
+      await table.insert(rows);
+    });
+
+    afterEach(async () => {
+      await table.delete();
+    });
+
+    it('should truncate a table', async () => {
+      await table.truncate();
+      const [rows] = await table.getRows();
+      assert.strictEqual(rows.length, 0);
+    });
+  });
+
+  describe('backups', () => {
+    const CLUSTER = INSTANCE.cluster(CLUSTER_ID);
+    let BACKUP: Backup;
+
+    // For these tests, two backups are needed. The backups are labeled for what
+    // they are intended to originate/interact from/with, but this is just for
+    // testing and the naming convention used here does not actually influence
+    // the real functionality - it is just a way to keep things organized!
+    const backupIdFromCluster = generateId('backup');
+    let backupNameFromCluster: string;
+    const restoreTableIdFromCluster = generateId('table');
+
+    const backupIdFromTable = generateId('backup');
+    let backupNameFromTable: string;
+
+    // The minimum backup expiry time is 6 hours. The times here each have a 2
+    // hour padding to tolerate latency and clock drift. Also, while the time
+    // implementation for backups in this client accepts any of a Timestamp
+    // Struct, Date, or PreciseDate, to keep things easy this uses PreciseDate.
+    const expireTime = new PreciseDate(PreciseDate.now() + 8 * 60 * 60 * 1000);
+    const updateExpireTime = new PreciseDate(
+      expireTime.getTime() + 2 + 60 * 60 * 1000
+    );
+
+    before(async () => {
+      const [backup, op] = await CLUSTER.createBackup(backupIdFromCluster, {
+        table: TABLE,
+        expireTime,
+      });
+      BACKUP = backup;
+      await op.promise();
+      backupNameFromCluster = replaceProjectIdToken(
+        `${CLUSTER.name}/backups/${backupIdFromCluster}`,
+        bigtable.projectId
+      );
+      backupNameFromTable = replaceProjectIdToken(
+        `${CLUSTER.name}/backups/${backupIdFromTable}`,
+        bigtable.projectId
+      );
+    });
+
+    it('should create backup of a table (from cluster)', async () => {
+      await BACKUP.getMetadata();
+
+      assert.strictEqual(BACKUP.metadata!.name, backupNameFromCluster);
+
+      assert.deepStrictEqual(BACKUP.expireDate, expireTime);
+    });
+
+    it('should create backup of a table (from table)', async () => {
+      const [backup, op] = await TABLE.createBackup(backupIdFromTable, {
+        expireTime,
+      });
+      await op.promise();
+      await backup.getMetadata();
+
+      assert.strictEqual(backup.metadata!.name, backupNameFromTable);
+
+      assert.deepStrictEqual(backup.expireDate, expireTime);
+    });
+
+    it('should get a specific backup (cluster)', async () => {
+      const [backup] = await CLUSTER.backup(backupIdFromCluster).get();
+      assert.strictEqual(backup.metadata!.name, backupNameFromCluster);
+      assert.strictEqual(backup.metadata!.state, 'READY');
+    });
+
+    it('should get backups in an instance', async () => {
+      const [backups] = await INSTANCE.getBackups();
+      assert(Array.isArray(backups));
+      assert(backups.length > 0);
+      assert(backups.some(backup => backup.id === BACKUP.id));
+    });
+
+    it('should get backups in an instance as a stream', done => {
+      const backups: Backup[] = [];
+
+      INSTANCE.getBackupsStream()
+        .on('error', done)
+        .on('data', backup => {
+          backups.push(backup);
+        })
+        .on('end', () => {
+          assert(backups.length > 0);
+          done();
+        });
+    });
+
+    it('should get backups in a cluster', async () => {
+      const [backups] = await CLUSTER.getBackups();
+      assert(Array.isArray(backups));
+      assert(backups.length > 0);
+      assert(backups.some(backup => backup.id === BACKUP.id));
+    });
+
+    it('should get backups in a cluster as a stream', done => {
+      const backups: Backup[] = [];
+
+      CLUSTER.getBackupsStream()
+        .on('error', done)
+        .on('data', backup => {
+          backups.push(backup);
+        })
+        .on('end', () => {
+          assert(backups.length > 0);
+          done();
+        });
+    });
+
+    it('should restore a backup (cluster)', async () => {
+      const backup = CLUSTER.backup(backupIdFromCluster);
+      const [table, op] = await backup.restore(restoreTableIdFromCluster);
+      await op.promise();
+
+      const restoredTableId = table.name?.split('/').pop();
+      assert.strictEqual(restoredTableId, restoreTableIdFromCluster);
+    });
+
+    it('should restore a backup to a different instance', async () => {
+      const [, operation] = await DIFF_INSTANCE.create(
+        createInstanceConfig(generateId('d-clust'), 'us-east1-c', 3, Date.now())
+      );
+      await operation.promise();
+      const [iExists] = await DIFF_INSTANCE.exists();
+      assert.strictEqual(iExists, true);
+
+      const backup = CLUSTER.backup(backupIdFromCluster);
+      const [table, op] = await backup.restoreTo({
+        tableId: restoreTableIdFromCluster,
+        instance: DIFF_INSTANCE,
+      });
+      await op.promise();
+      const [tExists] = await table.exists();
+      assert.strictEqual(tExists, true);
+      assert.strictEqual(table.id, restoreTableIdFromCluster);
+    });
+
+    it('should update a backup (cluster)', async () => {
+      const backup = CLUSTER.backup(backupIdFromCluster);
+      const [metadata] = await backup.setMetadata({
+        expireTime: updateExpireTime,
+      });
+
+      assert.strictEqual(metadata.name, backupNameFromCluster);
+      assert.deepStrictEqual(backup.expireDate, updateExpireTime);
+    });
+
+    it('should get an Iam Policy for the backup', async () => {
+      const policyProperties = ['version', 'bindings', 'etag'];
+      const [policy] = await BACKUP.getIamPolicy();
+
+      policyProperties.forEach(property => {
+        assert(property in policy);
+      });
+    });
+
+    it('should test Iam permissions for the backup', async () => {
+      const permissions = ['bigtable.backups.get', 'bigtable.backups.delete'];
+      const [grantedPermissions] = await BACKUP.testIamPermissions(permissions);
+      assert.strictEqual(grantedPermissions.length, permissions.length);
+      permissions.forEach(permission => {
+        assert.strictEqual(grantedPermissions.includes(permission), true);
+      });
+    });
+
+    it('should set Iam Policy on the backup', async () => {
+      const backup = CLUSTER.backup(backupIdFromCluster);
+
+      const [policy] = await backup.getIamPolicy();
+      const [updatedPolicy] = await backup.setIamPolicy(policy);
+
+      Object.keys(policy).forEach(key => assert(key in updatedPolicy));
+    });
+    describe('copying backups', () => {
+      // The server requires the copy backup time to be sufficiently ahead of
+      // the create backup time to avoid an error.
+      // Set it to 308 hours ahead
+      const sourceExpireTimeMilliseconds =
+        PreciseDate.now() + (8 + 300) * 60 * 60 * 1000;
+      const sourceExpireTime = new PreciseDate(sourceExpireTimeMilliseconds);
+      // 608 hours ahead of now, 300 hours ahead of sourceExpireTimeMilliseconds
+      const copyExpireTimeMilliseconds =
+        PreciseDate.now() + (8 + 600) * 60 * 60 * 1000;
+      const copyExpireTime = new PreciseDate(copyExpireTimeMilliseconds);
+
+      /*
+        This function checks that when a backup is copied using the provided
+        config that a new backup is created on the instance.
+       */
+      async function testCopyBackup(
+        backup: Backup,
+        config: CopyBackupConfig,
+        instance: Instance
+      ) {
+        // Get a list of backup ids before the copy
+        const [backupsBeforeCopy] = await instance.getBackups();
+        const backupIdsBeforeCopy = backupsBeforeCopy.map(backup => backup.id);
+        // Copy the backup
+        const [newBackup, operation] = await backup.copy(config);
+        try {
+          assert.strictEqual(config.id, newBackup.id);
+          await operation.promise();
+          const id = config.id;
+          const backupPath = `${config.cluster.name}/backups/${id}`;
+          {
+            // Ensure that the backup specified by the config and id match the backup name for the operation returned by the server.
+            // the split/map/join functions replace the project name with the {{projectId}} string
+            assert(operation);
+            assert(operation.metadata);
+            assert.strictEqual(
+              operation.metadata.name
+                .split('/')
+                .map((item, index) => (index === 1 ? '{{projectId}}' : item))
+                .join('/'),
+              backupPath
+                .split('/')
+                .map((item, index) => (index === 1 ? '{{projectId}}' : item))
+                .join('/')
+            );
+          }
+          // Check that there is now one more backup
+          const [backupsAfterCopy] = await instance.getBackups();
+          const newBackups = backupsAfterCopy.filter(
+            backup => !backupIdsBeforeCopy.includes(backup.id)
+          );
+          assert.strictEqual(newBackups.length, 1);
+          const [fetchedNewBackup] = newBackups;
+          // Ensure the fetched backup matches the config
+          assert.strictEqual(fetchedNewBackup.id, id);
+          assert.strictEqual(fetchedNewBackup.name, backupPath);
+          // Delete the copied backup
+        } finally {
+          await config.cluster.backup(newBackup.id).delete();
+        }
+      }
+
+      describe('should create backup of a table and copy it in the same cluster', async () => {
+        async function testWithExpiryTimes(
+          sourceTestExpireTime: BackupTimestamp,
+          copyTestExpireTime: BackupTimestamp
+        ) {
+          const [backup, op] = await TABLE.createBackup(generateId('backup'), {
+            expireTime: sourceTestExpireTime,
+          });
+          try {
+            {
+              await op.promise();
+              // Check expiry time for running operation.
+              await backup.getMetadata();
+              assert.deepStrictEqual(backup.expireDate, sourceExpireTime);
+            }
+            await testCopyBackup(
+              backup,
+              {
+                cluster: backup.cluster,
+                id: generateId('backup'),
+                expireTime: copyTestExpireTime,
+              },
+              INSTANCE
+            );
+          } finally {
+            await backup.delete();
+          }
+        }
+        it('should copy to the same cluster with precise date expiry times', async () => {
+          await testWithExpiryTimes(sourceExpireTime, copyExpireTime);
+        });
+        it('should copy to the same cluster with timestamp expiry times', async () => {
+          // Calling toStruct converts times to a timestamp object.
+          // For example: sourceExpireTime.toStruct() = {seconds: 1706659851, nanos: 981000000}
+          await testWithExpiryTimes(
+            sourceExpireTime.toStruct(),
+            copyExpireTime.toStruct()
+          );
+        });
+        it('should copy to the same cluster with date expiry times', async () => {
+          await testWithExpiryTimes(
+            new Date(sourceExpireTimeMilliseconds),
+            new Date(copyExpireTimeMilliseconds)
+          );
+        });
+      });
+      it('should create backup of a table and copy it on another cluster of another instance', async () => {
+        const [backup, op] = await TABLE.createBackup(generateId('backup'), {
+          expireTime: sourceExpireTime,
+        });
+        try {
+          {
+            await op.promise();
+            // Check the expiry time.
+            await backup.getMetadata();
+            assert.deepStrictEqual(backup.expireDate, sourceExpireTime);
+          }
+          // Create another instance
+          const instance = bigtable.instance(generateId('instance'));
+          const destinationClusterId = generateId('cluster');
+          {
+            // Create production instance with given options
+            const instanceOptions: InstanceOptions = {
+              clusters: [
+                {
+                  id: destinationClusterId,
+                  nodes: 3,
+                  location: 'us-central1-f',
+                  storage: 'ssd',
+                },
+              ],
+              labels: {'prod-label': 'prod-label'},
+              type: 'production',
+            };
+            const [, operation] = await instance.create(instanceOptions);
+            await operation.promise();
+          }
+          // Create the copy and test the copied backup
+          await testCopyBackup(
+            backup,
+            {
+              cluster: new Cluster(instance, destinationClusterId),
+              id: generateId('backup'),
+              expireTime: copyExpireTime,
+            },
+            instance
+          );
+          await instance.delete();
+        } finally {
+          await backup.delete();
+        }
+      });
+      it('should create backup of a table and copy it on another cluster of the same instance', async () => {
+        const [backup, op] = await TABLE.createBackup(generateId('backup'), {
+          expireTime: sourceExpireTime,
+        });
+        try {
+          {
+            await op.promise();
+            // Check the expiry time.
+            await backup.getMetadata();
+            assert.deepStrictEqual(backup.expireDate, sourceExpireTime);
+          }
+          const destinationClusterId = generateId('cluster');
+          {
+            // Create destination cluster with given options
+            const [, operation] = await INSTANCE.cluster(
+              destinationClusterId
+            ).create({
+              location: 'us-central1-b',
+              nodes: 3,
+            });
+            await operation.promise();
+          }
+          // Create the copy and test the copied backup
+          await testCopyBackup(
+            backup,
+            {
+              cluster: new Cluster(INSTANCE, destinationClusterId),
+              id: generateId('backup'),
+              expireTime: copyExpireTime,
+            },
+            INSTANCE
+          );
+        } finally {
+          await backup.delete();
+        }
+      });
+      it('should create backup of a table and copy it on another project', async () => {
+        const [backup, op] = await TABLE.createBackup(generateId('backup'), {
+          expireTime: sourceExpireTime,
+        });
+        try {
+          {
+            await op.promise();
+            // Check the expiry time.
+            await backup.getMetadata();
+            assert.deepStrictEqual(backup.expireDate, sourceExpireTime);
+          }
+          // Create client, instance, cluster for second project
+          const bigtableSecondaryProject = new Bigtable(
+            process.env.GCLOUD_PROJECT2
+              ? {projectId: process.env.GCLOUD_PROJECT2}
+              : {}
+          );
+          const secondInstance = bigtableSecondaryProject.instance(
+            generateId('instance')
+          );
+          const destinationClusterId = generateId('cluster');
+          {
+            // Create production instance with given options
+            const instanceOptions: InstanceOptions = {
+              clusters: [
+                {
+                  id: destinationClusterId,
+                  nodes: 3,
+                  location: 'us-central1-f',
+                  storage: 'ssd',
+                },
+              ],
+              labels: {'prod-label': 'prod-label'},
+              type: 'production',
+            };
+            const [, operation] = await secondInstance.create(instanceOptions);
+            await operation.promise();
+          }
+          // Create the copy and test the copied backup
+          await testCopyBackup(
+            backup,
+            {
+              cluster: new Cluster(secondInstance, destinationClusterId),
+              id: generateId('backup'),
+              expireTime: copyExpireTime,
+            },
+            secondInstance
+          );
+          await secondInstance.delete();
+        } finally {
+          await backup.delete();
+        }
+      });
+      it('should restore a copied backup', async () => {
+        const backupId = generateId('backup');
+        const table = INSTANCE.table('old-table');
+        {
+          // Create a table and insert data into it.
+          await table.create();
+          await table.createFamily('follows');
+          await table.insert([
+            {
+              key: 'some-data-to-copy-key',
+              data: {
+                follows: {
+                  copyData: 'data-to-copy',
+                },
+              },
+            },
+          ]);
+        }
+        // Create the backup
+        const [backup, createBackupOperation] = await table.createBackup(
+          backupId,
+          {
+            expireTime: sourceExpireTime,
+          }
+        );
+        try {
+          await createBackupOperation.promise();
+          // Copy the backup
+          const config = {
+            cluster: backup.cluster,
+            id: generateId('backup'),
+            expireTime: copyExpireTime,
+          };
+          const [newBackup, copyOperation] = await backup.copy(config);
+          await copyOperation.promise();
+          // Restore a table from the copied backup
+          const [newTable, restoreOperation] =
+            await newBackup.restore('new-table');
+          await restoreOperation.promise();
+          const rows = await newTable.getRows();
+          assert.deepStrictEqual(rows[0][0].id, 'some-data-to-copy-key');
+        } finally {
+          await backup.delete();
+        }
+      });
+    });
+  });
 
   describe('mutateRows entries tests', () => {
     const table = INSTANCE.table(generateId('table'));

--- a/system-test/bigtable.ts
+++ b/system-test/bigtable.ts
@@ -1714,37 +1714,87 @@ describe.only('Bigtable', () => {
   //   });
   // });
 
-  describe('mutate', () => {
+  describe('mutateRows entries tests', () => {
     const table = INSTANCE.table(generateId('table'));
-    beforeEach(async () => {
-      const tableOptions = {
-        families: ['follows'],
-      };
-      const entry = {
-        key: 'alincoln',
-        data: {
-          follows: {
-            tjefferson: 1,
-          },
-        },
-      };
-      const mutation = {
-        key: 'some-id',
-        data: entry,
-        method: Mutation.methods.INSERT,
-      };
-      await table.create(tableOptions);
-      const gaxOptions = {maxRetries: 4};
-      await table.mutate(mutation, {gaxOptions});
-    });
 
     afterEach(async () => {
       await table.delete();
     });
 
-    it('should get one row from the table', async () => {
+    it('should only insert one row in the table with mutate', async () => {
+      // Create table
+      const tableOptions = {
+        families: ['columnFamily'],
+      };
+      await table.create(tableOptions);
+      // Add entries
+      const entry = {
+        columnFamily: {
+          column: 1,
+        },
+      };
+      const mutation = {
+        key: 'rowKey',
+        data: entry,
+        method: Mutation.methods.INSERT,
+      };
+      const gaxOptions = {maxRetries: 4};
+      await table.mutate(mutation, {gaxOptions});
+      // Get rows and compare
       const [rows] = await table.getRows();
       assert.strictEqual(rows.length, 1);
+    });
+
+    it('should insert one row in the table using mutate in a similar way to how the documentation says to use insert', async () => {
+      // Create table
+      const tableOptions = {
+        families: ['columnFamily'],
+      };
+      await table.create(tableOptions);
+      // Add entries
+      const mutation = {
+        key: 'rowKey',
+        data: {
+          columnFamily: {
+            column: 1,
+          },
+        },
+        method: Mutation.methods.INSERT,
+      };
+      const gaxOptions = {maxRetries: 4};
+      await table.mutate(mutation, {gaxOptions});
+      // Get rows and compare
+      const [rows] = await table.getRows();
+      assert.strictEqual(rows.length, 1);
+    });
+
+    it('should only insert one row in the table with insert as described by the GCP documentation', async () => {
+      // Create table
+      const tableOptions = {
+        families: ['follows'],
+      };
+      await table.create(tableOptions);
+      // Add entries
+      const greetings = ['Hello World!', 'Hello Bigtable!', 'Hello Node!'];
+      const rowsToInsert = greetings.map((greeting, index) => ({
+        key: `greeting${index}`,
+        data: {
+          follows: {
+            // 'follows' is the column family
+            someColumn: {
+              // Setting the timestamp allows the client to perform retries. If
+              // server-side time is used, retries may cause multiple cells to
+              // be generated.
+              timestamp: new Date(),
+              value: greeting,
+            },
+          },
+        },
+      }));
+      await table.insert(rowsToInsert);
+      // Get rows and compare
+      const [rows] = await table.getRows();
+      assert.strictEqual(rows.length, 3);
     });
   });
 });

--- a/system-test/bigtable.ts
+++ b/system-test/bigtable.ts
@@ -34,7 +34,7 @@ import {Table} from '../src/table.js';
 import {RawFilter} from '../src/filter';
 import {generateId, PREFIX} from './common';
 
-describe('Bigtable', () => {
+describe.only('Bigtable', () => {
   const bigtable = new Bigtable();
   const INSTANCE = bigtable.instance(generateId('instance'));
   const DIFF_INSTANCE = bigtable.instance(generateId('d-inst'));
@@ -121,1597 +121,1597 @@ describe('Bigtable', () => {
     );
   });
 
-  describe('instances', () => {
-    it('should get a list of instances', async () => {
-      const [instances, failedLocations] = await bigtable.getInstances();
-      assert(instances.length > 0);
-      assert(Array.isArray(failedLocations));
-    });
-
-    it('should check if an instance exists', async () => {
-      const [exists] = await INSTANCE.exists();
-      assert.strictEqual(exists, true);
-    });
-
-    it('should check if an instance does not exist', async () => {
-      const instance = bigtable.instance('fake-instance');
-      const [exists] = await instance.exists();
-      assert.strictEqual(exists, false);
-    });
-
-    it('should get a single instance', async () => {
-      await INSTANCE.get();
-    });
-
-    it('should update an instance', async () => {
-      const metadata = {
-        displayName: 'metadata-test',
-      };
-      await INSTANCE.setMetadata(metadata);
-      const [metadata_] = await INSTANCE.getMetadata();
-      assert.strictEqual(metadata.displayName, metadata_.displayName);
-    });
-
-    it('should get an Iam Policy for the instance', async () => {
-      const policyProperties = ['version', 'bindings', 'etag'];
-      const [policy] = await INSTANCE.getIamPolicy();
-      policyProperties.forEach(property => {
-        assert(property in policy);
-      });
-    });
-
-    it('should test Iam permissions for the instance', async () => {
-      const permissions = ['bigtable.tables.get', 'bigtable.tables.readRows'];
-      const [grantedPermissions] =
-        await INSTANCE.testIamPermissions(permissions);
-      assert.strictEqual(grantedPermissions.length, permissions.length);
-      permissions.forEach(permission => {
-        assert.strictEqual(grantedPermissions.includes(permission), true);
-      });
-    });
-
-    it('should set Iam Policy on the instance', async () => {
-      const instance = bigtable.instance(generateId('instance'));
-      const clusteId = generateId('cluster');
-      const [, operation] = await instance.create({
-        clusters: [
-          {
-            id: clusteId,
-            location: 'us-central1-c',
-            nodes: 3,
-          },
-        ],
-        labels: {
-          time_created: Date.now(),
-        },
-      });
-      await operation.promise();
-
-      const [policy] = await instance.getIamPolicy();
-      const [updatedPolicy] = await instance.setIamPolicy(policy);
-      Object.keys(policy).forEach(key => assert(key in updatedPolicy));
-
-      await instance.delete();
-    });
-  });
-
-  describe('CMEK', () => {
-    let kmsKeyName: string;
-
-    const CMEK_CLUSTER = CMEK_INSTANCE.cluster(generateId('cluster'));
-
-    const cryptoKeyId = generateId('key');
-    const keyRingId = generateId('key-ring');
-    let keyRingsBaseUrl: string;
-    let cryptoKeyVersionName: string;
-
-    before(async () => {
-      const projectId = await bigtable.auth.getProjectId();
-      kmsKeyName = `projects/${projectId}/locations/us-central1/keyRings/${keyRingId}/cryptoKeys/${cryptoKeyId}`;
-      keyRingsBaseUrl = `https://cloudkms.googleapis.com/v1/projects/${projectId}/locations/us-central1/keyRings`;
-
-      await bigtable.auth.request({
-        method: 'POST',
-        url: keyRingsBaseUrl,
-        params: {keyRingId},
-      });
-
-      const resp = await bigtable.auth.request({
-        method: 'POST',
-        url: `${keyRingsBaseUrl}/${keyRingId}/cryptoKeys`,
-        params: {cryptoKeyId},
-        data: {purpose: 'ENCRYPT_DECRYPT'},
-      });
-      cryptoKeyVersionName = resp.data.primary.name;
-
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const [_, operation] = await CMEK_INSTANCE.create({
-        clusters: [
-          {
-            id: CMEK_CLUSTER.id,
-            location: 'us-central1-a',
-            nodes: 3,
-            key: kmsKeyName,
-          },
-        ],
-        labels: {
-          time_created: Date.now(),
-        },
-      });
-      await operation.promise();
-    });
-
-    after(async () => {
-      await bigtable.auth.request({
-        method: 'POST',
-        url: `${keyRingsBaseUrl}/${keyRingId}/cryptoKeys/${cryptoKeyId}/cryptoKeyVersions/${cryptoKeyVersionName
-          .split('/')
-          .pop()}:destroy`,
-        params: {name: cryptoKeyVersionName},
-      });
-    });
-
-    it('should have created an instance', async () => {
-      const [metadata] = await CMEK_CLUSTER.getMetadata();
-      assert.deepStrictEqual(metadata.encryptionConfig, {kmsKeyName});
-    });
-
-    it('should create a cluster', async () => {
-      const cluster = CMEK_INSTANCE.cluster(generateId('cluster'));
-
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const [_, operation] = await cluster.create({
-        location: 'us-central1-b',
-        nodes: 3,
-        key: kmsKeyName,
-      });
-      await operation.promise();
-
-      const [metadata] = await cluster.getMetadata();
-      assert.deepStrictEqual(metadata.encryptionConfig, {kmsKeyName});
-    });
-
-    it('should fail if key not provided', async () => {
-      const cluster = CMEK_INSTANCE.cluster(generateId('cluster'));
-
-      try {
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        const [_, operation] = await cluster.create({
-          location: 'us-central1-b',
-          nodes: 3,
-        });
-        await operation.promise();
-        throw new Error('Cluster creation should not have succeeded');
-      } catch (e) {
-        assert(
-          (e as Error).message.includes(
-            'default keys and CMEKs are not allowed'
-          )
-        );
-      }
-    });
-  });
-
-  describe('appProfiles', () => {
-    it('should retrieve a list of app profiles', async () => {
-      const [appProfiles] = await INSTANCE.getAppProfiles();
-      assert(appProfiles[0] instanceof AppProfile);
-      assert(appProfiles.length > 0);
-    });
-
-    it('should retrieve a list of app profiles in stream mode', done => {
-      const appProfiles: AppProfile[] = [];
-      INSTANCE.getAppProfilesStream()
-        .on('error', done)
-        .on('data', appProfile => {
-          assert(appProfile instanceof AppProfile);
-          appProfiles.push(appProfile);
-        })
-        .on('end', () => {
-          assert(appProfiles.length > 0);
-          done();
-        });
-    });
-
-    it('should check if an app profile exists', async () => {
-      const [exists] = await APP_PROFILE.exists();
-      assert.strictEqual(exists, true);
-    });
-
-    it('should check if an app profile does not exist', async () => {
-      const appProfile = INSTANCE.appProfile('should-not-exist');
-      const [exists] = await appProfile.exists();
-      assert.strictEqual(exists, false);
-    });
-
-    it('should get an app profile', async () => {
-      await APP_PROFILE.get();
-    });
-
-    it('should delete an app profile', async () => {
-      const appProfile = INSTANCE.appProfile(generateId('app-profile'));
-      await appProfile.create({
-        routing: 'any',
-        ignoreWarnings: true,
-      });
-      await appProfile.delete({ignoreWarnings: true});
-    });
-
-    it('should get the app profiles metadata', async () => {
-      const [metadata] = await APP_PROFILE.getMetadata();
-      assert.strictEqual(
-        metadata.name,
-        APP_PROFILE.name.replace('{{projectId}}', bigtable.projectId)
-      );
-    });
-
-    it('should update an app profile', async () => {
-      const cluster = INSTANCE.cluster(CLUSTER_ID);
-      const options = {
-        routing: cluster,
-        allowTransactionalWrites: true,
-        description: 'My Updated App Profile',
-      };
-      await APP_PROFILE.setMetadata(options);
-      const [updatedAppProfile] = await APP_PROFILE.get();
-      assert.strictEqual(
-        updatedAppProfile.metadata!.description,
-        options.description
-      );
-      assert.deepStrictEqual(updatedAppProfile.metadata!.singleClusterRouting, {
-        clusterId: CLUSTER_ID,
-        allowTransactionalWrites: true,
-      });
-    });
-  });
-
-  describe('clusters', () => {
-    let CLUSTER: Cluster;
-
-    beforeEach(() => {
-      CLUSTER = INSTANCE.cluster(CLUSTER_ID);
-    });
-
-    it('should retrieve a list of clusters', async () => {
-      const [clusters] = await INSTANCE.getClusters();
-      assert(clusters[0] instanceof Cluster);
-    });
-
-    it('should check if a cluster exists', async () => {
-      const [exists] = await CLUSTER.exists();
-      assert.strictEqual(exists, true);
-    });
-
-    it('should check if a cluster does not exist', async () => {
-      const cluster = INSTANCE.cluster('fake-cluster');
-      const [exists] = await cluster.exists();
-      assert.strictEqual(exists, false);
-    });
-
-    it('should get a cluster', async () => {
-      await CLUSTER.get();
-    });
-
-    it('should update a cluster', async () => {
-      const metadata = {
-        nodes: 4,
-      };
-      const [operation] = await CLUSTER.setMetadata(metadata);
-      await operation.promise();
-      const [_metadata] = await CLUSTER.getMetadata();
-      assert.strictEqual(metadata.nodes, _metadata.serveNodes);
-    });
-  });
-
-  describe('tables', () => {
-    it('should retrieve a list of tables', async () => {
-      const [tables] = await INSTANCE.getTables();
-      assert(tables[0] instanceof Table);
-    });
-
-    it('should retrieve a list of tables in stream mode', done => {
-      const tables: Table[] = [];
-      INSTANCE.getTablesStream()
-        .on('error', done)
-        .on('data', table => {
-          assert(table instanceof Table);
-          tables.push(table);
-        })
-        .on('end', () => {
-          assert(tables.length > 0);
-          done();
-        });
-    });
-
-    it('should check if a table exists', async () => {
-      const [exists] = await TABLE.exists();
-      assert.strictEqual(exists, true);
-    });
-
-    it('should check if a table does not exist', async () => {
-      const table = INSTANCE.table('should-not-exist');
-      const [exists] = await table.exists();
-      assert.strictEqual(exists, false);
-    });
-
-    it('should get a table', async () => {
-      await TABLE.get();
-    });
-
-    it('should get an Iam Policy for the table', async () => {
-      const policyProperties = ['version', 'bindings', 'etag'];
-      const [policy] = await TABLE.getIamPolicy();
-      policyProperties.forEach(property => {
-        assert(property in policy);
-      });
-    });
-
-    it('should test Iam permissions for the table', async () => {
-      const permissions = ['bigtable.tables.get', 'bigtable.tables.readRows'];
-      const [grantedPermissions] = await TABLE.testIamPermissions(permissions);
-      assert.strictEqual(grantedPermissions.length, permissions.length);
-      permissions.forEach(permission => {
-        assert.strictEqual(grantedPermissions.includes(permission), true);
-      });
-    });
-
-    it('should set Iam Policy on the table', async () => {
-      const table = INSTANCE.table(generateId('table'));
-      await table.create();
-
-      const [policy] = await table.getIamPolicy();
-      const [updatedPolicy] = await table.setIamPolicy(policy);
-      Object.keys(policy).forEach(key => assert(key in updatedPolicy));
-
-      await table.delete();
-    });
-
-    it('should delete a table', async () => {
-      const table = INSTANCE.table(generateId('table'));
-      await table.create();
-      await table.delete();
-    });
-
-    it('should get the tables metadata', async () => {
-      const [metadata] = await TABLE.getMetadata();
-      assert.strictEqual(
-        metadata.name,
-        TABLE.name.replace('{{projectId}}', bigtable.projectId)
-      );
-    });
-
-    it('should create a table with column family data', async () => {
-      const name = generateId('table');
-      const options = {
-        families: ['test'],
-      };
-      const [table] = await INSTANCE.createTable(name, options);
-      assert(table.metadata!.columnFamilies!.test);
-    });
-
-    it('should create a table if autoCreate is true', async () => {
-      const table = INSTANCE.table(generateId('table'));
-      await table.get({autoCreate: true});
-      await table.delete();
-    });
-  });
-
-  describe('consistency tokens', () => {
-    it('should generate consistency token', async () => {
-      const [token] = await TABLE.generateConsistencyToken();
-      assert.strictEqual(typeof token, 'string');
-    });
-
-    it('should return error for checkConsistency of invalid token', done => {
-      TABLE.checkConsistency('dummy-token', err => {
-        assert.strictEqual(err!.code, 3);
-        done();
-      });
-    });
-
-    it('should return boolean for checkConsistency of token', async () => {
-      const [token] = await TABLE.generateConsistencyToken();
-      const [res] = await TABLE.checkConsistency(token);
-      assert.strictEqual(typeof res, 'boolean');
-    });
-
-    it('should return boolean for waitForReplication', async () => {
-      const [res] = await TABLE.waitForReplication();
-      assert.strictEqual(typeof res, 'boolean');
-    });
-  });
-
-  describe('replication states', () => {
-    it('should get a map of clusterId and state', async () => {
-      const [clusterStates] = await TABLE.getReplicationStates();
-      assert(clusterStates instanceof Map);
-      assert(clusterStates.has(CLUSTER_ID));
-    });
-  });
-
-  describe('column families', () => {
-    const FAMILY_ID = 'presidents';
-    let FAMILY: Family;
-
-    before(async () => {
-      FAMILY = TABLE.family(FAMILY_ID);
-      await FAMILY.create();
-    });
-
-    it('should get a list of families', async () => {
-      const [families] = await TABLE.getFamilies();
-      assert.strictEqual(families.length, 3);
-      assert(families[0] instanceof Family);
-      assert.notStrictEqual(-1, families.map(f => f.id).indexOf(FAMILY.id));
-    });
-
-    it('should get a family', async () => {
-      const family = TABLE.family(FAMILY_ID);
-      await family.get();
-      assert(family instanceof Family);
-      assert.strictEqual(family.name, FAMILY.name);
-      assert.strictEqual(family.id, FAMILY.id);
-    });
-
-    it('should check if a family exists', async () => {
-      const [exists] = await FAMILY.exists();
-      assert.strictEqual(exists, true);
-    });
-
-    it('should check if a family does not exist', async () => {
-      const family = TABLE.family('prezzies');
-      const [exists] = await family.exists();
-      assert.strictEqual(exists, false);
-    });
-
-    it('should create a family if autoCreate is true', async () => {
-      const family = TABLE.family('prezzies');
-      await family.get({autoCreate: true});
-      await family.delete();
-    });
-
-    it('should create a family with nested gc rules', async () => {
-      const family = TABLE.family('prezzies');
-      const options = {
-        rule: {
-          union: true,
-          versions: 10,
-          rule: {
-            versions: 2,
-            age: {seconds: 60 * 60 * 24 * 30},
-          },
-        },
-      };
-      await family.create(options);
-      const [metadata] = await family.getMetadata();
-      assert.deepStrictEqual(metadata.gcRule, {
-        union: {
-          rules: [
-            {
-              maxNumVersions: 10,
-              rule: 'maxNumVersions',
-            },
-            {
-              intersection: {
-                rules: [
-                  {
-                    maxAge: {
-                      seconds: '2592000',
-                      nanos: 0,
-                    },
-                    rule: 'maxAge',
-                  },
-                  {
-                    maxNumVersions: 2,
-                    rule: 'maxNumVersions',
-                  },
-                ],
-              },
-              rule: 'intersection',
-            },
-          ],
-        },
-        rule: 'union',
-      });
-      await family.delete();
-    });
-
-    it('should get the column family metadata', async () => {
-      const [metadata] = await FAMILY.getMetadata();
-      assert.strictEqual(FAMILY.metadata, metadata);
-    });
-
-    it('should update a column family', async () => {
-      const rule = {
-        age: {
-          seconds: 10000,
-          nanos: 10000,
-        },
-      };
-      const [metadata] = await FAMILY.setMetadata({rule});
-      const maxAge = metadata.gcRule!.maxAge;
-      assert.strictEqual(maxAge!.seconds, rule.age.seconds.toString());
-      assert.strictEqual(maxAge!.nanos, rule.age.nanos);
-    });
-
-    it('should delete a column family', async () => {
-      await FAMILY.delete();
-    });
-  });
-
-  describe('rows', () => {
-    describe('.exists()', () => {
-      const row = TABLE.row('alincoln');
-
-      beforeEach(async () => {
-        await row.create({
-          entry: {
-            follows: {
-              gwashington: 1,
-              jadams: 1,
-              tjefferson: 1,
-            },
-          },
-        });
-      });
-
-      afterEach(async () => row.delete());
-
-      it('should check if a row exists', async () => {
-        const [exists] = await row.exists();
-        assert.strictEqual(exists, true);
-      });
-
-      it('should check if a row does not exist', async () => {
-        const row = TABLE.row('gwashington');
-        const [exists] = await row.exists();
-        assert.strictEqual(exists, false);
-      });
-    });
-
-    describe('inserting data', () => {
-      it('should insert rows', async () => {
-        const rows = [
-          {
-            key: 'gwashington',
-            data: {
-              follows: {
-                jadams: 1,
-              },
-            },
-          },
-          {
-            key: 'tjefferson',
-            data: {
-              follows: {
-                gwashington: 1,
-                jadams: 1,
-              },
-            },
-          },
-          {
-            key: 'jadams',
-            data: {
-              follows: {
-                gwashington: 1,
-                tjefferson: 1,
-              },
-            },
-          },
-        ];
-        await TABLE.insert(rows);
-      });
-
-      it('should insert a large row', async () => {
-        await TABLE.insert({
-          key: 'gwashington',
-          data: {
-            follows: {
-              jadams: Buffer.alloc(5000000),
-            },
-          },
-        });
-      });
-
-      it('should create an individual row', async () => {
-        const row = TABLE.row('alincoln');
-        const rowData = {
-          follows: {
-            gwashington: 1,
-            jadams: 1,
-            tjefferson: 1,
-          },
-        };
-        await row.create({entry: rowData});
-      });
-
-      it('should insert individual cells', async () => {
-        const row = TABLE.row('gwashington');
-        const rowData = {
-          follows: {
-            jadams: 1,
-          },
-        };
-        await row.save(rowData);
-      });
-
-      it('should allow for user specified timestamps', async () => {
-        const row = TABLE.row('gwashington');
-        const rowData = {
-          follows: {
-            jadams: {
-              value: 1,
-              timestamp: new Date('March 22, 1986'),
-            },
-          },
-        };
-        await row.save(rowData);
-      });
-
-      it('should increment a column value', async () => {
-        const row = TABLE.row('gwashington');
-        const increment = 5;
-        const [value] = await row.increment('follows:increment', increment);
-        assert.strictEqual(value, increment);
-      });
-
-      it('should apply read/modify/write rules to a row', async () => {
-        const row = TABLE.row('gwashington');
-        const rule = {
-          column: 'traits:teeth',
-          append: '-wood',
-        };
-        await row.save({
-          traits: {
-            teeth: 'shiny',
-          },
-        });
-        await row.createRules(rule);
-        const [data] = await row.get(['traits:teeth']);
-        assert.strictEqual(data.traits.teeth[0].value, 'shiny-wood');
-      });
-
-      it('should check and mutate a row', async () => {
-        const row = TABLE.row('gwashington');
-        const filter: RawFilter = {
-          family: 'follows',
-          value: 'alincoln',
-        };
-        const mutations = [
-          {
-            method: 'delete',
-            data: ['follows:alincoln'],
-          },
-        ];
-        const [matched] = await row.filter(filter, {onMatch: mutations});
-        assert(matched);
-      });
-    });
-
-    describe('fetching data', () => {
-      it('should get rows', async () => {
-        const [rows] = await TABLE.getRows();
-        assert.strictEqual(rows.length, 4);
-        assert(rows[0] instanceof Row);
-      });
-
-      it('should get rows via stream', done => {
-        const rows: Row[] = [];
-        TABLE.createReadStream()
-          .on('error', done)
-          .on('data', row => {
-            assert(row instanceof Row);
-            rows.push(row);
-          })
-          .on('end', () => {
-            assert.strictEqual(rows.length, 4);
-            done();
-          });
-      });
-
-      it('should should cancel request if stream ended early', done => {
-        const rows: Row[] = [];
-        const stream = TABLE.createReadStream()
-          .on('error', done)
-          .on('data', row => {
-            stream.end();
-            rows.push(row);
-          })
-          .on('end', () => {
-            assert.strictEqual(rows.length, 1);
-            done();
-          });
-      });
-
-      it('should fetch an individual row', async () => {
-        const row = TABLE.row('alincoln');
-        const [row_] = await row.get();
-        assert.strictEqual(row, row_);
-      });
-
-      it('should limit the number of rows', async () => {
-        const [rows] = await TABLE.getRows({
-          limit: 1,
-        });
-        assert.strictEqual(rows.length, 1);
-      });
-
-      it('should fetch a range of rows', async () => {
-        const options = {
-          start: 'alincoln',
-          end: 'jadams',
-        };
-        const [rows] = await TABLE.getRows(options);
-        assert.strictEqual(rows.length, 3);
-      });
-
-      it('should fetch a range of rows via prefix', async () => {
-        const options = {
-          prefix: 'g',
-        };
-        const [rows] = await TABLE.getRows(options);
-        assert.strictEqual(rows.length, 1);
-        assert.strictEqual(rows[0].id, 'gwashington');
-      });
-
-      it('should fetch individual cells of a row', async () => {
-        const row = TABLE.row('alincoln');
-        const [data] = await row.get(['follows:gwashington']);
-        assert.strictEqual(data.follows.gwashington[0].value, 1);
-      });
-
-      it('should not decode the values', async () => {
-        const row = TABLE.row('gwashington');
-        const options = {
-          decode: false,
-        };
-        await row.get(options);
-        const teeth = row.data.traits.teeth;
-        const value = teeth[0].value;
-        assert(value instanceof Buffer);
-        assert.strictEqual(value.toString(), 'shiny-wood');
-      });
-
-      it('should get sample row keys', async () => {
-        const [keys] = await TABLE.sampleRowKeys();
-        assert(keys.length > 0);
-      });
-
-      it('should get sample row keys via stream', done => {
-        const keys: string[] = [];
-        TABLE.sampleRowKeysStream()
-          .on('error', done)
-          .on('data', (rowKey: string) => {
-            keys.push(rowKey);
-          })
-          .on('end', () => {
-            assert(keys.length > 0);
-            done();
-          });
-      });
-
-      it('should end stream early', async () => {
-        const entries = [
-          {
-            key: 'gwashington',
-            data: {
-              follows: {
-                jadams: 1,
-              },
-            },
-          },
-          {
-            key: 'tjefferson',
-            data: {
-              follows: {
-                gwashington: 1,
-                jadams: 1,
-              },
-            },
-          },
-          {
-            key: 'jadams',
-            data: {
-              follows: {
-                gwashington: 1,
-                tjefferson: 1,
-              },
-            },
-          },
-        ];
-        await TABLE.insert(entries);
-        const rows: Row[] = [];
-        await new Promise<void>((resolve, reject) => {
-          const stream = TABLE.createReadStream()
-            .on('error', reject)
-            .on('data', row => {
-              rows.push(row);
-              stream.end();
-            })
-            .on('end', () => {
-              assert.strictEqual(rows.length, 1);
-              resolve();
-            });
-        });
-      });
-
-      describe('filters', () => {
-        it('should get rows via column data', async () => {
-          const filter = {
-            column: 'gwashington',
-          };
-          const [rows] = await TABLE.getRows({filter});
-          assert.strictEqual(rows.length, 3);
-          const keys = rows.map(row => row.id).sort();
-          assert.deepStrictEqual(keys, ['alincoln', 'jadams', 'tjefferson']);
-        });
-
-        it('should get rows that satisfy the cell limit', async () => {
-          const entry = {
-            key: 'alincoln',
-            data: {
-              follows: {
-                tjefferson: 1,
-              },
-            },
-          };
-          const filter = [
-            {
-              row: 'alincoln',
-            },
-            {
-              column: {
-                name: 'tjefferson',
-                cellLimit: 1,
-              },
-            },
-          ];
-          await TABLE.insert(entry);
-          const [rows] = await TABLE.getRows({filter});
-          const rowData = rows[0].data;
-          assert.strictEqual(rowData.follows.tjefferson.length, 1);
-        });
-
-        it('should get a range of columns', async () => {
-          const filter = [
-            {
-              row: 'tjefferson',
-            },
-            {
-              column: {
-                family: 'follows',
-                start: 'gwashington',
-                end: 'jadams',
-              },
-            },
-          ];
-
-          const [rows] = await TABLE.getRows({filter});
-          rows.forEach(row => {
-            const keys = Object.keys(row.data.follows).sort();
-            assert.deepStrictEqual(keys, ['gwashington', 'jadams']);
-          });
-        });
-
-        it('should run a conditional filter', async () => {
-          const filter = {
-            condition: {
-              test: [
-                {
-                  row: 'gwashington',
-                },
-                {
-                  family: 'follows',
-                },
-                {
-                  column: 'tjefferson',
-                },
-              ],
-              pass: {
-                row: 'gwashington',
-              },
-              fail: {
-                row: 'tjefferson',
-              },
-            },
-          };
-          const [rows] = await TABLE.getRows({filter});
-          assert.strictEqual(rows.length, 1);
-          assert.strictEqual(rows[0].id, 'tjefferson');
-        });
-
-        it('should run a conditional filter with pass only', async () => {
-          const filter = {
-            condition: {
-              test: [
-                {
-                  row: 'gwashington',
-                },
-              ],
-              pass: [
-                {
-                  all: true,
-                },
-              ],
-            },
-          };
-          const [rows] = await TABLE.getRows({filter});
-          assert(rows.length > 0);
-        });
-
-        it('should only get cells for a specific family', async () => {
-          const entries = [
-            {
-              key: 'gwashington',
-              data: {
-                traits: {
-                  teeth: 'wood',
-                },
-              },
-            },
-          ];
-          await TABLE.insert(entries);
-          const filter = {
-            family: 'traits',
-          };
-          const [rows] = await TABLE.getRows({filter});
-          assert(rows.length > 0);
-          const families = Object.keys(rows[0].data);
-          assert.deepStrictEqual(families, ['traits']);
-        });
-
-        it('should interleave filters', async () => {
-          const filter = [
-            {
-              interleave: [
-                [
-                  {
-                    row: 'gwashington',
-                  },
-                ],
-                [
-                  {
-                    row: 'tjefferson',
-                  },
-                ],
-              ],
-            },
-          ];
-          const [rows] = await TABLE.getRows({filter});
-          assert.strictEqual(rows.length, 2);
-          const ids = rows.map(row => row.id).sort();
-          assert.deepStrictEqual(ids, ['gwashington', 'tjefferson']);
-        });
-
-        it('should apply labels to the results', async () => {
-          const filter = {
-            label: 'test-label',
-          };
-          const [rows] = await TABLE.getRows({filter});
-          rows.forEach(row => {
-            const follows = row.data.follows;
-            Object.keys(follows).forEach(column => {
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              follows[column].forEach((cell: any) => {
-                assert.deepStrictEqual(cell.labels, [filter.label]);
-              });
-            });
-          });
-        });
-
-        it('should run a regex against the row id', async () => {
-          const filter = {
-            row: /[a-z]+on$/,
-          };
-          const [rows] = await TABLE.getRows({filter});
-          const keys = rows.map(row => row.id).sort();
-          assert.deepStrictEqual(keys, ['gwashington', 'tjefferson']);
-        });
-
-        it('should run a sink filter', async () => {
-          const filter = [
-            {
-              row: 'alincoln',
-            },
-            {
-              family: 'follows',
-            },
-            {
-              interleave: [
-                [
-                  {
-                    all: true,
-                  },
-                ],
-                [
-                  {
-                    label: 'prezzy',
-                  },
-                  {
-                    sink: true,
-                  },
-                ],
-              ],
-            },
-            {
-              column: 'gwashington',
-            },
-          ];
-          const [rows] = await TABLE.getRows({filter});
-          const columns = Object.keys(rows[0].data.follows).sort();
-          assert.deepStrictEqual(columns, [
-            'gwashington',
-            'jadams',
-            'tjefferson',
-          ]);
-        });
-      });
-
-      it('should accept a date range', async () => {
-        const filter = {
-          time: {
-            start: new Date('March 21, 1986'),
-            end: new Date('March 23, 1986'),
-          },
-        };
-        const [rows] = await TABLE.getRows({filter});
-        assert(rows.length > 0);
-      });
-    });
-  });
-
-  describe('deleting rows', () => {
-    it('should delete specific cells', async () => {
-      const row = TABLE.row('alincoln');
-      await row.deleteCells(['follows:gwashington']);
-    });
-
-    it('should delete a family', async () => {
-      const row = TABLE.row('gwashington');
-      await row.deleteCells(['traits']);
-    });
-
-    it('should delete all the cells', async () => {
-      const row = TABLE.row('alincoln');
-      await row.delete();
-    });
-  });
-
-  describe('.deleteRows()', () => {
-    const table = INSTANCE.table(generateId('table'));
-    beforeEach(async () => {
-      const tableOptions = {
-        families: ['cf1'],
-      };
-      const data = {
-        cf1: {
-          foo: 1,
-        },
-      };
-      const rows = [
-        {
-          key: 'aaa',
-          data,
-        },
-        {
-          key: 'abc',
-          data,
-        },
-        {
-          key: 'def',
-          data,
-        },
-      ];
-      await table.create(tableOptions);
-      await table.insert(rows);
-    });
-
-    afterEach(async () => {
-      await table.delete();
-    });
-
-    it('should delete the prefixes', async () => {
-      await table.deleteRows('a');
-      const [rows] = await table.getRows();
-      assert.strictEqual(rows.length, 1);
-    });
-  });
-
-  describe('.truncate()', () => {
-    const table = INSTANCE.table(generateId('table'));
-    beforeEach(async () => {
-      const tableOptions = {
-        families: ['follows'],
-      };
-      const rows = [
-        {
-          key: 'gwashington',
-          data: {
-            follows: {
-              jadams: 1,
-            },
-          },
-        },
-      ];
-      await table.create(tableOptions);
-      await table.insert(rows);
-    });
-
-    afterEach(async () => {
-      await table.delete();
-    });
-
-    it('should truncate a table', async () => {
-      await table.truncate();
-      const [rows] = await table.getRows();
-      assert.strictEqual(rows.length, 0);
-    });
-  });
-
-  describe('backups', () => {
-    const CLUSTER = INSTANCE.cluster(CLUSTER_ID);
-    let BACKUP: Backup;
-
-    // For these tests, two backups are needed. The backups are labeled for what
-    // they are intended to originate/interact from/with, but this is just for
-    // testing and the naming convention used here does not actually influence
-    // the real functionality - it is just a way to keep things organized!
-    const backupIdFromCluster = generateId('backup');
-    let backupNameFromCluster: string;
-    const restoreTableIdFromCluster = generateId('table');
-
-    const backupIdFromTable = generateId('backup');
-    let backupNameFromTable: string;
-
-    // The minimum backup expiry time is 6 hours. The times here each have a 2
-    // hour padding to tolerate latency and clock drift. Also, while the time
-    // implementation for backups in this client accepts any of a Timestamp
-    // Struct, Date, or PreciseDate, to keep things easy this uses PreciseDate.
-    const expireTime = new PreciseDate(PreciseDate.now() + 8 * 60 * 60 * 1000);
-    const updateExpireTime = new PreciseDate(
-      expireTime.getTime() + 2 + 60 * 60 * 1000
-    );
-
-    before(async () => {
-      const [backup, op] = await CLUSTER.createBackup(backupIdFromCluster, {
-        table: TABLE,
-        expireTime,
-      });
-      BACKUP = backup;
-      await op.promise();
-      backupNameFromCluster = replaceProjectIdToken(
-        `${CLUSTER.name}/backups/${backupIdFromCluster}`,
-        bigtable.projectId
-      );
-      backupNameFromTable = replaceProjectIdToken(
-        `${CLUSTER.name}/backups/${backupIdFromTable}`,
-        bigtable.projectId
-      );
-    });
-
-    it('should create backup of a table (from cluster)', async () => {
-      await BACKUP.getMetadata();
-
-      assert.strictEqual(BACKUP.metadata!.name, backupNameFromCluster);
-
-      assert.deepStrictEqual(BACKUP.expireDate, expireTime);
-    });
-
-    it('should create backup of a table (from table)', async () => {
-      const [backup, op] = await TABLE.createBackup(backupIdFromTable, {
-        expireTime,
-      });
-      await op.promise();
-      await backup.getMetadata();
-
-      assert.strictEqual(backup.metadata!.name, backupNameFromTable);
-
-      assert.deepStrictEqual(backup.expireDate, expireTime);
-    });
-
-    it('should get a specific backup (cluster)', async () => {
-      const [backup] = await CLUSTER.backup(backupIdFromCluster).get();
-      assert.strictEqual(backup.metadata!.name, backupNameFromCluster);
-      assert.strictEqual(backup.metadata!.state, 'READY');
-    });
-
-    it('should get backups in an instance', async () => {
-      const [backups] = await INSTANCE.getBackups();
-      assert(Array.isArray(backups));
-      assert(backups.length > 0);
-      assert(backups.some(backup => backup.id === BACKUP.id));
-    });
-
-    it('should get backups in an instance as a stream', done => {
-      const backups: Backup[] = [];
-
-      INSTANCE.getBackupsStream()
-        .on('error', done)
-        .on('data', backup => {
-          backups.push(backup);
-        })
-        .on('end', () => {
-          assert(backups.length > 0);
-          done();
-        });
-    });
-
-    it('should get backups in a cluster', async () => {
-      const [backups] = await CLUSTER.getBackups();
-      assert(Array.isArray(backups));
-      assert(backups.length > 0);
-      assert(backups.some(backup => backup.id === BACKUP.id));
-    });
-
-    it('should get backups in a cluster as a stream', done => {
-      const backups: Backup[] = [];
-
-      CLUSTER.getBackupsStream()
-        .on('error', done)
-        .on('data', backup => {
-          backups.push(backup);
-        })
-        .on('end', () => {
-          assert(backups.length > 0);
-          done();
-        });
-    });
-
-    it('should restore a backup (cluster)', async () => {
-      const backup = CLUSTER.backup(backupIdFromCluster);
-      const [table, op] = await backup.restore(restoreTableIdFromCluster);
-      await op.promise();
-
-      const restoredTableId = table.name?.split('/').pop();
-      assert.strictEqual(restoredTableId, restoreTableIdFromCluster);
-    });
-
-    it('should restore a backup to a different instance', async () => {
-      const [, operation] = await DIFF_INSTANCE.create(
-        createInstanceConfig(generateId('d-clust'), 'us-east1-c', 3, Date.now())
-      );
-      await operation.promise();
-      const [iExists] = await DIFF_INSTANCE.exists();
-      assert.strictEqual(iExists, true);
-
-      const backup = CLUSTER.backup(backupIdFromCluster);
-      const [table, op] = await backup.restoreTo({
-        tableId: restoreTableIdFromCluster,
-        instance: DIFF_INSTANCE,
-      });
-      await op.promise();
-      const [tExists] = await table.exists();
-      assert.strictEqual(tExists, true);
-      assert.strictEqual(table.id, restoreTableIdFromCluster);
-    });
-
-    it('should update a backup (cluster)', async () => {
-      const backup = CLUSTER.backup(backupIdFromCluster);
-      const [metadata] = await backup.setMetadata({
-        expireTime: updateExpireTime,
-      });
-
-      assert.strictEqual(metadata.name, backupNameFromCluster);
-      assert.deepStrictEqual(backup.expireDate, updateExpireTime);
-    });
-
-    it('should get an Iam Policy for the backup', async () => {
-      const policyProperties = ['version', 'bindings', 'etag'];
-      const [policy] = await BACKUP.getIamPolicy();
-
-      policyProperties.forEach(property => {
-        assert(property in policy);
-      });
-    });
-
-    it('should test Iam permissions for the backup', async () => {
-      const permissions = ['bigtable.backups.get', 'bigtable.backups.delete'];
-      const [grantedPermissions] = await BACKUP.testIamPermissions(permissions);
-      assert.strictEqual(grantedPermissions.length, permissions.length);
-      permissions.forEach(permission => {
-        assert.strictEqual(grantedPermissions.includes(permission), true);
-      });
-    });
-
-    it('should set Iam Policy on the backup', async () => {
-      const backup = CLUSTER.backup(backupIdFromCluster);
-
-      const [policy] = await backup.getIamPolicy();
-      const [updatedPolicy] = await backup.setIamPolicy(policy);
-
-      Object.keys(policy).forEach(key => assert(key in updatedPolicy));
-    });
-    describe('copying backups', () => {
-      // The server requires the copy backup time to be sufficiently ahead of
-      // the create backup time to avoid an error.
-      // Set it to 308 hours ahead
-      const sourceExpireTimeMilliseconds =
-        PreciseDate.now() + (8 + 300) * 60 * 60 * 1000;
-      const sourceExpireTime = new PreciseDate(sourceExpireTimeMilliseconds);
-      // 608 hours ahead of now, 300 hours ahead of sourceExpireTimeMilliseconds
-      const copyExpireTimeMilliseconds =
-        PreciseDate.now() + (8 + 600) * 60 * 60 * 1000;
-      const copyExpireTime = new PreciseDate(copyExpireTimeMilliseconds);
-
-      /*
-        This function checks that when a backup is copied using the provided
-        config that a new backup is created on the instance.
-       */
-      async function testCopyBackup(
-        backup: Backup,
-        config: CopyBackupConfig,
-        instance: Instance
-      ) {
-        // Get a list of backup ids before the copy
-        const [backupsBeforeCopy] = await instance.getBackups();
-        const backupIdsBeforeCopy = backupsBeforeCopy.map(backup => backup.id);
-        // Copy the backup
-        const [newBackup, operation] = await backup.copy(config);
-        try {
-          assert.strictEqual(config.id, newBackup.id);
-          await operation.promise();
-          const id = config.id;
-          const backupPath = `${config.cluster.name}/backups/${id}`;
-          {
-            // Ensure that the backup specified by the config and id match the backup name for the operation returned by the server.
-            // the split/map/join functions replace the project name with the {{projectId}} string
-            assert(operation);
-            assert(operation.metadata);
-            assert.strictEqual(
-              operation.metadata.name
-                .split('/')
-                .map((item, index) => (index === 1 ? '{{projectId}}' : item))
-                .join('/'),
-              backupPath
-                .split('/')
-                .map((item, index) => (index === 1 ? '{{projectId}}' : item))
-                .join('/')
-            );
-          }
-          // Check that there is now one more backup
-          const [backupsAfterCopy] = await instance.getBackups();
-          const newBackups = backupsAfterCopy.filter(
-            backup => !backupIdsBeforeCopy.includes(backup.id)
-          );
-          assert.strictEqual(newBackups.length, 1);
-          const [fetchedNewBackup] = newBackups;
-          // Ensure the fetched backup matches the config
-          assert.strictEqual(fetchedNewBackup.id, id);
-          assert.strictEqual(fetchedNewBackup.name, backupPath);
-          // Delete the copied backup
-        } finally {
-          await config.cluster.backup(newBackup.id).delete();
-        }
-      }
-
-      describe('should create backup of a table and copy it in the same cluster', async () => {
-        async function testWithExpiryTimes(
-          sourceTestExpireTime: BackupTimestamp,
-          copyTestExpireTime: BackupTimestamp
-        ) {
-          const [backup, op] = await TABLE.createBackup(generateId('backup'), {
-            expireTime: sourceTestExpireTime,
-          });
-          try {
-            {
-              await op.promise();
-              // Check expiry time for running operation.
-              await backup.getMetadata();
-              assert.deepStrictEqual(backup.expireDate, sourceExpireTime);
-            }
-            await testCopyBackup(
-              backup,
-              {
-                cluster: backup.cluster,
-                id: generateId('backup'),
-                expireTime: copyTestExpireTime,
-              },
-              INSTANCE
-            );
-          } finally {
-            await backup.delete();
-          }
-        }
-        it('should copy to the same cluster with precise date expiry times', async () => {
-          await testWithExpiryTimes(sourceExpireTime, copyExpireTime);
-        });
-        it('should copy to the same cluster with timestamp expiry times', async () => {
-          // Calling toStruct converts times to a timestamp object.
-          // For example: sourceExpireTime.toStruct() = {seconds: 1706659851, nanos: 981000000}
-          await testWithExpiryTimes(
-            sourceExpireTime.toStruct(),
-            copyExpireTime.toStruct()
-          );
-        });
-        it('should copy to the same cluster with date expiry times', async () => {
-          await testWithExpiryTimes(
-            new Date(sourceExpireTimeMilliseconds),
-            new Date(copyExpireTimeMilliseconds)
-          );
-        });
-      });
-      it('should create backup of a table and copy it on another cluster of another instance', async () => {
-        const [backup, op] = await TABLE.createBackup(generateId('backup'), {
-          expireTime: sourceExpireTime,
-        });
-        try {
-          {
-            await op.promise();
-            // Check the expiry time.
-            await backup.getMetadata();
-            assert.deepStrictEqual(backup.expireDate, sourceExpireTime);
-          }
-          // Create another instance
-          const instance = bigtable.instance(generateId('instance'));
-          const destinationClusterId = generateId('cluster');
-          {
-            // Create production instance with given options
-            const instanceOptions: InstanceOptions = {
-              clusters: [
-                {
-                  id: destinationClusterId,
-                  nodes: 3,
-                  location: 'us-central1-f',
-                  storage: 'ssd',
-                },
-              ],
-              labels: {'prod-label': 'prod-label'},
-              type: 'production',
-            };
-            const [, operation] = await instance.create(instanceOptions);
-            await operation.promise();
-          }
-          // Create the copy and test the copied backup
-          await testCopyBackup(
-            backup,
-            {
-              cluster: new Cluster(instance, destinationClusterId),
-              id: generateId('backup'),
-              expireTime: copyExpireTime,
-            },
-            instance
-          );
-          await instance.delete();
-        } finally {
-          await backup.delete();
-        }
-      });
-      it('should create backup of a table and copy it on another cluster of the same instance', async () => {
-        const [backup, op] = await TABLE.createBackup(generateId('backup'), {
-          expireTime: sourceExpireTime,
-        });
-        try {
-          {
-            await op.promise();
-            // Check the expiry time.
-            await backup.getMetadata();
-            assert.deepStrictEqual(backup.expireDate, sourceExpireTime);
-          }
-          const destinationClusterId = generateId('cluster');
-          {
-            // Create destination cluster with given options
-            const [, operation] = await INSTANCE.cluster(
-              destinationClusterId
-            ).create({
-              location: 'us-central1-b',
-              nodes: 3,
-            });
-            await operation.promise();
-          }
-          // Create the copy and test the copied backup
-          await testCopyBackup(
-            backup,
-            {
-              cluster: new Cluster(INSTANCE, destinationClusterId),
-              id: generateId('backup'),
-              expireTime: copyExpireTime,
-            },
-            INSTANCE
-          );
-        } finally {
-          await backup.delete();
-        }
-      });
-      it('should create backup of a table and copy it on another project', async () => {
-        const [backup, op] = await TABLE.createBackup(generateId('backup'), {
-          expireTime: sourceExpireTime,
-        });
-        try {
-          {
-            await op.promise();
-            // Check the expiry time.
-            await backup.getMetadata();
-            assert.deepStrictEqual(backup.expireDate, sourceExpireTime);
-          }
-          // Create client, instance, cluster for second project
-          const bigtableSecondaryProject = new Bigtable(
-            process.env.GCLOUD_PROJECT2
-              ? {projectId: process.env.GCLOUD_PROJECT2}
-              : {}
-          );
-          const secondInstance = bigtableSecondaryProject.instance(
-            generateId('instance')
-          );
-          const destinationClusterId = generateId('cluster');
-          {
-            // Create production instance with given options
-            const instanceOptions: InstanceOptions = {
-              clusters: [
-                {
-                  id: destinationClusterId,
-                  nodes: 3,
-                  location: 'us-central1-f',
-                  storage: 'ssd',
-                },
-              ],
-              labels: {'prod-label': 'prod-label'},
-              type: 'production',
-            };
-            const [, operation] = await secondInstance.create(instanceOptions);
-            await operation.promise();
-          }
-          // Create the copy and test the copied backup
-          await testCopyBackup(
-            backup,
-            {
-              cluster: new Cluster(secondInstance, destinationClusterId),
-              id: generateId('backup'),
-              expireTime: copyExpireTime,
-            },
-            secondInstance
-          );
-          await secondInstance.delete();
-        } finally {
-          await backup.delete();
-        }
-      });
-      it('should restore a copied backup', async () => {
-        const backupId = generateId('backup');
-        const table = INSTANCE.table('old-table');
-        {
-          // Create a table and insert data into it.
-          await table.create();
-          await table.createFamily('follows');
-          await table.insert([
-            {
-              key: 'some-data-to-copy-key',
-              data: {
-                follows: {
-                  copyData: 'data-to-copy',
-                },
-              },
-            },
-          ]);
-        }
-        // Create the backup
-        const [backup, createBackupOperation] = await table.createBackup(
-          backupId,
-          {
-            expireTime: sourceExpireTime,
-          }
-        );
-        try {
-          await createBackupOperation.promise();
-          // Copy the backup
-          const config = {
-            cluster: backup.cluster,
-            id: generateId('backup'),
-            expireTime: copyExpireTime,
-          };
-          const [newBackup, copyOperation] = await backup.copy(config);
-          await copyOperation.promise();
-          // Restore a table from the copied backup
-          const [newTable, restoreOperation] =
-            await newBackup.restore('new-table');
-          await restoreOperation.promise();
-          const rows = await newTable.getRows();
-          assert.deepStrictEqual(rows[0][0].id, 'some-data-to-copy-key');
-        } finally {
-          await backup.delete();
-        }
-      });
-    });
-  });
+  // describe('instances', () => {
+  //   it('should get a list of instances', async () => {
+  //     const [instances, failedLocations] = await bigtable.getInstances();
+  //     assert(instances.length > 0);
+  //     assert(Array.isArray(failedLocations));
+  //   });
+  //
+  //   it('should check if an instance exists', async () => {
+  //     const [exists] = await INSTANCE.exists();
+  //     assert.strictEqual(exists, true);
+  //   });
+  //
+  //   it('should check if an instance does not exist', async () => {
+  //     const instance = bigtable.instance('fake-instance');
+  //     const [exists] = await instance.exists();
+  //     assert.strictEqual(exists, false);
+  //   });
+  //
+  //   it('should get a single instance', async () => {
+  //     await INSTANCE.get();
+  //   });
+  //
+  //   it('should update an instance', async () => {
+  //     const metadata = {
+  //       displayName: 'metadata-test',
+  //     };
+  //     await INSTANCE.setMetadata(metadata);
+  //     const [metadata_] = await INSTANCE.getMetadata();
+  //     assert.strictEqual(metadata.displayName, metadata_.displayName);
+  //   });
+  //
+  //   it('should get an Iam Policy for the instance', async () => {
+  //     const policyProperties = ['version', 'bindings', 'etag'];
+  //     const [policy] = await INSTANCE.getIamPolicy();
+  //     policyProperties.forEach(property => {
+  //       assert(property in policy);
+  //     });
+  //   });
+  //
+  //   it('should test Iam permissions for the instance', async () => {
+  //     const permissions = ['bigtable.tables.get', 'bigtable.tables.readRows'];
+  //     const [grantedPermissions] =
+  //       await INSTANCE.testIamPermissions(permissions);
+  //     assert.strictEqual(grantedPermissions.length, permissions.length);
+  //     permissions.forEach(permission => {
+  //       assert.strictEqual(grantedPermissions.includes(permission), true);
+  //     });
+  //   });
+  //
+  //   it('should set Iam Policy on the instance', async () => {
+  //     const instance = bigtable.instance(generateId('instance'));
+  //     const clusteId = generateId('cluster');
+  //     const [, operation] = await instance.create({
+  //       clusters: [
+  //         {
+  //           id: clusteId,
+  //           location: 'us-central1-c',
+  //           nodes: 3,
+  //         },
+  //       ],
+  //       labels: {
+  //         time_created: Date.now(),
+  //       },
+  //     });
+  //     await operation.promise();
+  //
+  //     const [policy] = await instance.getIamPolicy();
+  //     const [updatedPolicy] = await instance.setIamPolicy(policy);
+  //     Object.keys(policy).forEach(key => assert(key in updatedPolicy));
+  //
+  //     await instance.delete();
+  //   });
+  // });
+  //
+  // describe('CMEK', () => {
+  //   let kmsKeyName: string;
+  //
+  //   const CMEK_CLUSTER = CMEK_INSTANCE.cluster(generateId('cluster'));
+  //
+  //   const cryptoKeyId = generateId('key');
+  //   const keyRingId = generateId('key-ring');
+  //   let keyRingsBaseUrl: string;
+  //   let cryptoKeyVersionName: string;
+  //
+  //   before(async () => {
+  //     const projectId = await bigtable.auth.getProjectId();
+  //     kmsKeyName = `projects/${projectId}/locations/us-central1/keyRings/${keyRingId}/cryptoKeys/${cryptoKeyId}`;
+  //     keyRingsBaseUrl = `https://cloudkms.googleapis.com/v1/projects/${projectId}/locations/us-central1/keyRings`;
+  //
+  //     await bigtable.auth.request({
+  //       method: 'POST',
+  //       url: keyRingsBaseUrl,
+  //       params: {keyRingId},
+  //     });
+  //
+  //     const resp = await bigtable.auth.request({
+  //       method: 'POST',
+  //       url: `${keyRingsBaseUrl}/${keyRingId}/cryptoKeys`,
+  //       params: {cryptoKeyId},
+  //       data: {purpose: 'ENCRYPT_DECRYPT'},
+  //     });
+  //     cryptoKeyVersionName = resp.data.primary.name;
+  //
+  //     // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  //     const [_, operation] = await CMEK_INSTANCE.create({
+  //       clusters: [
+  //         {
+  //           id: CMEK_CLUSTER.id,
+  //           location: 'us-central1-a',
+  //           nodes: 3,
+  //           key: kmsKeyName,
+  //         },
+  //       ],
+  //       labels: {
+  //         time_created: Date.now(),
+  //       },
+  //     });
+  //     await operation.promise();
+  //   });
+  //
+  //   after(async () => {
+  //     await bigtable.auth.request({
+  //       method: 'POST',
+  //       url: `${keyRingsBaseUrl}/${keyRingId}/cryptoKeys/${cryptoKeyId}/cryptoKeyVersions/${cryptoKeyVersionName
+  //         .split('/')
+  //         .pop()}:destroy`,
+  //       params: {name: cryptoKeyVersionName},
+  //     });
+  //   });
+  //
+  //   it('should have created an instance', async () => {
+  //     const [metadata] = await CMEK_CLUSTER.getMetadata();
+  //     assert.deepStrictEqual(metadata.encryptionConfig, {kmsKeyName});
+  //   });
+  //
+  //   it('should create a cluster', async () => {
+  //     const cluster = CMEK_INSTANCE.cluster(generateId('cluster'));
+  //
+  //     // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  //     const [_, operation] = await cluster.create({
+  //       location: 'us-central1-b',
+  //       nodes: 3,
+  //       key: kmsKeyName,
+  //     });
+  //     await operation.promise();
+  //
+  //     const [metadata] = await cluster.getMetadata();
+  //     assert.deepStrictEqual(metadata.encryptionConfig, {kmsKeyName});
+  //   });
+  //
+  //   it('should fail if key not provided', async () => {
+  //     const cluster = CMEK_INSTANCE.cluster(generateId('cluster'));
+  //
+  //     try {
+  //       // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  //       const [_, operation] = await cluster.create({
+  //         location: 'us-central1-b',
+  //         nodes: 3,
+  //       });
+  //       await operation.promise();
+  //       throw new Error('Cluster creation should not have succeeded');
+  //     } catch (e) {
+  //       assert(
+  //         (e as Error).message.includes(
+  //           'default keys and CMEKs are not allowed'
+  //         )
+  //       );
+  //     }
+  //   });
+  // });
+  //
+  // describe('appProfiles', () => {
+  //   it('should retrieve a list of app profiles', async () => {
+  //     const [appProfiles] = await INSTANCE.getAppProfiles();
+  //     assert(appProfiles[0] instanceof AppProfile);
+  //     assert(appProfiles.length > 0);
+  //   });
+  //
+  //   it('should retrieve a list of app profiles in stream mode', done => {
+  //     const appProfiles: AppProfile[] = [];
+  //     INSTANCE.getAppProfilesStream()
+  //       .on('error', done)
+  //       .on('data', appProfile => {
+  //         assert(appProfile instanceof AppProfile);
+  //         appProfiles.push(appProfile);
+  //       })
+  //       .on('end', () => {
+  //         assert(appProfiles.length > 0);
+  //         done();
+  //       });
+  //   });
+  //
+  //   it('should check if an app profile exists', async () => {
+  //     const [exists] = await APP_PROFILE.exists();
+  //     assert.strictEqual(exists, true);
+  //   });
+  //
+  //   it('should check if an app profile does not exist', async () => {
+  //     const appProfile = INSTANCE.appProfile('should-not-exist');
+  //     const [exists] = await appProfile.exists();
+  //     assert.strictEqual(exists, false);
+  //   });
+  //
+  //   it('should get an app profile', async () => {
+  //     await APP_PROFILE.get();
+  //   });
+  //
+  //   it('should delete an app profile', async () => {
+  //     const appProfile = INSTANCE.appProfile(generateId('app-profile'));
+  //     await appProfile.create({
+  //       routing: 'any',
+  //       ignoreWarnings: true,
+  //     });
+  //     await appProfile.delete({ignoreWarnings: true});
+  //   });
+  //
+  //   it('should get the app profiles metadata', async () => {
+  //     const [metadata] = await APP_PROFILE.getMetadata();
+  //     assert.strictEqual(
+  //       metadata.name,
+  //       APP_PROFILE.name.replace('{{projectId}}', bigtable.projectId)
+  //     );
+  //   });
+  //
+  //   it('should update an app profile', async () => {
+  //     const cluster = INSTANCE.cluster(CLUSTER_ID);
+  //     const options = {
+  //       routing: cluster,
+  //       allowTransactionalWrites: true,
+  //       description: 'My Updated App Profile',
+  //     };
+  //     await APP_PROFILE.setMetadata(options);
+  //     const [updatedAppProfile] = await APP_PROFILE.get();
+  //     assert.strictEqual(
+  //       updatedAppProfile.metadata!.description,
+  //       options.description
+  //     );
+  //     assert.deepStrictEqual(updatedAppProfile.metadata!.singleClusterRouting, {
+  //       clusterId: CLUSTER_ID,
+  //       allowTransactionalWrites: true,
+  //     });
+  //   });
+  // });
+  //
+  // describe('clusters', () => {
+  //   let CLUSTER: Cluster;
+  //
+  //   beforeEach(() => {
+  //     CLUSTER = INSTANCE.cluster(CLUSTER_ID);
+  //   });
+  //
+  //   it('should retrieve a list of clusters', async () => {
+  //     const [clusters] = await INSTANCE.getClusters();
+  //     assert(clusters[0] instanceof Cluster);
+  //   });
+  //
+  //   it('should check if a cluster exists', async () => {
+  //     const [exists] = await CLUSTER.exists();
+  //     assert.strictEqual(exists, true);
+  //   });
+  //
+  //   it('should check if a cluster does not exist', async () => {
+  //     const cluster = INSTANCE.cluster('fake-cluster');
+  //     const [exists] = await cluster.exists();
+  //     assert.strictEqual(exists, false);
+  //   });
+  //
+  //   it('should get a cluster', async () => {
+  //     await CLUSTER.get();
+  //   });
+  //
+  //   it('should update a cluster', async () => {
+  //     const metadata = {
+  //       nodes: 4,
+  //     };
+  //     const [operation] = await CLUSTER.setMetadata(metadata);
+  //     await operation.promise();
+  //     const [_metadata] = await CLUSTER.getMetadata();
+  //     assert.strictEqual(metadata.nodes, _metadata.serveNodes);
+  //   });
+  // });
+  //
+  // describe('tables', () => {
+  //   it('should retrieve a list of tables', async () => {
+  //     const [tables] = await INSTANCE.getTables();
+  //     assert(tables[0] instanceof Table);
+  //   });
+  //
+  //   it('should retrieve a list of tables in stream mode', done => {
+  //     const tables: Table[] = [];
+  //     INSTANCE.getTablesStream()
+  //       .on('error', done)
+  //       .on('data', table => {
+  //         assert(table instanceof Table);
+  //         tables.push(table);
+  //       })
+  //       .on('end', () => {
+  //         assert(tables.length > 0);
+  //         done();
+  //       });
+  //   });
+  //
+  //   it('should check if a table exists', async () => {
+  //     const [exists] = await TABLE.exists();
+  //     assert.strictEqual(exists, true);
+  //   });
+  //
+  //   it('should check if a table does not exist', async () => {
+  //     const table = INSTANCE.table('should-not-exist');
+  //     const [exists] = await table.exists();
+  //     assert.strictEqual(exists, false);
+  //   });
+  //
+  //   it('should get a table', async () => {
+  //     await TABLE.get();
+  //   });
+  //
+  //   it('should get an Iam Policy for the table', async () => {
+  //     const policyProperties = ['version', 'bindings', 'etag'];
+  //     const [policy] = await TABLE.getIamPolicy();
+  //     policyProperties.forEach(property => {
+  //       assert(property in policy);
+  //     });
+  //   });
+  //
+  //   it('should test Iam permissions for the table', async () => {
+  //     const permissions = ['bigtable.tables.get', 'bigtable.tables.readRows'];
+  //     const [grantedPermissions] = await TABLE.testIamPermissions(permissions);
+  //     assert.strictEqual(grantedPermissions.length, permissions.length);
+  //     permissions.forEach(permission => {
+  //       assert.strictEqual(grantedPermissions.includes(permission), true);
+  //     });
+  //   });
+  //
+  //   it('should set Iam Policy on the table', async () => {
+  //     const table = INSTANCE.table(generateId('table'));
+  //     await table.create();
+  //
+  //     const [policy] = await table.getIamPolicy();
+  //     const [updatedPolicy] = await table.setIamPolicy(policy);
+  //     Object.keys(policy).forEach(key => assert(key in updatedPolicy));
+  //
+  //     await table.delete();
+  //   });
+  //
+  //   it('should delete a table', async () => {
+  //     const table = INSTANCE.table(generateId('table'));
+  //     await table.create();
+  //     await table.delete();
+  //   });
+  //
+  //   it('should get the tables metadata', async () => {
+  //     const [metadata] = await TABLE.getMetadata();
+  //     assert.strictEqual(
+  //       metadata.name,
+  //       TABLE.name.replace('{{projectId}}', bigtable.projectId)
+  //     );
+  //   });
+  //
+  //   it('should create a table with column family data', async () => {
+  //     const name = generateId('table');
+  //     const options = {
+  //       families: ['test'],
+  //     };
+  //     const [table] = await INSTANCE.createTable(name, options);
+  //     assert(table.metadata!.columnFamilies!.test);
+  //   });
+  //
+  //   it('should create a table if autoCreate is true', async () => {
+  //     const table = INSTANCE.table(generateId('table'));
+  //     await table.get({autoCreate: true});
+  //     await table.delete();
+  //   });
+  // });
+  //
+  // describe('consistency tokens', () => {
+  //   it('should generate consistency token', async () => {
+  //     const [token] = await TABLE.generateConsistencyToken();
+  //     assert.strictEqual(typeof token, 'string');
+  //   });
+  //
+  //   it('should return error for checkConsistency of invalid token', done => {
+  //     TABLE.checkConsistency('dummy-token', err => {
+  //       assert.strictEqual(err!.code, 3);
+  //       done();
+  //     });
+  //   });
+  //
+  //   it('should return boolean for checkConsistency of token', async () => {
+  //     const [token] = await TABLE.generateConsistencyToken();
+  //     const [res] = await TABLE.checkConsistency(token);
+  //     assert.strictEqual(typeof res, 'boolean');
+  //   });
+  //
+  //   it('should return boolean for waitForReplication', async () => {
+  //     const [res] = await TABLE.waitForReplication();
+  //     assert.strictEqual(typeof res, 'boolean');
+  //   });
+  // });
+  //
+  // describe('replication states', () => {
+  //   it('should get a map of clusterId and state', async () => {
+  //     const [clusterStates] = await TABLE.getReplicationStates();
+  //     assert(clusterStates instanceof Map);
+  //     assert(clusterStates.has(CLUSTER_ID));
+  //   });
+  // });
+  //
+  // describe('column families', () => {
+  //   const FAMILY_ID = 'presidents';
+  //   let FAMILY: Family;
+  //
+  //   before(async () => {
+  //     FAMILY = TABLE.family(FAMILY_ID);
+  //     await FAMILY.create();
+  //   });
+  //
+  //   it('should get a list of families', async () => {
+  //     const [families] = await TABLE.getFamilies();
+  //     assert.strictEqual(families.length, 3);
+  //     assert(families[0] instanceof Family);
+  //     assert.notStrictEqual(-1, families.map(f => f.id).indexOf(FAMILY.id));
+  //   });
+  //
+  //   it('should get a family', async () => {
+  //     const family = TABLE.family(FAMILY_ID);
+  //     await family.get();
+  //     assert(family instanceof Family);
+  //     assert.strictEqual(family.name, FAMILY.name);
+  //     assert.strictEqual(family.id, FAMILY.id);
+  //   });
+  //
+  //   it('should check if a family exists', async () => {
+  //     const [exists] = await FAMILY.exists();
+  //     assert.strictEqual(exists, true);
+  //   });
+  //
+  //   it('should check if a family does not exist', async () => {
+  //     const family = TABLE.family('prezzies');
+  //     const [exists] = await family.exists();
+  //     assert.strictEqual(exists, false);
+  //   });
+  //
+  //   it('should create a family if autoCreate is true', async () => {
+  //     const family = TABLE.family('prezzies');
+  //     await family.get({autoCreate: true});
+  //     await family.delete();
+  //   });
+  //
+  //   it('should create a family with nested gc rules', async () => {
+  //     const family = TABLE.family('prezzies');
+  //     const options = {
+  //       rule: {
+  //         union: true,
+  //         versions: 10,
+  //         rule: {
+  //           versions: 2,
+  //           age: {seconds: 60 * 60 * 24 * 30},
+  //         },
+  //       },
+  //     };
+  //     await family.create(options);
+  //     const [metadata] = await family.getMetadata();
+  //     assert.deepStrictEqual(metadata.gcRule, {
+  //       union: {
+  //         rules: [
+  //           {
+  //             maxNumVersions: 10,
+  //             rule: 'maxNumVersions',
+  //           },
+  //           {
+  //             intersection: {
+  //               rules: [
+  //                 {
+  //                   maxAge: {
+  //                     seconds: '2592000',
+  //                     nanos: 0,
+  //                   },
+  //                   rule: 'maxAge',
+  //                 },
+  //                 {
+  //                   maxNumVersions: 2,
+  //                   rule: 'maxNumVersions',
+  //                 },
+  //               ],
+  //             },
+  //             rule: 'intersection',
+  //           },
+  //         ],
+  //       },
+  //       rule: 'union',
+  //     });
+  //     await family.delete();
+  //   });
+  //
+  //   it('should get the column family metadata', async () => {
+  //     const [metadata] = await FAMILY.getMetadata();
+  //     assert.strictEqual(FAMILY.metadata, metadata);
+  //   });
+  //
+  //   it('should update a column family', async () => {
+  //     const rule = {
+  //       age: {
+  //         seconds: 10000,
+  //         nanos: 10000,
+  //       },
+  //     };
+  //     const [metadata] = await FAMILY.setMetadata({rule});
+  //     const maxAge = metadata.gcRule!.maxAge;
+  //     assert.strictEqual(maxAge!.seconds, rule.age.seconds.toString());
+  //     assert.strictEqual(maxAge!.nanos, rule.age.nanos);
+  //   });
+  //
+  //   it('should delete a column family', async () => {
+  //     await FAMILY.delete();
+  //   });
+  // });
+  //
+  // describe('rows', () => {
+  //   describe('.exists()', () => {
+  //     const row = TABLE.row('alincoln');
+  //
+  //     beforeEach(async () => {
+  //       await row.create({
+  //         entry: {
+  //           follows: {
+  //             gwashington: 1,
+  //             jadams: 1,
+  //             tjefferson: 1,
+  //           },
+  //         },
+  //       });
+  //     });
+  //
+  //     afterEach(async () => row.delete());
+  //
+  //     it('should check if a row exists', async () => {
+  //       const [exists] = await row.exists();
+  //       assert.strictEqual(exists, true);
+  //     });
+  //
+  //     it('should check if a row does not exist', async () => {
+  //       const row = TABLE.row('gwashington');
+  //       const [exists] = await row.exists();
+  //       assert.strictEqual(exists, false);
+  //     });
+  //   });
+  //
+  //   describe('inserting data', () => {
+  //     it('should insert rows', async () => {
+  //       const rows = [
+  //         {
+  //           key: 'gwashington',
+  //           data: {
+  //             follows: {
+  //               jadams: 1,
+  //             },
+  //           },
+  //         },
+  //         {
+  //           key: 'tjefferson',
+  //           data: {
+  //             follows: {
+  //               gwashington: 1,
+  //               jadams: 1,
+  //             },
+  //           },
+  //         },
+  //         {
+  //           key: 'jadams',
+  //           data: {
+  //             follows: {
+  //               gwashington: 1,
+  //               tjefferson: 1,
+  //             },
+  //           },
+  //         },
+  //       ];
+  //       await TABLE.insert(rows);
+  //     });
+  //
+  //     it('should insert a large row', async () => {
+  //       await TABLE.insert({
+  //         key: 'gwashington',
+  //         data: {
+  //           follows: {
+  //             jadams: Buffer.alloc(5000000),
+  //           },
+  //         },
+  //       });
+  //     });
+  //
+  //     it('should create an individual row', async () => {
+  //       const row = TABLE.row('alincoln');
+  //       const rowData = {
+  //         follows: {
+  //           gwashington: 1,
+  //           jadams: 1,
+  //           tjefferson: 1,
+  //         },
+  //       };
+  //       await row.create({entry: rowData});
+  //     });
+  //
+  //     it('should insert individual cells', async () => {
+  //       const row = TABLE.row('gwashington');
+  //       const rowData = {
+  //         follows: {
+  //           jadams: 1,
+  //         },
+  //       };
+  //       await row.save(rowData);
+  //     });
+  //
+  //     it('should allow for user specified timestamps', async () => {
+  //       const row = TABLE.row('gwashington');
+  //       const rowData = {
+  //         follows: {
+  //           jadams: {
+  //             value: 1,
+  //             timestamp: new Date('March 22, 1986'),
+  //           },
+  //         },
+  //       };
+  //       await row.save(rowData);
+  //     });
+  //
+  //     it('should increment a column value', async () => {
+  //       const row = TABLE.row('gwashington');
+  //       const increment = 5;
+  //       const [value] = await row.increment('follows:increment', increment);
+  //       assert.strictEqual(value, increment);
+  //     });
+  //
+  //     it('should apply read/modify/write rules to a row', async () => {
+  //       const row = TABLE.row('gwashington');
+  //       const rule = {
+  //         column: 'traits:teeth',
+  //         append: '-wood',
+  //       };
+  //       await row.save({
+  //         traits: {
+  //           teeth: 'shiny',
+  //         },
+  //       });
+  //       await row.createRules(rule);
+  //       const [data] = await row.get(['traits:teeth']);
+  //       assert.strictEqual(data.traits.teeth[0].value, 'shiny-wood');
+  //     });
+  //
+  //     it('should check and mutate a row', async () => {
+  //       const row = TABLE.row('gwashington');
+  //       const filter: RawFilter = {
+  //         family: 'follows',
+  //         value: 'alincoln',
+  //       };
+  //       const mutations = [
+  //         {
+  //           method: 'delete',
+  //           data: ['follows:alincoln'],
+  //         },
+  //       ];
+  //       const [matched] = await row.filter(filter, {onMatch: mutations});
+  //       assert(matched);
+  //     });
+  //   });
+  //
+  //   describe('fetching data', () => {
+  //     it('should get rows', async () => {
+  //       const [rows] = await TABLE.getRows();
+  //       assert.strictEqual(rows.length, 4);
+  //       assert(rows[0] instanceof Row);
+  //     });
+  //
+  //     it('should get rows via stream', done => {
+  //       const rows: Row[] = [];
+  //       TABLE.createReadStream()
+  //         .on('error', done)
+  //         .on('data', row => {
+  //           assert(row instanceof Row);
+  //           rows.push(row);
+  //         })
+  //         .on('end', () => {
+  //           assert.strictEqual(rows.length, 4);
+  //           done();
+  //         });
+  //     });
+  //
+  //     it('should should cancel request if stream ended early', done => {
+  //       const rows: Row[] = [];
+  //       const stream = TABLE.createReadStream()
+  //         .on('error', done)
+  //         .on('data', row => {
+  //           stream.end();
+  //           rows.push(row);
+  //         })
+  //         .on('end', () => {
+  //           assert.strictEqual(rows.length, 1);
+  //           done();
+  //         });
+  //     });
+  //
+  //     it('should fetch an individual row', async () => {
+  //       const row = TABLE.row('alincoln');
+  //       const [row_] = await row.get();
+  //       assert.strictEqual(row, row_);
+  //     });
+  //
+  //     it('should limit the number of rows', async () => {
+  //       const [rows] = await TABLE.getRows({
+  //         limit: 1,
+  //       });
+  //       assert.strictEqual(rows.length, 1);
+  //     });
+  //
+  //     it('should fetch a range of rows', async () => {
+  //       const options = {
+  //         start: 'alincoln',
+  //         end: 'jadams',
+  //       };
+  //       const [rows] = await TABLE.getRows(options);
+  //       assert.strictEqual(rows.length, 3);
+  //     });
+  //
+  //     it('should fetch a range of rows via prefix', async () => {
+  //       const options = {
+  //         prefix: 'g',
+  //       };
+  //       const [rows] = await TABLE.getRows(options);
+  //       assert.strictEqual(rows.length, 1);
+  //       assert.strictEqual(rows[0].id, 'gwashington');
+  //     });
+  //
+  //     it('should fetch individual cells of a row', async () => {
+  //       const row = TABLE.row('alincoln');
+  //       const [data] = await row.get(['follows:gwashington']);
+  //       assert.strictEqual(data.follows.gwashington[0].value, 1);
+  //     });
+  //
+  //     it('should not decode the values', async () => {
+  //       const row = TABLE.row('gwashington');
+  //       const options = {
+  //         decode: false,
+  //       };
+  //       await row.get(options);
+  //       const teeth = row.data.traits.teeth;
+  //       const value = teeth[0].value;
+  //       assert(value instanceof Buffer);
+  //       assert.strictEqual(value.toString(), 'shiny-wood');
+  //     });
+  //
+  //     it('should get sample row keys', async () => {
+  //       const [keys] = await TABLE.sampleRowKeys();
+  //       assert(keys.length > 0);
+  //     });
+  //
+  //     it('should get sample row keys via stream', done => {
+  //       const keys: string[] = [];
+  //       TABLE.sampleRowKeysStream()
+  //         .on('error', done)
+  //         .on('data', (rowKey: string) => {
+  //           keys.push(rowKey);
+  //         })
+  //         .on('end', () => {
+  //           assert(keys.length > 0);
+  //           done();
+  //         });
+  //     });
+  //
+  //     it('should end stream early', async () => {
+  //       const entries = [
+  //         {
+  //           key: 'gwashington',
+  //           data: {
+  //             follows: {
+  //               jadams: 1,
+  //             },
+  //           },
+  //         },
+  //         {
+  //           key: 'tjefferson',
+  //           data: {
+  //             follows: {
+  //               gwashington: 1,
+  //               jadams: 1,
+  //             },
+  //           },
+  //         },
+  //         {
+  //           key: 'jadams',
+  //           data: {
+  //             follows: {
+  //               gwashington: 1,
+  //               tjefferson: 1,
+  //             },
+  //           },
+  //         },
+  //       ];
+  //       await TABLE.insert(entries);
+  //       const rows: Row[] = [];
+  //       await new Promise<void>((resolve, reject) => {
+  //         const stream = TABLE.createReadStream()
+  //           .on('error', reject)
+  //           .on('data', row => {
+  //             rows.push(row);
+  //             stream.end();
+  //           })
+  //           .on('end', () => {
+  //             assert.strictEqual(rows.length, 1);
+  //             resolve();
+  //           });
+  //       });
+  //     });
+  //
+  //     describe('filters', () => {
+  //       it('should get rows via column data', async () => {
+  //         const filter = {
+  //           column: 'gwashington',
+  //         };
+  //         const [rows] = await TABLE.getRows({filter});
+  //         assert.strictEqual(rows.length, 3);
+  //         const keys = rows.map(row => row.id).sort();
+  //         assert.deepStrictEqual(keys, ['alincoln', 'jadams', 'tjefferson']);
+  //       });
+  //
+  //       it('should get rows that satisfy the cell limit', async () => {
+  //         const entry = {
+  //           key: 'alincoln',
+  //           data: {
+  //             follows: {
+  //               tjefferson: 1,
+  //             },
+  //           },
+  //         };
+  //         const filter = [
+  //           {
+  //             row: 'alincoln',
+  //           },
+  //           {
+  //             column: {
+  //               name: 'tjefferson',
+  //               cellLimit: 1,
+  //             },
+  //           },
+  //         ];
+  //         await TABLE.insert(entry);
+  //         const [rows] = await TABLE.getRows({filter});
+  //         const rowData = rows[0].data;
+  //         assert.strictEqual(rowData.follows.tjefferson.length, 1);
+  //       });
+  //
+  //       it('should get a range of columns', async () => {
+  //         const filter = [
+  //           {
+  //             row: 'tjefferson',
+  //           },
+  //           {
+  //             column: {
+  //               family: 'follows',
+  //               start: 'gwashington',
+  //               end: 'jadams',
+  //             },
+  //           },
+  //         ];
+  //
+  //         const [rows] = await TABLE.getRows({filter});
+  //         rows.forEach(row => {
+  //           const keys = Object.keys(row.data.follows).sort();
+  //           assert.deepStrictEqual(keys, ['gwashington', 'jadams']);
+  //         });
+  //       });
+  //
+  //       it('should run a conditional filter', async () => {
+  //         const filter = {
+  //           condition: {
+  //             test: [
+  //               {
+  //                 row: 'gwashington',
+  //               },
+  //               {
+  //                 family: 'follows',
+  //               },
+  //               {
+  //                 column: 'tjefferson',
+  //               },
+  //             ],
+  //             pass: {
+  //               row: 'gwashington',
+  //             },
+  //             fail: {
+  //               row: 'tjefferson',
+  //             },
+  //           },
+  //         };
+  //         const [rows] = await TABLE.getRows({filter});
+  //         assert.strictEqual(rows.length, 1);
+  //         assert.strictEqual(rows[0].id, 'tjefferson');
+  //       });
+  //
+  //       it('should run a conditional filter with pass only', async () => {
+  //         const filter = {
+  //           condition: {
+  //             test: [
+  //               {
+  //                 row: 'gwashington',
+  //               },
+  //             ],
+  //             pass: [
+  //               {
+  //                 all: true,
+  //               },
+  //             ],
+  //           },
+  //         };
+  //         const [rows] = await TABLE.getRows({filter});
+  //         assert(rows.length > 0);
+  //       });
+  //
+  //       it('should only get cells for a specific family', async () => {
+  //         const entries = [
+  //           {
+  //             key: 'gwashington',
+  //             data: {
+  //               traits: {
+  //                 teeth: 'wood',
+  //               },
+  //             },
+  //           },
+  //         ];
+  //         await TABLE.insert(entries);
+  //         const filter = {
+  //           family: 'traits',
+  //         };
+  //         const [rows] = await TABLE.getRows({filter});
+  //         assert(rows.length > 0);
+  //         const families = Object.keys(rows[0].data);
+  //         assert.deepStrictEqual(families, ['traits']);
+  //       });
+  //
+  //       it('should interleave filters', async () => {
+  //         const filter = [
+  //           {
+  //             interleave: [
+  //               [
+  //                 {
+  //                   row: 'gwashington',
+  //                 },
+  //               ],
+  //               [
+  //                 {
+  //                   row: 'tjefferson',
+  //                 },
+  //               ],
+  //             ],
+  //           },
+  //         ];
+  //         const [rows] = await TABLE.getRows({filter});
+  //         assert.strictEqual(rows.length, 2);
+  //         const ids = rows.map(row => row.id).sort();
+  //         assert.deepStrictEqual(ids, ['gwashington', 'tjefferson']);
+  //       });
+  //
+  //       it('should apply labels to the results', async () => {
+  //         const filter = {
+  //           label: 'test-label',
+  //         };
+  //         const [rows] = await TABLE.getRows({filter});
+  //         rows.forEach(row => {
+  //           const follows = row.data.follows;
+  //           Object.keys(follows).forEach(column => {
+  //             // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  //             follows[column].forEach((cell: any) => {
+  //               assert.deepStrictEqual(cell.labels, [filter.label]);
+  //             });
+  //           });
+  //         });
+  //       });
+  //
+  //       it('should run a regex against the row id', async () => {
+  //         const filter = {
+  //           row: /[a-z]+on$/,
+  //         };
+  //         const [rows] = await TABLE.getRows({filter});
+  //         const keys = rows.map(row => row.id).sort();
+  //         assert.deepStrictEqual(keys, ['gwashington', 'tjefferson']);
+  //       });
+  //
+  //       it('should run a sink filter', async () => {
+  //         const filter = [
+  //           {
+  //             row: 'alincoln',
+  //           },
+  //           {
+  //             family: 'follows',
+  //           },
+  //           {
+  //             interleave: [
+  //               [
+  //                 {
+  //                   all: true,
+  //                 },
+  //               ],
+  //               [
+  //                 {
+  //                   label: 'prezzy',
+  //                 },
+  //                 {
+  //                   sink: true,
+  //                 },
+  //               ],
+  //             ],
+  //           },
+  //           {
+  //             column: 'gwashington',
+  //           },
+  //         ];
+  //         const [rows] = await TABLE.getRows({filter});
+  //         const columns = Object.keys(rows[0].data.follows).sort();
+  //         assert.deepStrictEqual(columns, [
+  //           'gwashington',
+  //           'jadams',
+  //           'tjefferson',
+  //         ]);
+  //       });
+  //     });
+  //
+  //     it('should accept a date range', async () => {
+  //       const filter = {
+  //         time: {
+  //           start: new Date('March 21, 1986'),
+  //           end: new Date('March 23, 1986'),
+  //         },
+  //       };
+  //       const [rows] = await TABLE.getRows({filter});
+  //       assert(rows.length > 0);
+  //     });
+  //   });
+  // });
+  //
+  // describe('deleting rows', () => {
+  //   it('should delete specific cells', async () => {
+  //     const row = TABLE.row('alincoln');
+  //     await row.deleteCells(['follows:gwashington']);
+  //   });
+  //
+  //   it('should delete a family', async () => {
+  //     const row = TABLE.row('gwashington');
+  //     await row.deleteCells(['traits']);
+  //   });
+  //
+  //   it('should delete all the cells', async () => {
+  //     const row = TABLE.row('alincoln');
+  //     await row.delete();
+  //   });
+  // });
+  //
+  // describe('.deleteRows()', () => {
+  //   const table = INSTANCE.table(generateId('table'));
+  //   beforeEach(async () => {
+  //     const tableOptions = {
+  //       families: ['cf1'],
+  //     };
+  //     const data = {
+  //       cf1: {
+  //         foo: 1,
+  //       },
+  //     };
+  //     const rows = [
+  //       {
+  //         key: 'aaa',
+  //         data,
+  //       },
+  //       {
+  //         key: 'abc',
+  //         data,
+  //       },
+  //       {
+  //         key: 'def',
+  //         data,
+  //       },
+  //     ];
+  //     await table.create(tableOptions);
+  //     await table.insert(rows);
+  //   });
+  //
+  //   afterEach(async () => {
+  //     await table.delete();
+  //   });
+  //
+  //   it('should delete the prefixes', async () => {
+  //     await table.deleteRows('a');
+  //     const [rows] = await table.getRows();
+  //     assert.strictEqual(rows.length, 1);
+  //   });
+  // });
+  //
+  // describe('.truncate()', () => {
+  //   const table = INSTANCE.table(generateId('table'));
+  //   beforeEach(async () => {
+  //     const tableOptions = {
+  //       families: ['follows'],
+  //     };
+  //     const rows = [
+  //       {
+  //         key: 'gwashington',
+  //         data: {
+  //           follows: {
+  //             jadams: 1,
+  //           },
+  //         },
+  //       },
+  //     ];
+  //     await table.create(tableOptions);
+  //     await table.insert(rows);
+  //   });
+  //
+  //   afterEach(async () => {
+  //     await table.delete();
+  //   });
+  //
+  //   it('should truncate a table', async () => {
+  //     await table.truncate();
+  //     const [rows] = await table.getRows();
+  //     assert.strictEqual(rows.length, 0);
+  //   });
+  // });
+  //
+  // describe('backups', () => {
+  //   const CLUSTER = INSTANCE.cluster(CLUSTER_ID);
+  //   let BACKUP: Backup;
+  //
+  //   // For these tests, two backups are needed. The backups are labeled for what
+  //   // they are intended to originate/interact from/with, but this is just for
+  //   // testing and the naming convention used here does not actually influence
+  //   // the real functionality - it is just a way to keep things organized!
+  //   const backupIdFromCluster = generateId('backup');
+  //   let backupNameFromCluster: string;
+  //   const restoreTableIdFromCluster = generateId('table');
+  //
+  //   const backupIdFromTable = generateId('backup');
+  //   let backupNameFromTable: string;
+  //
+  //   // The minimum backup expiry time is 6 hours. The times here each have a 2
+  //   // hour padding to tolerate latency and clock drift. Also, while the time
+  //   // implementation for backups in this client accepts any of a Timestamp
+  //   // Struct, Date, or PreciseDate, to keep things easy this uses PreciseDate.
+  //   const expireTime = new PreciseDate(PreciseDate.now() + 8 * 60 * 60 * 1000);
+  //   const updateExpireTime = new PreciseDate(
+  //     expireTime.getTime() + 2 + 60 * 60 * 1000
+  //   );
+  //
+  //   before(async () => {
+  //     const [backup, op] = await CLUSTER.createBackup(backupIdFromCluster, {
+  //       table: TABLE,
+  //       expireTime,
+  //     });
+  //     BACKUP = backup;
+  //     await op.promise();
+  //     backupNameFromCluster = replaceProjectIdToken(
+  //       `${CLUSTER.name}/backups/${backupIdFromCluster}`,
+  //       bigtable.projectId
+  //     );
+  //     backupNameFromTable = replaceProjectIdToken(
+  //       `${CLUSTER.name}/backups/${backupIdFromTable}`,
+  //       bigtable.projectId
+  //     );
+  //   });
+  //
+  //   it('should create backup of a table (from cluster)', async () => {
+  //     await BACKUP.getMetadata();
+  //
+  //     assert.strictEqual(BACKUP.metadata!.name, backupNameFromCluster);
+  //
+  //     assert.deepStrictEqual(BACKUP.expireDate, expireTime);
+  //   });
+  //
+  //   it('should create backup of a table (from table)', async () => {
+  //     const [backup, op] = await TABLE.createBackup(backupIdFromTable, {
+  //       expireTime,
+  //     });
+  //     await op.promise();
+  //     await backup.getMetadata();
+  //
+  //     assert.strictEqual(backup.metadata!.name, backupNameFromTable);
+  //
+  //     assert.deepStrictEqual(backup.expireDate, expireTime);
+  //   });
+  //
+  //   it('should get a specific backup (cluster)', async () => {
+  //     const [backup] = await CLUSTER.backup(backupIdFromCluster).get();
+  //     assert.strictEqual(backup.metadata!.name, backupNameFromCluster);
+  //     assert.strictEqual(backup.metadata!.state, 'READY');
+  //   });
+  //
+  //   it('should get backups in an instance', async () => {
+  //     const [backups] = await INSTANCE.getBackups();
+  //     assert(Array.isArray(backups));
+  //     assert(backups.length > 0);
+  //     assert(backups.some(backup => backup.id === BACKUP.id));
+  //   });
+  //
+  //   it('should get backups in an instance as a stream', done => {
+  //     const backups: Backup[] = [];
+  //
+  //     INSTANCE.getBackupsStream()
+  //       .on('error', done)
+  //       .on('data', backup => {
+  //         backups.push(backup);
+  //       })
+  //       .on('end', () => {
+  //         assert(backups.length > 0);
+  //         done();
+  //       });
+  //   });
+  //
+  //   it('should get backups in a cluster', async () => {
+  //     const [backups] = await CLUSTER.getBackups();
+  //     assert(Array.isArray(backups));
+  //     assert(backups.length > 0);
+  //     assert(backups.some(backup => backup.id === BACKUP.id));
+  //   });
+  //
+  //   it('should get backups in a cluster as a stream', done => {
+  //     const backups: Backup[] = [];
+  //
+  //     CLUSTER.getBackupsStream()
+  //       .on('error', done)
+  //       .on('data', backup => {
+  //         backups.push(backup);
+  //       })
+  //       .on('end', () => {
+  //         assert(backups.length > 0);
+  //         done();
+  //       });
+  //   });
+  //
+  //   it('should restore a backup (cluster)', async () => {
+  //     const backup = CLUSTER.backup(backupIdFromCluster);
+  //     const [table, op] = await backup.restore(restoreTableIdFromCluster);
+  //     await op.promise();
+  //
+  //     const restoredTableId = table.name?.split('/').pop();
+  //     assert.strictEqual(restoredTableId, restoreTableIdFromCluster);
+  //   });
+  //
+  //   it('should restore a backup to a different instance', async () => {
+  //     const [, operation] = await DIFF_INSTANCE.create(
+  //       createInstanceConfig(generateId('d-clust'), 'us-east1-c', 3, Date.now())
+  //     );
+  //     await operation.promise();
+  //     const [iExists] = await DIFF_INSTANCE.exists();
+  //     assert.strictEqual(iExists, true);
+  //
+  //     const backup = CLUSTER.backup(backupIdFromCluster);
+  //     const [table, op] = await backup.restoreTo({
+  //       tableId: restoreTableIdFromCluster,
+  //       instance: DIFF_INSTANCE,
+  //     });
+  //     await op.promise();
+  //     const [tExists] = await table.exists();
+  //     assert.strictEqual(tExists, true);
+  //     assert.strictEqual(table.id, restoreTableIdFromCluster);
+  //   });
+  //
+  //   it('should update a backup (cluster)', async () => {
+  //     const backup = CLUSTER.backup(backupIdFromCluster);
+  //     const [metadata] = await backup.setMetadata({
+  //       expireTime: updateExpireTime,
+  //     });
+  //
+  //     assert.strictEqual(metadata.name, backupNameFromCluster);
+  //     assert.deepStrictEqual(backup.expireDate, updateExpireTime);
+  //   });
+  //
+  //   it('should get an Iam Policy for the backup', async () => {
+  //     const policyProperties = ['version', 'bindings', 'etag'];
+  //     const [policy] = await BACKUP.getIamPolicy();
+  //
+  //     policyProperties.forEach(property => {
+  //       assert(property in policy);
+  //     });
+  //   });
+  //
+  //   it('should test Iam permissions for the backup', async () => {
+  //     const permissions = ['bigtable.backups.get', 'bigtable.backups.delete'];
+  //     const [grantedPermissions] = await BACKUP.testIamPermissions(permissions);
+  //     assert.strictEqual(grantedPermissions.length, permissions.length);
+  //     permissions.forEach(permission => {
+  //       assert.strictEqual(grantedPermissions.includes(permission), true);
+  //     });
+  //   });
+  //
+  //   it('should set Iam Policy on the backup', async () => {
+  //     const backup = CLUSTER.backup(backupIdFromCluster);
+  //
+  //     const [policy] = await backup.getIamPolicy();
+  //     const [updatedPolicy] = await backup.setIamPolicy(policy);
+  //
+  //     Object.keys(policy).forEach(key => assert(key in updatedPolicy));
+  //   });
+  //   describe('copying backups', () => {
+  //     // The server requires the copy backup time to be sufficiently ahead of
+  //     // the create backup time to avoid an error.
+  //     // Set it to 308 hours ahead
+  //     const sourceExpireTimeMilliseconds =
+  //       PreciseDate.now() + (8 + 300) * 60 * 60 * 1000;
+  //     const sourceExpireTime = new PreciseDate(sourceExpireTimeMilliseconds);
+  //     // 608 hours ahead of now, 300 hours ahead of sourceExpireTimeMilliseconds
+  //     const copyExpireTimeMilliseconds =
+  //       PreciseDate.now() + (8 + 600) * 60 * 60 * 1000;
+  //     const copyExpireTime = new PreciseDate(copyExpireTimeMilliseconds);
+  //
+  //     /*
+  //       This function checks that when a backup is copied using the provided
+  //       config that a new backup is created on the instance.
+  //      */
+  //     async function testCopyBackup(
+  //       backup: Backup,
+  //       config: CopyBackupConfig,
+  //       instance: Instance
+  //     ) {
+  //       // Get a list of backup ids before the copy
+  //       const [backupsBeforeCopy] = await instance.getBackups();
+  //       const backupIdsBeforeCopy = backupsBeforeCopy.map(backup => backup.id);
+  //       // Copy the backup
+  //       const [newBackup, operation] = await backup.copy(config);
+  //       try {
+  //         assert.strictEqual(config.id, newBackup.id);
+  //         await operation.promise();
+  //         const id = config.id;
+  //         const backupPath = `${config.cluster.name}/backups/${id}`;
+  //         {
+  //           // Ensure that the backup specified by the config and id match the backup name for the operation returned by the server.
+  //           // the split/map/join functions replace the project name with the {{projectId}} string
+  //           assert(operation);
+  //           assert(operation.metadata);
+  //           assert.strictEqual(
+  //             operation.metadata.name
+  //               .split('/')
+  //               .map((item, index) => (index === 1 ? '{{projectId}}' : item))
+  //               .join('/'),
+  //             backupPath
+  //               .split('/')
+  //               .map((item, index) => (index === 1 ? '{{projectId}}' : item))
+  //               .join('/')
+  //           );
+  //         }
+  //         // Check that there is now one more backup
+  //         const [backupsAfterCopy] = await instance.getBackups();
+  //         const newBackups = backupsAfterCopy.filter(
+  //           backup => !backupIdsBeforeCopy.includes(backup.id)
+  //         );
+  //         assert.strictEqual(newBackups.length, 1);
+  //         const [fetchedNewBackup] = newBackups;
+  //         // Ensure the fetched backup matches the config
+  //         assert.strictEqual(fetchedNewBackup.id, id);
+  //         assert.strictEqual(fetchedNewBackup.name, backupPath);
+  //         // Delete the copied backup
+  //       } finally {
+  //         await config.cluster.backup(newBackup.id).delete();
+  //       }
+  //     }
+  //
+  //     describe('should create backup of a table and copy it in the same cluster', async () => {
+  //       async function testWithExpiryTimes(
+  //         sourceTestExpireTime: BackupTimestamp,
+  //         copyTestExpireTime: BackupTimestamp
+  //       ) {
+  //         const [backup, op] = await TABLE.createBackup(generateId('backup'), {
+  //           expireTime: sourceTestExpireTime,
+  //         });
+  //         try {
+  //           {
+  //             await op.promise();
+  //             // Check expiry time for running operation.
+  //             await backup.getMetadata();
+  //             assert.deepStrictEqual(backup.expireDate, sourceExpireTime);
+  //           }
+  //           await testCopyBackup(
+  //             backup,
+  //             {
+  //               cluster: backup.cluster,
+  //               id: generateId('backup'),
+  //               expireTime: copyTestExpireTime,
+  //             },
+  //             INSTANCE
+  //           );
+  //         } finally {
+  //           await backup.delete();
+  //         }
+  //       }
+  //       it('should copy to the same cluster with precise date expiry times', async () => {
+  //         await testWithExpiryTimes(sourceExpireTime, copyExpireTime);
+  //       });
+  //       it('should copy to the same cluster with timestamp expiry times', async () => {
+  //         // Calling toStruct converts times to a timestamp object.
+  //         // For example: sourceExpireTime.toStruct() = {seconds: 1706659851, nanos: 981000000}
+  //         await testWithExpiryTimes(
+  //           sourceExpireTime.toStruct(),
+  //           copyExpireTime.toStruct()
+  //         );
+  //       });
+  //       it('should copy to the same cluster with date expiry times', async () => {
+  //         await testWithExpiryTimes(
+  //           new Date(sourceExpireTimeMilliseconds),
+  //           new Date(copyExpireTimeMilliseconds)
+  //         );
+  //       });
+  //     });
+  //     it('should create backup of a table and copy it on another cluster of another instance', async () => {
+  //       const [backup, op] = await TABLE.createBackup(generateId('backup'), {
+  //         expireTime: sourceExpireTime,
+  //       });
+  //       try {
+  //         {
+  //           await op.promise();
+  //           // Check the expiry time.
+  //           await backup.getMetadata();
+  //           assert.deepStrictEqual(backup.expireDate, sourceExpireTime);
+  //         }
+  //         // Create another instance
+  //         const instance = bigtable.instance(generateId('instance'));
+  //         const destinationClusterId = generateId('cluster');
+  //         {
+  //           // Create production instance with given options
+  //           const instanceOptions: InstanceOptions = {
+  //             clusters: [
+  //               {
+  //                 id: destinationClusterId,
+  //                 nodes: 3,
+  //                 location: 'us-central1-f',
+  //                 storage: 'ssd',
+  //               },
+  //             ],
+  //             labels: {'prod-label': 'prod-label'},
+  //             type: 'production',
+  //           };
+  //           const [, operation] = await instance.create(instanceOptions);
+  //           await operation.promise();
+  //         }
+  //         // Create the copy and test the copied backup
+  //         await testCopyBackup(
+  //           backup,
+  //           {
+  //             cluster: new Cluster(instance, destinationClusterId),
+  //             id: generateId('backup'),
+  //             expireTime: copyExpireTime,
+  //           },
+  //           instance
+  //         );
+  //         await instance.delete();
+  //       } finally {
+  //         await backup.delete();
+  //       }
+  //     });
+  //     it('should create backup of a table and copy it on another cluster of the same instance', async () => {
+  //       const [backup, op] = await TABLE.createBackup(generateId('backup'), {
+  //         expireTime: sourceExpireTime,
+  //       });
+  //       try {
+  //         {
+  //           await op.promise();
+  //           // Check the expiry time.
+  //           await backup.getMetadata();
+  //           assert.deepStrictEqual(backup.expireDate, sourceExpireTime);
+  //         }
+  //         const destinationClusterId = generateId('cluster');
+  //         {
+  //           // Create destination cluster with given options
+  //           const [, operation] = await INSTANCE.cluster(
+  //             destinationClusterId
+  //           ).create({
+  //             location: 'us-central1-b',
+  //             nodes: 3,
+  //           });
+  //           await operation.promise();
+  //         }
+  //         // Create the copy and test the copied backup
+  //         await testCopyBackup(
+  //           backup,
+  //           {
+  //             cluster: new Cluster(INSTANCE, destinationClusterId),
+  //             id: generateId('backup'),
+  //             expireTime: copyExpireTime,
+  //           },
+  //           INSTANCE
+  //         );
+  //       } finally {
+  //         await backup.delete();
+  //       }
+  //     });
+  //     it('should create backup of a table and copy it on another project', async () => {
+  //       const [backup, op] = await TABLE.createBackup(generateId('backup'), {
+  //         expireTime: sourceExpireTime,
+  //       });
+  //       try {
+  //         {
+  //           await op.promise();
+  //           // Check the expiry time.
+  //           await backup.getMetadata();
+  //           assert.deepStrictEqual(backup.expireDate, sourceExpireTime);
+  //         }
+  //         // Create client, instance, cluster for second project
+  //         const bigtableSecondaryProject = new Bigtable(
+  //           process.env.GCLOUD_PROJECT2
+  //             ? {projectId: process.env.GCLOUD_PROJECT2}
+  //             : {}
+  //         );
+  //         const secondInstance = bigtableSecondaryProject.instance(
+  //           generateId('instance')
+  //         );
+  //         const destinationClusterId = generateId('cluster');
+  //         {
+  //           // Create production instance with given options
+  //           const instanceOptions: InstanceOptions = {
+  //             clusters: [
+  //               {
+  //                 id: destinationClusterId,
+  //                 nodes: 3,
+  //                 location: 'us-central1-f',
+  //                 storage: 'ssd',
+  //               },
+  //             ],
+  //             labels: {'prod-label': 'prod-label'},
+  //             type: 'production',
+  //           };
+  //           const [, operation] = await secondInstance.create(instanceOptions);
+  //           await operation.promise();
+  //         }
+  //         // Create the copy and test the copied backup
+  //         await testCopyBackup(
+  //           backup,
+  //           {
+  //             cluster: new Cluster(secondInstance, destinationClusterId),
+  //             id: generateId('backup'),
+  //             expireTime: copyExpireTime,
+  //           },
+  //           secondInstance
+  //         );
+  //         await secondInstance.delete();
+  //       } finally {
+  //         await backup.delete();
+  //       }
+  //     });
+  //     it('should restore a copied backup', async () => {
+  //       const backupId = generateId('backup');
+  //       const table = INSTANCE.table('old-table');
+  //       {
+  //         // Create a table and insert data into it.
+  //         await table.create();
+  //         await table.createFamily('follows');
+  //         await table.insert([
+  //           {
+  //             key: 'some-data-to-copy-key',
+  //             data: {
+  //               follows: {
+  //                 copyData: 'data-to-copy',
+  //               },
+  //             },
+  //           },
+  //         ]);
+  //       }
+  //       // Create the backup
+  //       const [backup, createBackupOperation] = await table.createBackup(
+  //         backupId,
+  //         {
+  //           expireTime: sourceExpireTime,
+  //         }
+  //       );
+  //       try {
+  //         await createBackupOperation.promise();
+  //         // Copy the backup
+  //         const config = {
+  //           cluster: backup.cluster,
+  //           id: generateId('backup'),
+  //           expireTime: copyExpireTime,
+  //         };
+  //         const [newBackup, copyOperation] = await backup.copy(config);
+  //         await copyOperation.promise();
+  //         // Restore a table from the copied backup
+  //         const [newTable, restoreOperation] =
+  //           await newBackup.restore('new-table');
+  //         await restoreOperation.promise();
+  //         const rows = await newTable.getRows();
+  //         assert.deepStrictEqual(rows[0][0].id, 'some-data-to-copy-key');
+  //       } finally {
+  //         await backup.delete();
+  //       }
+  //     });
+  //   });
+  // });
 
   describe('mutate', () => {
     const table = INSTANCE.table(generateId('table'));

--- a/system-test/bigtable.ts
+++ b/system-test/bigtable.ts
@@ -35,7 +35,7 @@ import {RawFilter} from '../src/filter';
 import {generateId, PREFIX} from './common';
 import {Mutation} from '../src/mutation';
 
-describe.only('Bigtable', () => {
+describe('Bigtable', () => {
   const bigtable = new Bigtable();
   const INSTANCE = bigtable.instance(generateId('instance'));
   const DIFF_INSTANCE = bigtable.instance(generateId('d-inst'));


### PR DESCRIPTION
**Summary:**

While working on unit tests for the `mutate` function for `Authorized Views` we needed to determine the structure of the first argument passed into `mutate`. Currently the type of the first argument is `Entry` which is just an alias for `any`, but this is problematic because we can't expect any data structure for this argument. In fact, this method will only work properly if this argument is in a very specific format. Knowing this exact format is important when writing unit tests for mutate.

In this PR we add comments to the source code that describe the shape of the first mutate argument by describing the `Entry` data type and provide some tests that demonstrate how `mutate` and `insert` can be used.

**Next steps:**

In the future we may want to change the `Entry` type to be more specific so that users can only use `mutate` in the way it was intended to be used or else they will see a compiler error. This would be a breaking change though so it is a safer first step just to add some comments.