### PR TITLE
chore(testproxy): Address the TestReadRows_Generic_DeadlineExceeded test

### DIFF
--- a/src/tabular-api-surface.ts
+++ b/src/tabular-api-surface.ts
@@ -537,15 +537,20 @@ Please use the format 'prezzy' or '${instance.name}/tables/prezzy'.`);
           numRequestsMade++;
           if (
             numConsecutiveErrors <= maxRetries &&
-            (RETRYABLE_STATUS_CODES.has(error.code) || isRstStreamError(error)) &&
-            !(timeout && error.code === grpc.status.DEADLINE_EXCEEDED && timeout < new Date().getTime() - callTimeMillis)
+            (RETRYABLE_STATUS_CODES.has(error.code) ||
+              isRstStreamError(error)) &&
+            !(
+              timeout &&
+              error.code === grpc.status.DEADLINE_EXCEEDED &&
+              timeout < new Date().getTime() - callTimeMillis
+            )
           ) {
             const backOffSettings =
-                options.gaxOptions?.retry?.backoffSettings ||
-                DEFAULT_BACKOFF_SETTINGS;
+              options.gaxOptions?.retry?.backoffSettings ||
+              DEFAULT_BACKOFF_SETTINGS;
             const nextRetryDelay = getNextDelay(
-                numConsecutiveErrors,
-                backOffSettings
+              numConsecutiveErrors,
+              backOffSettings
             );
             retryTimer = setTimeout(makeNewRequest, nextRetryDelay);
           } else {

--- a/src/tabular-api-surface.ts
+++ b/src/tabular-api-surface.ts
@@ -231,27 +231,10 @@ Please use the format 'prezzy' or '${instance.name}/tables/prezzy'.`);
     downstream in google-gax.
      */
     const timeout =
-      this.bigtable &&
-      this.bigtable.options &&
-      this.bigtable.options.BigtableClient &&
-      this.bigtable.options.BigtableClient.clientConfig &&
-      this.bigtable.options.BigtableClient.clientConfig.interfaces &&
-      this.bigtable.options.BigtableClient.clientConfig.interfaces[
+      this?.bigtable?.options?.BigtableClient?.clientConfig?.interfaces &&
+      this?.bigtable?.options?.BigtableClient?.clientConfig?.interfaces[
         'google.bigtable.v2.Bigtable'
-      ] &&
-      this.bigtable.options.BigtableClient.clientConfig.interfaces[
-        'google.bigtable.v2.Bigtable'
-      ].methods &&
-      this.bigtable.options.BigtableClient.clientConfig.interfaces[
-        'google.bigtable.v2.Bigtable'
-      ].methods['ReadRows'] &&
-      this.bigtable.options.BigtableClient.clientConfig.interfaces[
-        'google.bigtable.v2.Bigtable'
-      ].methods['ReadRows'].timeout_millis
-        ? this.bigtable.options.BigtableClient.clientConfig.interfaces[
-            'google.bigtable.v2.Bigtable'
-          ].methods['ReadRows'].timeout_millis
-        : undefined;
+      ]?.methods['ReadRows']?.timeout_millis;
     const callTimeMillis = new Date().getTime();
 
     const ranges = TableUtils.getRanges(options);

