### PR TITLE
chore(testproxy): Address the TestReadModifyWriteRow_Generic_DeadlineExceeded conformance test

### DIFF
--- a/testproxy/known_failures.txt
+++ b/testproxy/known_failures.txt
@@ -3,7 +3,6 @@ TestMutateRow_Generic_DeadlineExceeded\|
 TestMutateRows_Generic_CloseClient\|
 TestMutateRows_Retry_WithRoutingCookie\|
 TestMutateRows_Generic_DeadlineExceeded\|
-TestReadModifyWriteRow_Generic_DeadlineExceeded\|
 TestReadModifyWriteRow_NoRetry_MultiValues\|
 TestReadModifyWriteRow_Generic_CloseClient\|
 TestReadModifyWriteRow_Generic_MultiStreams\|

--- a/testproxy/services/create-client.js
+++ b/testproxy/services/create-client.js
@@ -69,7 +69,7 @@ const createClient = ({clientMap}) =>
       Object.entries(
         clientConfig.interfaces['google.bigtable.v2.Bigtable'].methods
       ).forEach(([k, v]) => {
-        if (k === 'ReadRows') {
+        if (k === 'ReadRows' || k === 'ReadModifyWriteRow') {
           /*
           TODO: In the future we should apply this for all methods, but right
           now doing so results in regressions in the TestSampleRowKeys_Generic_MultiStreams

--- a/testproxy/services/create-client.js
+++ b/testproxy/services/create-client.js
@@ -70,18 +70,8 @@ const createClient = ({clientMap}) =>
        */
       Object.entries(
         clientConfig.interfaces['google.bigtable.v2.Bigtable'].methods
-      ).forEach(([k, v]) => {
-        if (k === 'ReadRows' || k === 'ReadModifyWriteRow') {
-          /*
-          TODO: In the future we should apply this for all methods, but right
-          now doing so results in regressions in the TestSampleRowKeys_Generic_MultiStreams
-          and TestSampleRowKeys_Generic_CloseClient conformance tests that need
-          to be addressed.
-          */
-          v.timeout_millis = durationToMilliseconds(
-            request.perOperationTimeout
-          );
-        }
+      ).forEach(([, v]) => {
+        v.timeout_millis = durationToMilliseconds(request.perOperationTimeout);
       });
     }
     const bigtable = new Bigtable({

--- a/testproxy/services/create-client.js
+++ b/testproxy/services/create-client.js
@@ -31,7 +31,9 @@ const createClient = ({clientMap}) =>
   normalizeCallback(async rawRequest => {
     // TODO: Handle refresh periods
     const {request} = rawRequest;
-    const clientConfig = require('../../src/v2/bigtable_client_config.json');
+    const clientConfig = JSON.parse(
+      JSON.stringify(require('../../src/v2/bigtable_client_config.json'))
+    );
     const {
       callCredential,
       clientId,


### PR DESCRIPTION
**Summary**

The conformance test passes a timeout setting into the `createClient` test proxy service. With this change the timeout setting will now be applied to the client and used in the readModifyWriteRow call. This allows the `TestReadModifyWriteRow_Generic_DeadlineExceeded` conformance test to pass because now the timeout is being used for these calls.