### PR TITLE
chore(testproxy): Address the TestReadRows_Retry_StreamReset test

### DIFF
--- a/testproxy/known_failures.txt
+++ b/testproxy/known_failures.txt
@@ -14,7 +14,6 @@ TestReadRows_ReverseScans_FeatureFlag_Enabled\|
 TestReadRows_NoRetry_OutOfOrderError_Reverse\|
 TestReadRows_Retry_PausedScan\|
 TestReadRows_Retry_LastScannedRow_Reverse\|
-TestReadRows_Retry_StreamReset\|
 TestReadRows_Retry_WithRoutingCookie\|
 TestReadRows_Retry_WithRoutingCookie_MultipleErrorResponses\|
 TestReadRows_Retry_WithRetryInfo\|


### PR DESCRIPTION
[A fix in the test runner](https://github.com/googleapis/cloud-bigtable-clients-test/pull/218) was made to allow a slightly different ReadRows request for full table scans and a downstream grpc change in version 1.12.4 was made so that the TestReadRows_Retry_StreamReset conformance test will pass.
