### PR TITLE
feat: allow table creates to specific column types with the low level proto format

### DIFF
--- a/src/instance.ts
+++ b/src/instance.ts
@@ -522,6 +522,9 @@ Please use the format 'my-instance' or '${bigtable.projectName}/instances/my-ins
           if (family.rule) {
             columnFamily.gcRule = Family.formatRule_(family.rule);
           }
+          if (family.valueType) {
+            columnFamily.valueType = family.valueType;
+          }
           return families;
         },
         {}


### PR DESCRIPTION
Without this, table creates can't specify a value type ever, which is required if you want to use `AddToCell` mutations for server-side aggregations. With this in place, the call to create a table with an aggregated value type is nasty, but possible. Here's what it would look like:

```
const int64Type: google.bigtable.v2.IType = {
  int64Type: {
    encoding: { bigEndianBytes: {} },
  },
};

bigtable.table("some_table").create({
  families: [
    {
      name: "aggregations",
      rule: {
        versions: 1,
      },
      // hacky specification of the column family aggregation type -- the JS client doesn't have support for these types, but putting this here passes it down to the eventual protobuf call the client makes
      valueType: {
        aggregateType: {
          inputType: int64Type,
          stateType: int64Type,
          sum: {},
        },
      },
    },
  ],
});
```

I'm not exactly sure what the policy is around features of this nature, but it seems busted to me to not allow calls to specify this level of schema at all and have to go through some other system like `cbt` to create tables with specific value types, but I'm open to feedback! 