--- a/src/tabular-api-surface.ts
+++ b/src/tabular-api-surface.ts
@@ -537,18 +537,18 @@ Please use the format 'prezzy' or '${instance.name}/tables/prezzy'.`);
           numRequestsMade++;
           if (
             numConsecutiveErrors <= maxRetries &&
-            (RETRYABLE_STATUS_CODES.has(error.code) || isRstStreamError(error))
+            (RETRYABLE_STATUS_CODES.has(error.code) || isRstStreamError(error)) &&
             !(error.code === grpc.status.DEADLINE_EXCEEDED && timeout < new Date().getTime() - callTimeMillis)
           ) {
+            const backOffSettings =
+                options.gaxOptions?.retry?.backoffSettings ||
+                DEFAULT_BACKOFF_SETTINGS;
+            const nextRetryDelay = getNextDelay(
+                numConsecutiveErrors,
+                backOffSettings
+            );
             retryTimer = setTimeout(makeNewRequest, nextRetryDelay);
           } else {
-            const backOffSettings =
-              options.gaxOptions?.retry?.backoffSettings ||
-              DEFAULT_BACKOFF_SETTINGS;
-            const nextRetryDelay = getNextDelay(
-              numConsecutiveErrors,
-              backOffSettings
-            );
             if (
               !error.code &&
               error.message === 'The client has already been closed.'

--- a/src/tabular-api-surface.ts
+++ b/src/tabular-api-surface.ts
@@ -523,11 +523,7 @@ Please use the format 'prezzy' or '${instance.name}/tables/prezzy'.`);
             numConsecutiveErrors <= maxRetries &&
             (RETRYABLE_STATUS_CODES.has(error.code) ||
               isRstStreamError(error)) &&
