### PR TITLE
test: Try not closing the generated client

### DIFF
--- a/testproxy/services/close-client.js
+++ b/testproxy/services/close-client.js
@@ -24,7 +24,6 @@ const closeClient = ({clientMap}) =>
     const bigtable = clientMap.get(clientId);
 
     if (bigtable) {
-      await bigtable[v2].close();
       await bigtable.close();
       return {};
     }


### PR DESCRIPTION
This is an experimental PR to see if any of the passing conformance tests break when the generated client isn't closed directly.