### PR TITLE
chore(testproxy): Resolve the TestMutateRows_Generic_CloseClient conformance test

### DIFF
--- a/protos/protos.d.ts
+++ b/protos/protos.d.ts
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/testproxy/known_failures.txt
+++ b/testproxy/known_failures.txt
@@ -1,5 +1,4 @@
 TestMutateRow_Generic_DeadlineExceeded\|
-TestMutateRows_Generic_CloseClient\|
 TestMutateRows_Retry_WithRoutingCookie\|
 TestReadModifyWriteRow_NoRetry_MultiValues\|
 TestReadModifyWriteRow_Generic_CloseClient\|

--- a/testproxy/known_failures.txt
+++ b/testproxy/known_failures.txt
@@ -1,4 +1,5 @@
 TestMutateRow_Generic_DeadlineExceeded\|
+TestMutateRow_Generic_CloseClient\|
 TestMutateRows_Retry_WithRoutingCookie\|
 TestReadRow_Generic_DeadlineExceeded\|
 TestReadRow_Retry_WithRoutingCookie\|

--- a/testproxy/services/bulk-mutate-rows.js
+++ b/testproxy/services/bulk-mutate-rows.js
@@ -48,7 +48,7 @@ const bulkMutateRows = ({clientMap}) =>
         : [];
       return {
         status: {
-          code: error.code,
+          code: error.code ? error.code : grpc.status.UNKNOWN,
           details: [],
           message: error.message,
         },


### PR DESCRIPTION
**Summary:**

Much like some of the other tests, the client is sending back an error without a code, but the test is expecting an error code to be present. This fix appends an error code in the test proxy service if the error doesn't have one so that tests intending to check if there is an error by checking for a code will behave as intended.