### PR TITLE
chore(testproxy): Address the TestReadModifyWriteRow_Generic_Headers test

### DIFF
--- a/testproxy/known_failures.txt
+++ b/testproxy/known_failures.txt
@@ -3,7 +3,6 @@ TestMutateRow_Generic_DeadlineExceeded\|
 TestMutateRows_Generic_CloseClient\|
 TestMutateRows_Retry_WithRoutingCookie\|
 TestMutateRows_Generic_DeadlineExceeded\|
-TestReadModifyWriteRow_Generic_Headers\|
 TestReadModifyWriteRow_Generic_DeadlineExceeded\|
 TestReadModifyWriteRow_NoRetry_MultiValues\|
 TestReadModifyWriteRow_Generic_CloseClient\|

--- a/testproxy/services/read-modify-write-row.js
+++ b/testproxy/services/read-modify-write-row.js
@@ -28,7 +28,9 @@ const readModifyWriteRow = ({clientMap}) =>
     const {appProfileId, tableName} = readModifyWriteRow;
     const handWrittenRequest = getRMWRRequestInverse(readModifyWriteRow);
     const bigtable = clientMap.get(clientId);
-    bigtable.appProfileId = appProfileId;
+    if (appProfileId && appProfileId !== '') {
+      bigtable.appProfileId = appProfileId;
+    }
     const table = getTableInfo(bigtable, tableName);
     const row = table.row(handWrittenRequest.id);
     try {


### PR DESCRIPTION
Without these changes the `TestReadModifyWriteRow_Generic_Headers` test fails. In this test the call to the `createClient` test proxy service supplies the appProfileId and stores it on the client. However, when the `readModifyWriteRow` service is called, an empty `appProfileId` is provided and overwrites the appProfileId that was stored on the client in the `createClient` service call. The `appProfileId` is an empty string because the `appProfileId` is a `string` in the proto and the test runner does not provide an appProfileId for the call to the `readModifyWriteRow` service.

The change involves assuming the test runner does not intend to provide an appProfileId for the `readModifyWriteRow` service when the service receives an empty string for `appProfileId` and therefore doesn't override the `appProfileId` on the client in that situation.