### PR TITLE
chore(testproxy): Remove multiple known failures that have already been addressed

### DIFF
--- a/testproxy/known_failures.txt
+++ b/testproxy/known_failures.txt
@@ -2,7 +2,6 @@ TestMutateRow_Generic_DeadlineExceeded\|
 TestMutateRow_Generic_CloseClient\|
 TestMutateRows_Generic_CloseClient\|
 TestMutateRows_Retry_WithRoutingCookie\|
-TestReadModifyWriteRow_NoRetry_MultiValues\|
 TestReadRow_Generic_DeadlineExceeded\|
 TestReadRow_Retry_WithRoutingCookie\|
 TestReadRow_Retry_WithRetryInfo\|

--- a/testproxy/known_failures.txt
+++ b/testproxy/known_failures.txt
@@ -3,7 +3,6 @@ TestMutateRow_Generic_CloseClient\|
 TestMutateRows_Generic_CloseClient\|
 TestMutateRows_Retry_WithRoutingCookie\|
 TestReadModifyWriteRow_NoRetry_MultiValues\|
-TestReadModifyWriteRow_Generic_MultiStreams\|
 TestReadRow_Generic_DeadlineExceeded\|
 TestReadRow_Retry_WithRoutingCookie\|
 TestReadRow_Retry_WithRetryInfo\|
@@ -14,7 +13,6 @@ TestReadRows_Retry_WithRoutingCookie\|
 TestReadRows_Retry_WithRoutingCookie_MultipleErrorResponses\|
 TestReadRows_Retry_WithRetryInfo\|
 TestReadRows_Retry_WithRetryInfo_MultipleErrorResponse\|
-TestCheckAndMutateRow_Generic_DeadlineExceeded\|
 TestCheckAndMutateRow_NoRetry_TrueMutations\|
 TestCheckAndMutateRow_NoRetry_FalseMutations\|
 TestCheckAndMutateRow_Generic_MultiStreams\|

--- a/testproxy/known_failures.txt
+++ b/testproxy/known_failures.txt
@@ -15,7 +15,6 @@ TestReadRows_Retry_WithRetryInfo\|
 TestReadRows_Retry_WithRetryInfo_MultipleErrorResponse\|
 TestCheckAndMutateRow_NoRetry_TrueMutations\|
 TestCheckAndMutateRow_NoRetry_FalseMutations\|
-TestCheckAndMutateRow_Generic_MultiStreams\|
 TestSampleRowKeys_Generic_DeadlineExceeded\|
 TestSampleRowKeys_Retry_WithRoutingCookie\|
 TestSampleRowKeys_Generic_CloseClient


### PR DESCRIPTION
Other changes simultaneously addressed another set of known failures that are now being removed known_failures.txt list. We know these removed items have been addressed because otherwise the mandatory-conformance github action would fail.