### PR TITLE
fix: Fix TestReadRows_Generic_CloseClient conformance test by passing grpc status codes for closed client errors

### DIFF
--- a/src/tabular-api-surface.ts
+++ b/src/tabular-api-surface.ts
@@ -29,7 +29,7 @@ import {Row} from './row';
 import {ChunkTransformer} from './chunktransformer';
 import {BackoffSettings} from 'google-gax/build/src/gax';
 import {google} from '../protos/protos';
-import {CallOptions, ServiceError} from 'google-gax';
+import {CallOptions, grpc, ServiceError} from 'google-gax';
 import {Duplex, PassThrough, Transform} from 'stream';
 import * as is from 'is';
 import {GoogleInnerError} from './table';
@@ -491,8 +491,7 @@ Please use the format 'prezzy' or '${instance.name}/tables/prezzy'.`);
               // CANCELLED since the user actually cancelled the call by closing
               // the client.
               //
-              // TODO: Replace 1 with grpc.status.CANCELLED and address the docs github action failure that it causes.
-              error.code = 1; // grpc.status.CANCELLED = 1
+              error.code = grpc.status.CANCELLED;
             }
             userStream.emit('error', error);
           }

--- a/src/tabular-api-surface.ts
+++ b/src/tabular-api-surface.ts
@@ -491,6 +491,7 @@ Please use the format 'prezzy' or '${instance.name}/tables/prezzy'.`);
                * CANCELLED since the user actually cancelled the call by closing
                * the client.
                */
+              // TODO: Replace 1 with grpc.status.CANCELLED and address the docs github action failure that it causes.
               error.code = 1; // grpc.status.CANCELLED = 1
             }
             userStream.emit('error', error);

--- a/src/tabular-api-surface.ts
+++ b/src/tabular-api-surface.ts
@@ -484,13 +484,13 @@ Please use the format 'prezzy' or '${instance.name}/tables/prezzy'.`);
               !error.code &&
               error.message === 'The client has already been closed.'
             ) {
-              /**
-               * The TestReadRows_Generic_CloseClient conformance test requires
-               * a grpc code to be present when the client is closed. According
-               * to Gemini, the appropriate code for a closed client is
-               * CANCELLED since the user actually cancelled the call by closing
-               * the client.
-               */
+              //
+              // The TestReadRows_Generic_CloseClient conformance test requires
+              // a grpc code to be present when the client is closed. According
+              // to Gemini, the appropriate code for a closed client is
+              // CANCELLED since the user actually cancelled the call by closing
+              // the client.
+              //
               // TODO: Replace 1 with grpc.status.CANCELLED and address the docs github action failure that it causes.
               error.code = 1; // grpc.status.CANCELLED = 1
             }

--- a/src/tabular-api-surface.ts
+++ b/src/tabular-api-surface.ts
@@ -34,7 +34,6 @@ import {Duplex, PassThrough, Transform} from 'stream';
 import * as is from 'is';
 import {GoogleInnerError} from './table';
 import {TableUtils} from './utils/table';
-import * as grpc from '@grpc/grpc-js';
 
 // See protos/google/rpc/code.proto
 // (4=DEADLINE_EXCEEDED, 8=RESOURCE_EXHAUSTED, 10=ABORTED, 14=UNAVAILABLE)

--- a/src/tabular-api-surface.ts
+++ b/src/tabular-api-surface.ts
@@ -492,7 +492,7 @@ Please use the format 'prezzy' or '${instance.name}/tables/prezzy'.`);
                * CANCELLED since the user actually cancelled the call by closing
                * the client.
                */
-              error.code = grpc.status.CANCELLED;
+              error.code = 1; // grpc.status.CANCELLED = 1
             }
             userStream.emit('error', error);
           }

--- a/src/tabular-api-surface.ts
+++ b/src/tabular-api-surface.ts
@@ -458,13 +458,11 @@ Please use the format 'prezzy' or '${instance.name}/tables/prezzy'.`);
 
       rowStream
         .on('error', (error: ServiceError) => {
-          console.log(error.code);
           rowStreamUnpipe(rowStream, userStream);
           activeRequestStream = null;
           if (IGNORED_STATUS_CODES.has(error.code)) {
             // We ignore the `cancelled` "error", since we are the ones who cause
             // it when the user calls `.abort()`.
-            console.log('ending stream');
             userStream.end();
             return;
           }

--- a/testproxy/known_failures.txt
+++ b/testproxy/known_failures.txt
@@ -15,7 +15,6 @@ TestReadRows_Retry_PausedScan\|
 TestReadRows_Retry_LastScannedRow\|
 TestReadRows_Retry_LastScannedRow_Reverse\|
 TestReadRows_Retry_StreamReset\|
-TestReadRows_Generic_CloseClient\|
 TestReadRows_Generic_DeadlineExceeded\|
 TestReadRows_Retry_WithRoutingCookie\|
 TestReadRows_Retry_WithRoutingCookie_MultipleErrorResponses\|


### PR DESCRIPTION
**Summary**

The TestReadRows_Generic_CloseClient conformance test [is failing](https://github.com/googleapis/cloud-bigtable-clients-test/blob/3b0215b4a3ae88fa1f1d2ad2229b4d8069bc1a5a/tests/readrows_test.go#L754). The [assert that was failing](https://github.com/googleapis/cloud-bigtable-clients-test/blob/3b0215b4a3ae88fa1f1d2ad2229b4d8069bc1a5a/tests/readrows_test.go#L754) was failing because the client was sending back an error saying the client had been closed without providing a status code for the error, but the assertion requires a non-zero status code to be present. With the new code change, the error saying that the client has been closed will now have a `CANCELLED` status code as was recommended by Gemini and the assertion check will pass and the test will pass too.