-            !(
-              timeout &&
-              error.code === grpc.status.DEADLINE_EXCEEDED &&
-              timeout < new Date().getTime() - callTimeMillis
-            )
+            !(timeout && timeout < new Date().getTime() - callTimeMillis)
           ) {
             const backOffSettings =
               options.gaxOptions?.retry?.backoffSettings ||

--- a/src/tabular-api-surface.ts
+++ b/src/tabular-api-surface.ts
@@ -231,10 +231,11 @@ Please use the format 'prezzy' or '${instance.name}/tables/prezzy'.`);
     downstream in google-gax.
      */
     const timeout =
-      this?.bigtable?.options?.BigtableClient?.clientConfig?.interfaces &&
-      this?.bigtable?.options?.BigtableClient?.clientConfig?.interfaces[
-        'google.bigtable.v2.Bigtable'
-      ]?.methods['ReadRows']?.timeout_millis;
+      opts?.gaxOptions?.timeout ||
+      (this?.bigtable?.options?.BigtableClient?.clientConfig?.interfaces &&
+        this?.bigtable?.options?.BigtableClient?.clientConfig?.interfaces[
+          'google.bigtable.v2.Bigtable'
+        ]?.methods['ReadRows']?.timeout_millis);
     const callTimeMillis = new Date().getTime();
 
     const ranges = TableUtils.getRanges(options);

--- a/src/tabular-api-surface.ts
+++ b/src/tabular-api-surface.ts
@@ -538,7 +538,7 @@ Please use the format 'prezzy' or '${instance.name}/tables/prezzy'.`);
           if (
             numConsecutiveErrors <= maxRetries &&
             (RETRYABLE_STATUS_CODES.has(error.code) || isRstStreamError(error)) &&
-            !(error.code === grpc.status.DEADLINE_EXCEEDED && timeout < new Date().getTime() - callTimeMillis)
+            !(timeout && error.code === grpc.status.DEADLINE_EXCEEDED && timeout < new Date().getTime() - callTimeMillis)
           ) {
             const backOffSettings =
                 options.gaxOptions?.retry?.backoffSettings ||

--- a/test/table.ts
+++ b/test/table.ts
@@ -1138,6 +1138,7 @@ describe('Bigtable/Table', () => {
       const stream = table.createReadStream({gaxOptions: {timeout: 2000}});
       stream.on('error', (error: ServiceError) => {
         assert.strictEqual(error.code, 14);
+        assert.strictEqual(error.message, 'retry me!');
         assert.strictEqual(requestSpy.callCount, 1); // Ensures the client has not retried.
         done();
       });
@@ -1160,7 +1161,7 @@ describe('Bigtable/Table', () => {
       const stream = table.createReadStream({gaxOptions: {timeout: 2000}});
       stream.on('error', (error: ServiceError) => {
         assert.strictEqual(error.code, 4);
-        assert.notStrictEqual(error.message, 'retry me!');
+        assert.strictEqual(error.message, 'retry me!');
         assert.strictEqual(requestSpy.callCount, 1); // Ensures the client has not retried.
         done();
       });

--- a/test/table.ts
+++ b/test/table.ts
@@ -1120,7 +1120,26 @@ describe('Bigtable/Table', () => {
           .on('data', done);
       });
     });
-
+    it('Should respect the timeout parameter passed in', done => {
+      const timeout = 2000;
+      const options = {timeout};
+      table.bigtable.request = (config: any) => {
+        // TODO: Do an assert check here - correct config, only called once.
+        const stream = new PassThrough({
+          objectMode: true,
+        });
+        (stream as any).abort = () => {};
+        setTimeout(() => {
+          const error = new Error('retry me!') as ServiceError;
+          error.code = 4;
+          stream.emit('error', error);
+        }, 3000);
+      };
+      const stream = table.createReadStream(options);
+      stream.on('error', (error: any) => {
+        done();
+      });
+    });
     describe('retries', () => {
       let callCreateReadStream: Function;
       let emitters: EventEmitter[] | null; // = [((stream: Writable) => { stream.push([{ key: 'a' }]);

--- a/test/table.ts
+++ b/test/table.ts
@@ -1160,7 +1160,7 @@ describe('Bigtable/Table', () => {
       const stream = table.createReadStream({gaxOptions: {timeout: 2000}});
       stream.on('error', (error: ServiceError) => {
         assert.strictEqual(error.code, 4);
-        assert.notStrictEqual(error.message, "retry me!");
+        assert.notStrictEqual(error.message, 'retry me!');
         assert.strictEqual(requestSpy.callCount, 1); // Ensures the client has not retried.
         done();
       });

--- a/test/table.ts
+++ b/test/table.ts
@@ -1120,7 +1120,29 @@ describe('Bigtable/Table', () => {
           .on('data', done);
       });
     });
-    it('Should respect the timeout parameter passed in', done => {
+    it('Should respect the timeout parameter passed in for UNAVAILABLE error', done => {
+      // The timeout is 2 seconds, but the error is received after 3 seconds
+      // so the client doesn't retry because more than 2 seconds have elapsed.
+      const requestSpy = (table.bigtable.request = sinon.spy(() => {
+        const stream = new PassThrough({
+          objectMode: true,
+        });
+        (stream as any).abort = () => {};
+        setTimeout(() => {
+          const error = new Error('retry me!') as ServiceError;
+          error.code = 14;
+          stream.emit('error', error);
+        }, 3000);
+        return stream;
+      }));
+      const stream = table.createReadStream({gaxOptions: {timeout: 2000}});
+      stream.on('error', (error: ServiceError) => {
+        assert.strictEqual(error.code, 14);
+        assert.strictEqual(requestSpy.callCount, 1); // Ensures the client has not retried.
+        done();
+      });
+    });
+    it('Should respect the timeout parameter passed in for DEADLINE_EXCEEDED error', done => {
       // The timeout is 2 seconds, but the error is received after 3 seconds
       // so the client doesn't retry because more than 2 seconds have elapsed.
       const requestSpy = (table.bigtable.request = sinon.spy(() => {

--- a/test/table.ts
+++ b/test/table.ts
@@ -100,7 +100,7 @@ const FakeFilter = {
   },
 };
 
-describe.only('Bigtable/Table', () => {
+describe('Bigtable/Table', () => {
   const TABLE_ID = 'my-table';
   let INSTANCE: inst.Instance;
   let TABLE_NAME: string;

--- a/test/table.ts
+++ b/test/table.ts
@@ -1134,6 +1134,7 @@ describe('Bigtable/Table', () => {
           error.code = 4;
           stream.emit('error', error);
         }, 3000);
+        return stream;
       };
       const stream = table.createReadStream(options);
       stream.on('error', (error: any) => {

--- a/test/table.ts
+++ b/test/table.ts
@@ -1123,7 +1123,7 @@ describe.only('Bigtable/Table', () => {
     it('Should respect the timeout parameter passed in', done => {
       let callCount = 0;
       const timeout = 2000;
-      const options = {timeout};
+      const options = {gaxOptions: {timeout}};
       table.bigtable.request = () => {
         callCount++;
         const stream = new PassThrough({

--- a/test/table.ts
+++ b/test/table.ts
@@ -1160,6 +1160,7 @@ describe('Bigtable/Table', () => {
       const stream = table.createReadStream({gaxOptions: {timeout: 2000}});
       stream.on('error', (error: ServiceError) => {
         assert.strictEqual(error.code, 4);
+        assert.notStrictEqual(error.message, "retry me!");
         assert.strictEqual(requestSpy.callCount, 1); // Ensures the client has not retried.
         done();
       });

--- a/test/table.ts
+++ b/test/table.ts
@@ -100,7 +100,7 @@ const FakeFilter = {
   },
 };
 
-describe('Bigtable/Table', () => {
+describe.only('Bigtable/Table', () => {
   const TABLE_ID = 'my-table';
   let INSTANCE: inst.Instance;
   let TABLE_NAME: string;
@@ -1121,10 +1121,11 @@ describe('Bigtable/Table', () => {
       });
     });
     it('Should respect the timeout parameter passed in', done => {
+      let callCount = 0;
       const timeout = 2000;
       const options = {timeout};
-      table.bigtable.request = (config: any) => {
-        // TODO: Do an assert check here - correct config, only called once.
+      table.bigtable.request = () => {
+        callCount++;
         const stream = new PassThrough({
           objectMode: true,
         });
@@ -1137,7 +1138,9 @@ describe('Bigtable/Table', () => {
         return stream;
       };
       const stream = table.createReadStream(options);
-      stream.on('error', (error: any) => {
+      stream.on('error', (error: ServiceError) => {
+        assert.strictEqual(error.code, 4);
+        assert.strictEqual(callCount, 1); // Ensures the client has not retried.
         done();
       });
     });

--- a/testproxy/known_failures.txt
+++ b/testproxy/known_failures.txt
@@ -23,6 +23,4 @@ TestCheckAndMutateRow_Generic_DeadlineExceeded\|
 TestCheckAndMutateRow_Generic_Headers\|
 TestSampleRowKeys_Generic_Headers\|
 TestSampleRowKeys_Generic_DeadlineExceeded\|
-TestSampleRowKeys_Generic_CloseClient\|
-TestSampleRowKeys_Generic_MultiStreams\|
 TestSampleRowKeys_Retry_WithRoutingCookie

--- a/testproxy/known_failures.txt
+++ b/testproxy/known_failures.txt
@@ -23,4 +23,6 @@ TestCheckAndMutateRow_Generic_DeadlineExceeded\|
 TestCheckAndMutateRow_Generic_Headers\|
 TestSampleRowKeys_Generic_Headers\|
 TestSampleRowKeys_Generic_DeadlineExceeded\|
+TestSampleRowKeys_Generic_CloseClient\|
+TestSampleRowKeys_Generic_MultiStreams\|
 TestSampleRowKeys_Retry_WithRoutingCookie

--- a/testproxy/known_failures.txt
+++ b/testproxy/known_failures.txt
@@ -14,7 +14,6 @@ TestReadRows_NoRetry_OutOfOrderError_Reverse\|
 TestReadRows_Retry_PausedScan\|
 TestReadRows_Retry_LastScannedRow_Reverse\|
 TestReadRows_Retry_StreamReset\|
-TestReadRows_Generic_DeadlineExceeded\|
 TestReadRows_Retry_WithRoutingCookie\|
 TestReadRows_Retry_WithRoutingCookie_MultipleErrorResponses\|
 TestReadRows_Retry_WithRetryInfo\|

--- a/testproxy/services/create-client.js
+++ b/testproxy/services/create-client.js
@@ -68,12 +68,13 @@ const createClient = ({clientMap}) =>
        */
       Object.entries(
         clientConfig.interfaces['google.bigtable.v2.Bigtable'].methods
-      ).forEach(
-        ([, v]) =>
-          (v.timeout_millis = durationToMilliseconds(
+      ).forEach(([k, v]) => {
+        if (k === 'ReadRows') {
+          v.timeout_millis = durationToMilliseconds(
             request.perOperationTimeout
-          ))
-      );
+          );
+        }
+      });
     }
     const bigtable = new Bigtable({
       projectId,

--- a/testproxy/services/create-client.js
+++ b/testproxy/services/create-client.js
@@ -17,7 +17,6 @@ const normalizeCallback = require('./utils/normalize-callback.js');
 
 const grpc = require('@grpc/grpc-js');
 const {Bigtable} = require('../../build/src/index.js');
-const clientConfig = require('../../src/v2/bigtable_client_config.json');
 const {BigtableClient} = require('../../build/src/index.js').v2;
 
 const v2 = Symbol.for('v2');
@@ -32,6 +31,7 @@ const createClient = ({clientMap}) =>
   normalizeCallback(async rawRequest => {
     // TODO: Handle refresh periods
     const {request} = rawRequest;
+    const clientConfig = require('../../src/v2/bigtable_client_config.json');
     const {
       callCredential,
       clientId,

--- a/testproxy/services/create-client.js
+++ b/testproxy/services/create-client.js
@@ -70,6 +70,12 @@ const createClient = ({clientMap}) =>
         clientConfig.interfaces['google.bigtable.v2.Bigtable'].methods
       ).forEach(([k, v]) => {
         if (k === 'ReadRows') {
+          /*
+          TODO: In the future we should apply this for all methods, but right
+          now doing so results in regressions in the TestSampleRowKeys_Generic_MultiStreams
+          and TestSampleRowKeys_Generic_CloseClient conformance tests that need
+          to be addressed.
+          */
           v.timeout_millis = durationToMilliseconds(
             request.perOperationTimeout
           );

--- a/testproxy/services/create-client.js
+++ b/testproxy/services/create-client.js
@@ -17,9 +17,16 @@ const normalizeCallback = require('./utils/normalize-callback.js');
 
 const grpc = require('@grpc/grpc-js');
 const {Bigtable} = require('../../build/src/index.js');
+const clientConfig = require('../../src/v2/bigtable_client_config.json');
 const {BigtableClient} = require('../../build/src/index.js').v2;
 
 const v2 = Symbol.for('v2');
+
+function durationToMilliseconds(duration) {
+  const secondsInMs = parseInt(duration.seconds, 10) * 1000;
+  const nanosInMs = duration.nanos / 1000000;
+  return secondsInMs + nanosInMs;
+}
 
 const createClient = ({clientMap}) =>
   normalizeCallback(async rawRequest => {
@@ -54,12 +61,26 @@ const createClient = ({clientMap}) =>
     if (callCredential && callCredential.jsonServiceAccount) {
       authClient = JSON.parse(request.callCredential.jsonServiceAccount);
     }
+    if (request.perOperationTimeout) {
+      /**
+       * This block of code ensures the server times out for every method call
+       * after the amount of time specified in request.perOperationTimeout.
+       */
+      Object.entries(
+        clientConfig.interfaces['google.bigtable.v2.Bigtable'].methods
+      ).forEach(
+        ([, v]) =>
+          (v.timeout_millis = durationToMilliseconds(
+            request.perOperationTimeout
+          ))
+      );
+    }
     const bigtable = new Bigtable({
       projectId,
       apiEndpoint,
       authClient,
       appProfileId,
-      clientConfig: require('../../src/v2/bigtable_client_config.json'),
+      clientConfig,
     });
     bigtable[v2] = new BigtableClient(bigtable.options.BigtableClient);
     clientMap.set(clientId, bigtable);

--- a/testproxy/services/index.js
+++ b/testproxy/services/index.js
@@ -25,6 +25,8 @@ const readRows = require('./read-rows.js');
 const removeClient = require('./remove-client.js');
 const sampleRowKeys = require('./sample-row-keys.js');
 
+
+
 /*
  * Starts the client pool map and retrieves the object that
  * lists all methods to be passed to grpc.Server.addService.
@@ -34,6 +36,10 @@ const sampleRowKeys = require('./sample-row-keys.js');
 function getServicesImplementation() {
   const clientMap = new ClientMap();
 
+  function passThrough(arg1, arg2, arg3) {
+    const result = readRows(arg1, arg2, arg3);
+    return result;
+  }
   return {
     bulkMutateRows: bulkMutateRows({clientMap}),
     checkAndMutateRow: checkAndMutateRow({clientMap}),

--- a/testproxy/services/index.js
+++ b/testproxy/services/index.js
@@ -34,10 +34,6 @@ const sampleRowKeys = require('./sample-row-keys.js');
 function getServicesImplementation() {
   const clientMap = new ClientMap();
 
-  function passThrough(arg1, arg2, arg3) {
-    const result = readRows(arg1, arg2, arg3);
-    return result;
-  }
   return {
     bulkMutateRows: bulkMutateRows({clientMap}),
     checkAndMutateRow: checkAndMutateRow({clientMap}),

--- a/testproxy/services/index.js
+++ b/testproxy/services/index.js
@@ -25,8 +25,6 @@ const readRows = require('./read-rows.js');
 const removeClient = require('./remove-client.js');
 const sampleRowKeys = require('./sample-row-keys.js');
 
-
-
 /*
  * Starts the client pool map and retrieves the object that
  * lists all methods to be passed to grpc.Server.addService.

--- a/testproxy/services/read-rows.js
+++ b/testproxy/services/read-rows.js
@@ -75,7 +75,7 @@ const readRows = ({clientMap}) =>
       return {
         status: {
           code: e.code,
-          details: [],
+          details: [], // e.details must be in an empty array for the test runner to return the status. This is tracked in https://b.corp.google.com/issues/383096533.
           message: e.message,
         },
       };

--- a/testproxy/services/read-rows.js
+++ b/testproxy/services/read-rows.js
@@ -72,7 +72,14 @@ const readRows = ({clientMap}) =>
         rows: rows.map(getRowResponse),
       };
     } catch (e) {
-      return {status: e};
+      return {
+        status: {
+          code: e.code,
+          details: e.details,
+          message: e.message,
+        },
+        code: 7,
+      };
     }
   });
 

--- a/testproxy/services/read-rows.js
+++ b/testproxy/services/read-rows.js
@@ -75,10 +75,9 @@ const readRows = ({clientMap}) =>
       return {
         status: {
           code: e.code,
-          details: e.details,
+          details: [],
           message: e.message,
         },
-        code: 7,
       };
     }
   });


### PR DESCRIPTION
**Summary:**

This change allows the TestReadRows_Generic_DeadlineExceeded conformance test to pass by not retrying on DEADLINE_EXCEEDED errors when the client timeout has been exceeded.

**Changes:**

**`src/tabular-api-service.ts`:** The changes in this file make it so that readRows calls get the timeout value that was passed into the client, record the time the call was made and then only retry on DEADLINE_EXCEEDED errors when the amount of time that has passed is less than the timeout. Longer term this change should be moved downstream into google-gax.

**`testproxy/services/create-client.js`:** A change is made to use the perOperationTimeout passed into the create-client test proxy service to set the timeout parameter on the client so that it will be used by readRows calls.

**`testproxy/services/read-rows.js`:** The readRows test proxy service is modified so that the status is actually passed to the test runner instead of Nil.

**`test/table.ts`:** A unit test is added that ensures timeouts can be set per call.

**Next Steps:**

- In a separate PR we should allow the timeout to apply to all methods
- We should move the timeout logic upstream to google-gax and emit an error there when the client times out instead of relying on custom logic in the handwritten layer to track a timeout when handling DEADLINE_EXCEEDED errors from the server.