### PR TITLE
chore(testproxy): Remove TestCheckAndMutateRow_Generic_DeadlineExceeded from known failures

### DIFF
--- a/testproxy/known_failures.txt
+++ b/testproxy/known_failures.txt
@@ -14,6 +14,7 @@ TestReadRows_Retry_WithRoutingCookie\|
 TestReadRows_Retry_WithRoutingCookie_MultipleErrorResponses\|
 TestReadRows_Retry_WithRetryInfo\|
 TestReadRows_Retry_WithRetryInfo_MultipleErrorResponse\|
+TestCheckAndMutateRow_Generic_DeadlineExceeded\|
 TestCheckAndMutateRow_NoRetry_TrueMutations\|
 TestCheckAndMutateRow_NoRetry_FalseMutations\|
 TestCheckAndMutateRow_Generic_CloseClient\|

--- a/testproxy/known_failures.txt
+++ b/testproxy/known_failures.txt
@@ -14,7 +14,6 @@ TestReadRows_Retry_WithRoutingCookie\|
 TestReadRows_Retry_WithRoutingCookie_MultipleErrorResponses\|
 TestReadRows_Retry_WithRetryInfo\|
 TestReadRows_Retry_WithRetryInfo_MultipleErrorResponse\|
-TestCheckAndMutateRow_Generic_DeadlineExceeded\|
 TestCheckAndMutateRow_NoRetry_TrueMutations\|
 TestCheckAndMutateRow_NoRetry_FalseMutations\|
 TestCheckAndMutateRow_Generic_CloseClient\|

--- a/testproxy/known_failures.txt
+++ b/testproxy/known_failures.txt
@@ -15,7 +15,6 @@ TestReadRows_Retry_WithRoutingCookie_MultipleErrorResponses\|
 TestReadRows_Retry_WithRetryInfo\|
 TestReadRows_Retry_WithRetryInfo_MultipleErrorResponse\|
 TestCheckAndMutateRow_Generic_DeadlineExceeded\|
-TestCheckAndMutateRow_Generic_Headers\|
 TestCheckAndMutateRow_NoRetry_TrueMutations\|
 TestCheckAndMutateRow_NoRetry_FalseMutations\|
 TestCheckAndMutateRow_Generic_CloseClient\|


### PR DESCRIPTION
Another code change simultaneously addressed the TestCheckAndMutateRow_Generic_DeadlineExceeded test so we can remove it from known failures.