### PR TITLE
docs: Change the comment for Entry data type

### DIFF
--- a/src/table.ts
+++ b/src/table.ts
@@ -290,9 +290,9 @@ export type Entry = any;
 /*
 The Entry type is expected to be in the following format:
 {
-  columnFamily: {
-    column: Data // Data is the expected type passed into Mutation.encodeSetCell
-  }
+  key?: Uint8Array|string,
+  data?: Data, // The Data type is described in the Mutation class.
+  method?: typeof mutation.methods
 }
 */
 


### PR DESCRIPTION
**Summary**

This pull request is actually a follow-up to [this pull request](https://github.com/googleapis/nodejs-bigtable/pull/1498/files). There may have been a clerical error as the structure of the `Entry` data type which is passed into `insert` needs to be corrected. It should possibly contain a key, data and a method.

An example of an `Entry` is given [here](https://github.com/googleapis/nodejs-bigtable/blob/86c8f4b96668a91f01bda2c75356b1ed12828269/samples/writeSimple.js#L37-L55).
