### PR TITLE
chore(testproxy): Address the CheckAndMutateRow_Generic_CloseClient conformance test

### DIFF
--- a/src/row-data-utils.ts
+++ b/src/row-data-utils.ts
@@ -91,13 +91,6 @@ class RowDataUtils {
       },
       (err, apiResponse) => {
         if (err) {
-          if (
-            err &&
-            err.message === 'The client has already been closed.' &&
-            !err.code
-          ) {
-            err.code = 1; // CANCELLED
-          }
           callback(err, null, apiResponse);
           return;
         }

--- a/src/row-data-utils.ts
+++ b/src/row-data-utils.ts
@@ -253,6 +253,10 @@ class RowDataUtils {
     } as Rule;
 
     this.createRulesUtil(reqOpts, properties, gaxOptions, (err, resp) => {
+      if (err) {
+        callback(err, null, resp);
+        return;
+      }
       const data = this.formatFamilies_Util(resp!.row!.families!);
       const value = dotProp.get(data, column.replace(':', '.'))[0].value;
 

--- a/src/row-data-utils.ts
+++ b/src/row-data-utils.ts
@@ -91,6 +91,17 @@ class RowDataUtils {
       },
       (err, apiResponse) => {
         if (err) {
+          if (err) {
+            if (
+              err &&
+              err.message === 'The client has already been closed.' &&
+              !err.code
+            ) {
+              err.code = 1; // CANCELLED
+            }
+            callback(err, null, apiResponse);
+            return;
+          }
           callback(err, null, apiResponse);
           return;
         }
@@ -242,10 +253,6 @@ class RowDataUtils {
     } as Rule;
 
     this.createRulesUtil(reqOpts, properties, gaxOptions, (err, resp) => {
-      if (err) {
-        callback(err, null, resp);
-        return;
-      }
       const data = this.formatFamilies_Util(resp!.row!.families!);
       const value = dotProp.get(data, column.replace(':', '.'))[0].value;
 

--- a/src/row-data-utils.ts
+++ b/src/row-data-utils.ts
@@ -91,16 +91,12 @@ class RowDataUtils {
       },
       (err, apiResponse) => {
         if (err) {
-          if (err) {
-            if (
-              err &&
-              err.message === 'The client has already been closed.' &&
-              !err.code
-            ) {
-              err.code = 1; // CANCELLED
-            }
-            callback(err, null, apiResponse);
-            return;
+          if (
+            err &&
+            err.message === 'The client has already been closed.' &&
+            !err.code
+          ) {
+            err.code = 1; // CANCELLED
           }
           callback(err, null, apiResponse);
           return;

--- a/testproxy/known_failures.txt
+++ b/testproxy/known_failures.txt
@@ -19,7 +19,6 @@ TestCheckAndMutateRow_Generic_DeadlineExceeded\|
 TestCheckAndMutateRow_Generic_Headers\|
 TestCheckAndMutateRow_NoRetry_TrueMutations\|
 TestCheckAndMutateRow_NoRetry_FalseMutations\|
-TestCheckAndMutateRow_Generic_CloseClient\|
 TestCheckAndMutateRow_Generic_MultiStreams\|
 TestSampleRowKeys_Generic_DeadlineExceeded\|
 TestSampleRowKeys_Retry_WithRoutingCookie

--- a/testproxy/services/check-and-mutate-row.js
+++ b/testproxy/services/check-and-mutate-row.js
@@ -79,10 +79,10 @@ const checkAndMutateRow = ({clientMap}) =>
     const filter = [];
     const filterConfig = {onMatch, onNoMatch};
     try {
-      const result = await row.filter(filter, filterConfig);
+      const [, result] = await row.filter(filter, filterConfig);
       return {
         status: {code: grpc.status.OK, details: []},
-        row: result,
+        result,
       };
     } catch (e) {
       return {

--- a/testproxy/services/check-and-mutate-row.js
+++ b/testproxy/services/check-and-mutate-row.js
@@ -87,7 +87,7 @@ const checkAndMutateRow = ({clientMap}) =>
     } catch (e) {
       return {
         status: {
-          code: e.code,
+          code: e.code ? e.code : grpc.status.UNKNOWN,
           details: [],
           message: e.message,
         },


### PR DESCRIPTION
**Summary**

The CheckAndMutateRow_Generic_CloseClient conformance test is failing because results are not being passed along by the test proxy and the closed client error doesn't have an error code. These two problems are addressed in this PR so that the test passes.