### PR TITLE
test: Fix the reaper and simplify the instance and backup deletion

### DIFF
--- a/system-test/bigtable.ts
+++ b/system-test/bigtable.ts
@@ -69,20 +69,20 @@ describe('Bigtable', () => {
         const oneHourAgo = new Date(Date.now() - 3600000);
         return !timeCreated || timeCreated <= oneHourAgo;
       });
-    const q = [];
     // need to delete backups first due to instance deletion precondition
-    await Promise.all(testInstances.map(instance => reapBackups(instance)));
-    await Promise.all(
-      testInstances.map(instance => {
-        q.push(async () => {
-          try {
-            await instance.delete();
-          } catch (e) {
-            console.log(`Error deleting instance: ${instance.id}`);
-          }
-        });
-      }),
+    const deleteBackupPromises = testInstances.map(instance =>
+      reapBackups(instance),
     );
+    for (const backupPromise of deleteBackupPromises) {
+      await backupPromise;
+    }
+    for (const instance of testInstances) {
+      try {
+        await instance.delete();
+      } catch (e) {
+        console.log(`Error deleting instance: ${instance.id}`);
+      }
+    }
   }
 
   before(async () => {


### PR DESCRIPTION
While doing the Node 18 upgrade in https://github.com/googleapis/nodejs-bigtable/pull/1582 the pqueue dependency was removed because it had some incompatibilities with Node 18. Some compiler/linter errors emerged that prevented the PR from being merged when the pqueue dependency was used.

When pqueue was removed it broke the reaper so now instances aren't getting deleted and we are running into quota issues when testing. This PR simplifies the reaper logic by just deleting the instances and backups one at a time without the pqueue dependency. It might take the test a little bit longer, but we will never run into dependency conflicts with pqueue again so it's well worth the tradeoff.