### PR TITLE
test: Fix service path system tests

### DIFF
--- a/system-test/service-path.ts
+++ b/system-test/service-path.ts
@@ -18,7 +18,7 @@ import {ServiceError} from 'google-gax';
 import {Bigtable} from '../src';
 import {BigtableClient, BigtableInstanceAdminClient} from '../src/v2';
 
-describe('Service Path', () => {
+describe.only('Service Path', () => {
   it('Setting universe domain should set the service path', async () => {
     // Set the environment variable
     process.env.GOOGLE_CLOUD_UNIVERSE_DOMAIN = 'otherDomain';
@@ -43,9 +43,11 @@ describe('Service Path', () => {
       // This is necessary to initialize the bigtable instance admin client.
       await bigtable.getInstances({timeout: 1000});
     } catch (e) {
+      const expectedMessage =
+        'Total timeout of API google.bigtable.admin.v2.BigtableInstanceAdmin exceeded 1000 milliseconds retrying error Error: 14 UNAVAILABLE: Name resolution failed for target dns:bigtableadmin.someUniverseDomain:443  before any response was received.';
       assert.strictEqual(
-        (e as ServiceError).message,
-        'Total timeout of API google.bigtable.admin.v2.BigtableInstanceAdmin exceeded 1000 milliseconds retrying error Error: 14 UNAVAILABLE: Name resolution failed for target dns:bigtableadmin.someUniverseDomain:443  before any response was received.',
+        (e as ServiceError).message.substring(0, expectedMessage.length),
+        expectedMessage,
       );
     } finally {
       assert.strictEqual(
@@ -63,9 +65,11 @@ describe('Service Path', () => {
       const table = instance.table('tableId');
       await table.getRows({gaxOptions: {timeout: 1000}});
     } catch (e) {
+      const expectedMessage =
+        '14 UNAVAILABLE: Name resolution failed for target dns:bigtable.someUniverseDomain:443';
       assert.strictEqual(
-        (e as ServiceError).message,
-        '14 UNAVAILABLE: Name resolution failed for target dns:bigtable.someUniverseDomain:443',
+        (e as ServiceError).message.substring(0, expectedMessage.length),
+        expectedMessage,
       );
     } finally {
       assert.strictEqual(
@@ -103,9 +107,11 @@ describe('Service Path', () => {
       // This is necessary to initialize the bigtable instance admin client.
       await bigtable.getInstances({timeout: 1000});
     } catch (e) {
+      const expectedMessage =
+        'Total timeout of API google.bigtable.admin.v2.BigtableInstanceAdmin exceeded 1000 milliseconds retrying error Error: 14 UNAVAILABLE: Name resolution failed for target dns:someApiEndpoint:443  before any response was received.';
       assert.strictEqual(
-        (e as ServiceError).message,
-        'Total timeout of API google.bigtable.admin.v2.BigtableInstanceAdmin exceeded 1000 milliseconds retrying error Error: 14 UNAVAILABLE: Name resolution failed for target dns:someApiEndpoint:443  before any response was received.',
+        (e as ServiceError).message.substring(0, expectedMessage.length),
+        expectedMessage,
       );
     } finally {
       assert.strictEqual(
@@ -123,9 +129,11 @@ describe('Service Path', () => {
       const table = instance.table('tableId');
       await table.getRows({gaxOptions: {timeout: 1000}});
     } catch (e) {
+      const expectedMessage =
+        '14 UNAVAILABLE: Name resolution failed for target dns:someApiEndpoint:443';
       assert.strictEqual(
-        (e as ServiceError).message,
-        '14 UNAVAILABLE: Name resolution failed for target dns:someApiEndpoint:443',
+        (e as ServiceError).message.substring(0, expectedMessage.length),
+        expectedMessage,
       );
     } finally {
       assert.strictEqual(
@@ -156,9 +164,11 @@ describe('Service Path', () => {
       // This is necessary to initialize the bigtable instance admin client.
       await bigtable.getInstances({timeout: 1000});
     } catch (e) {
+      const expectedMessage =
+        'Total timeout of API google.bigtable.admin.v2.BigtableInstanceAdmin exceeded 1000 milliseconds retrying error Error: 14 UNAVAILABLE: Name resolution failed for target dns:bigtableadmin.someUniverseDomain:443  before any response was received.';
       assert.strictEqual(
-        (e as ServiceError).message,
-        'Total timeout of API google.bigtable.admin.v2.BigtableInstanceAdmin exceeded 1000 milliseconds retrying error Error: 14 UNAVAILABLE: Name resolution failed for target dns:bigtableadmin.someUniverseDomain:443  before any response was received.',
+        (e as ServiceError).message.substring(0, expectedMessage.length),
+        expectedMessage,
       );
     } finally {
       assert.strictEqual(
@@ -177,9 +187,11 @@ describe('Service Path', () => {
       const table = instance.table('tableId');
       await table.getRows({gaxOptions: {timeout: 1000}});
     } catch (e) {
+      const expectedMessage =
+        '14 UNAVAILABLE: Name resolution failed for target dns:bigtable.someUniverseDomain:443';
       assert.strictEqual(
-        (e as ServiceError).message,
-        '14 UNAVAILABLE: Name resolution failed for target dns:bigtable.someUniverseDomain:443',
+        (e as ServiceError).message.substring(0, expectedMessage.length),
+        expectedMessage,
       );
     } finally {
       assert.strictEqual(

--- a/system-test/service-path.ts
+++ b/system-test/service-path.ts
@@ -18,7 +18,7 @@ import {ServiceError} from 'google-gax';
 import {Bigtable} from '../src';
 import {BigtableClient, BigtableInstanceAdminClient} from '../src/v2';
 
-describe.only('Service Path', () => {
+describe('Service Path', () => {
   it('Setting universe domain should set the service path', async () => {
     // Set the environment variable
     process.env.GOOGLE_CLOUD_UNIVERSE_DOMAIN = 'otherDomain';


### PR DESCRIPTION
## Description

A fix was applied in gax [here](https://github.com/googleapis/gax-nodejs/pull/1740), but this fix is affecting Bigtable tests. Error messages now have more information so previous assert.strictEqual checks are failing. The solution to unblock the CI pipeline is to only check the first part of the error message for correctness as the latter part of the error message can vary.

## Impact

Unblocks the CI pipeline.

## Testing

Tests were changed just to check the first part of the string.
