### PR TITLE
fix: firstResponseLatencies should only be collected for readRows calls

### DIFF
--- a/src/client-side-metrics/gcp-metrics-handler.ts
+++ b/src/client-side-metrics/gcp-metrics-handler.ts
@@ -31,6 +31,7 @@ const {
 } = require('@opentelemetry/sdk-metrics');
 import * as os from 'os';
 import * as crypto from 'crypto';
+import {MethodName} from './client-side-metrics-attributes';
 
 /**
  * Generates a unique client identifier string.
@@ -251,10 +252,16 @@ export class GCPMetricsHandler implements IMetricsHandler {
       status: data.status,
       ...commonAttributes,
     });
-    otelInstruments.firstResponseLatencies.record(data.firstResponseLatency, {
-      status: data.status,
-      ...commonAttributes,
-    });
+    if (
+      data.metricsCollectorData.method === MethodName.READ_ROWS ||
+      data.metricsCollectorData.method === MethodName.READ_ROW
+    ) {
+      otelInstruments.firstResponseLatencies.record(data.firstResponseLatency, {
+        status: data.status,
+        ...commonAttributes,
+      });
+    }
+
     if (data.applicationLatency) {
       otelInstruments.applicationBlockingLatencies.record(
         data.applicationLatency,

--- a/src/client-side-metrics/operation-metrics-collector.ts
+++ b/src/client-side-metrics/operation-metrics-collector.ts
@@ -181,10 +181,7 @@ export class OperationMetricsCollector {
         }) => {
           this.onStatusMetadataReceived(status);
         },
-      )
-      .on('data', () => {
-        this.onResponse();
-      });
+      );
   }
 
   /**
@@ -303,6 +300,14 @@ export class OperationMetricsCollector {
         {
           this.handlers.forEach(metricsHandler => {
             if (metricsHandler.onOperationComplete) {
+              const firstResponseLatencyExpression =
+                this.methodName === MethodName.READ_ROWS ||
+                this.methodName === MethodName.READ_ROW
+                  ? {
+                      firstResponseLatency:
+                        this.firstResponseLatency ?? undefined,
+                    }
+                  : {};
               metricsHandler.onOperationComplete({
                 status: finalOperationStatus.toString(),
                 streaming: this.streamingOperation,
@@ -310,7 +315,8 @@ export class OperationMetricsCollector {
                 client_name: `nodejs-bigtable/${version}`,
                 operationLatency: totalMilliseconds,
                 retryCount: this.attemptCount - 1,
-                firstResponseLatency: this.firstResponseLatency ?? undefined,
+                // Conditionally add the firstResponseLatency property
+                ...firstResponseLatencyExpression,
                 applicationLatency: applicationLatency ?? 0,
               });
             }

--- a/src/client-side-metrics/operation-metrics-collector.ts
+++ b/src/client-side-metrics/operation-metrics-collector.ts
@@ -300,14 +300,6 @@ export class OperationMetricsCollector {
         {
           this.handlers.forEach(metricsHandler => {
             if (metricsHandler.onOperationComplete) {
-              const firstResponseLatencyExpression =
-                this.methodName === MethodName.READ_ROWS ||
-                this.methodName === MethodName.READ_ROW
-                  ? {
-                      firstResponseLatency:
-                        this.firstResponseLatency ?? undefined,
-                    }
-                  : {};
               metricsHandler.onOperationComplete({
                 status: finalOperationStatus.toString(),
                 streaming: this.streamingOperation,
@@ -315,8 +307,7 @@ export class OperationMetricsCollector {
                 client_name: `nodejs-bigtable/${version}`,
                 operationLatency: totalMilliseconds,
                 retryCount: this.attemptCount - 1,
-                // Conditionally add the firstResponseLatency property
-                ...firstResponseLatencyExpression,
+                firstResponseLatency: this.firstResponseLatency ?? 0,
                 applicationLatency: applicationLatency ?? 0,
               });
             }

--- a/src/utils/createReadStreamInternal.ts
+++ b/src/utils/createReadStreamInternal.ts
@@ -325,6 +325,7 @@ export function createReadStreamInternal(
       retryOpts,
     });
     requestStream.on('data', () => {
+      // This handler is necessary for recording firstResponseLatencies.
       metricsCollector.onResponse();
     });
 

--- a/src/utils/createReadStreamInternal.ts
+++ b/src/utils/createReadStreamInternal.ts
@@ -324,6 +324,9 @@ export function createReadStreamInternal(
       gaxOpts,
       retryOpts,
     });
+    requestStream.on('data', () => {
+      metricsCollector.onResponse();
+    });
 
     activeRequestStream = requestStream!;
 

--- a/system-test/client-side-metrics-all-methods.ts
+++ b/system-test/client-side-metrics-all-methods.ts
@@ -68,11 +68,17 @@ function getHandlerFromExporter(Exporter: typeof CloudMonitoringExporter) {
 }
 
 function checkFirstResponseLatency(requestHandled: OnOperationCompleteData) {
-  assert(requestHandled.firstResponseLatency);
+  assert(
+    Object.prototype.hasOwnProperty.call(
+      requestHandled,
+      'firstResponseLatency',
+    ),
+  );
   if (
     requestHandled.metricsCollectorData.method === MethodName.READ_ROWS ||
     requestHandled.metricsCollectorData.method === MethodName.READ_ROW
   ) {
+    assert(requestHandled.firstResponseLatency);
     assert(requestHandled.firstResponseLatency > 0);
   } else {
     assert.strictEqual(requestHandled.firstResponseLatency, 0);
@@ -814,7 +820,7 @@ describe('Bigtable/ClientSideMetrics', () => {
       });
     });
   });
-  describe.only('Bigtable/ClientSideMetricsToMetricsHandler', () => {
+  describe('Bigtable/ClientSideMetricsToMetricsHandler', () => {
     async function getFakeBigtableWithHandler(
       projectId: string,
       done: mocha.Done,

--- a/system-test/client-side-metrics-all-methods.ts
+++ b/system-test/client-side-metrics-all-methods.ts
@@ -268,7 +268,7 @@ async function checkForPublishedMetrics(projectId: string) {
   }
 }
 
-describe.only('Bigtable/ClientSideMetrics', () => {
+describe('Bigtable/ClientSideMetrics', () => {
   const instanceId1 = 'emulator-test-instance';
   const instanceId2 = 'emulator-test-instance2';
   const tableId1 = 'my-table';

--- a/system-test/client-side-metrics-all-methods.ts
+++ b/system-test/client-side-metrics-all-methods.ts
@@ -98,11 +98,15 @@ function readRowsAssertionCheck(
   const secondRequest = requestsHandled[1] as any;
   // We would expect these parameters to be different every time so delete
   // them from the comparison after checking they exist.
+  if (method === 'Bigtable.ReadRows' || method === 'Bigtable.ReadRow') {
+    assert(secondRequest.firstResponseLatency);
+    delete secondRequest.firstResponseLatency;
+  } else {
+    assert(!secondRequest.firstResponseLatency);
+  }
   assert(secondRequest.operationLatency);
-  assert(secondRequest.firstResponseLatency);
-  assert.strictEqual(secondRequest.applicationLatency, 0);
+  assert(secondRequest.applicationLatency < 10);
   delete secondRequest.operationLatency;
-  delete secondRequest.firstResponseLatency;
   delete secondRequest.applicationLatency;
   delete secondRequest.metricsCollectorData.appProfileId;
   assert.deepStrictEqual(secondRequest, {
@@ -144,11 +148,15 @@ function readRowsAssertionCheck(
   const fourthRequest = requestsHandled[3] as any;
   // We would expect these parameters to be different every time so delete
   // them from the comparison after checking they exist.
+  if (method === 'Bigtable.ReadRows' || method === 'Bigtable.ReadRow') {
+    assert(fourthRequest.firstResponseLatency);
+    delete fourthRequest.firstResponseLatency;
+  } else {
+    assert(!fourthRequest.firstResponseLatency);
+  }
   assert(fourthRequest.operationLatency);
-  assert(fourthRequest.firstResponseLatency);
-  assert.strictEqual(fourthRequest.applicationLatency, 0);
+  assert(fourthRequest.applicationLatency < 10);
   delete fourthRequest.operationLatency;
-  delete fourthRequest.firstResponseLatency;
   delete fourthRequest.applicationLatency;
   delete fourthRequest.metricsCollectorData.appProfileId;
   assert.deepStrictEqual(fourthRequest, {
@@ -260,7 +268,7 @@ async function checkForPublishedMetrics(projectId: string) {
   }
 }
 
-describe('Bigtable/ClientSideMetrics', () => {
+describe.only('Bigtable/ClientSideMetrics', () => {
   const instanceId1 = 'emulator-test-instance';
   const instanceId2 = 'emulator-test-instance2';
   const tableId1 = 'my-table';


### PR DESCRIPTION
## Description

This fix ensures that first response latencies are only collected for ReadRows calls and not for the other grpc methods. This matches the requirements described in https://cloud.google.com/bigtable/docs/client-side-metrics-descriptions#first-response-latencies.

## Impact

Ensures that the right client side metrics are getting collected for the right methods.

## Testing

- More tolerance has been added to application latencies
- We change the test to expect first response latencies for readRows calls and not expect them otherwise
