### PR TITLE
test: Generate a unique id for each of the instances in the client side metrics system tests

### DIFF
--- a/system-test/client-side-metrics-all-methods.ts
+++ b/system-test/client-side-metrics-all-methods.ts
@@ -1029,7 +1029,7 @@ describe('Bigtable/ClientSideMetricsAllMethods', () => {
       });
     });
   });
-  describe.only('Bigtable/ClientSideMetricsToMetricsHandler', () => {
+  describe('Bigtable/ClientSideMetricsToMetricsHandler', () => {
     async function getFakeBigtableWithHandler(
       projectId: string,
       done: mocha.Done,
@@ -1107,7 +1107,7 @@ describe('Bigtable/ClientSideMetricsAllMethods', () => {
       return bigtable;
     }
 
-    describe.only('ReadRows', () => {
+    describe('ReadRows', () => {
       it('should send the metrics to the metrics handler for a ReadRows call', done => {
         (async () => {
           const bigtable = await mockBigtableWithNoInserts(

--- a/system-test/client-side-metrics-all-methods.ts
+++ b/system-test/client-side-metrics-all-methods.ts
@@ -39,6 +39,11 @@ import {ClientSideMetricsConfigManager} from '../src/client-side-metrics/metrics
 import {MetricServiceClient} from '@google-cloud/monitoring';
 
 const SECOND_PROJECT_ID = 'cfdb-sdk-node-tests';
+const instanceId1 = 'emulator-test-instance';
+const instanceId2 = 'emulator-test-instance2';
+const tableId1 = 'my-table';
+const tableId2 = 'my-table2';
+const columnFamilyId = 'cf1';
 
 function getFakeBigtable(
   projectId: string,
@@ -87,7 +92,7 @@ function readRowsAssertionCheck(
     status: '0',
     client_name: 'nodejs-bigtable',
     metricsCollectorData: {
-      instanceId: 'emulator-test-instance',
+      instanceId: instanceId1,
       table: 'my-table',
       cluster: 'fake-cluster3',
       zone: 'us-west1-c',
@@ -110,7 +115,7 @@ function readRowsAssertionCheck(
     streaming,
     client_name: 'nodejs-bigtable',
     metricsCollectorData: {
-      instanceId: 'emulator-test-instance',
+      instanceId: instanceId1,
       cluster: 'fake-cluster3',
       zone: 'us-west1-c',
       method,
@@ -133,7 +138,7 @@ function readRowsAssertionCheck(
     status: '0',
     client_name: 'nodejs-bigtable',
     metricsCollectorData: {
-      instanceId: 'emulator-test-instance',
+      instanceId: instanceId1,
       table: 'my-table2',
       cluster: 'fake-cluster3',
       zone: 'us-west1-c',
@@ -156,7 +161,7 @@ function readRowsAssertionCheck(
     streaming,
     client_name: 'nodejs-bigtable',
     metricsCollectorData: {
-      instanceId: 'emulator-test-instance',
+      instanceId: instanceId1,
       cluster: 'fake-cluster3',
       zone: 'us-west1-c',
       method,
@@ -275,11 +280,6 @@ async function checkForPublishedMetrics(projectId: string) {
 }
 
 describe('Bigtable/ClientSideMetrics', () => {
-  const instanceId1 = 'emulator-test-instance';
-  const instanceId2 = 'emulator-test-instance2';
-  const tableId1 = 'my-table';
-  const tableId2 = 'my-table2';
-  const columnFamilyId = 'cf1';
   let defaultProjectId: string;
 
   before(async () => {

--- a/system-test/client-side-metrics-all-methods.ts
+++ b/system-test/client-side-metrics-all-methods.ts
@@ -280,49 +280,53 @@ async function checkForPublishedMetrics(projectId: string) {
   }
 }
 
-describe('Bigtable/ClientSideMetrics', () => {
+describe.only('Bigtable/ClientSideMetricsAllMethods', () => {
   let defaultProjectId: string;
 
   before(async () => {
-    const bigtable = new Bigtable();
-    // For easier debugging, don't include metrics handlers in the config
-    // manager. This helps us step through the metrics handler for an individual
-    // test more easily.
-    bigtable._metricsConfigManager = new ClientSideMetricsConfigManager([]);
-    for (const instanceId of [instanceId1, instanceId2]) {
-      await setupBigtableWithInsert(bigtable, columnFamilyId, instanceId, [
-        tableId1,
-        tableId2,
-      ]);
-    }
-    defaultProjectId = await new Promise((resolve, reject) => {
-      bigtable.getProjectId_((err: Error | null, projectId?: string) => {
-        if (err) {
-          reject(err);
-        } else {
-          resolve(projectId as string);
-        }
+    for (const bigtable of [
+      new Bigtable(),
+      new Bigtable({projectId: SECOND_PROJECT_ID}),
+    ]) {
+      for (const instanceId of [instanceId1, instanceId2]) {
+        await setupBigtableWithInsert(bigtable, columnFamilyId, instanceId, [
+          tableId1,
+          tableId2,
+        ]);
+      }
+      defaultProjectId = await new Promise((resolve, reject) => {
+        bigtable.getProjectId_((err: Error | null, projectId?: string) => {
+          if (err) {
+            reject(err);
+          } else {
+            resolve(projectId as string);
+          }
+        });
       });
-    });
+    }
   });
 
   after(async () => {
-    const bigtable = new Bigtable();
-    try {
-      // If the instance has been deleted already by another source, we don't
-      // want this after hook to block the continuous integration pipeline.
-      const instance = bigtable.instance(instanceId1);
-      await instance.delete({});
-    } catch (e) {
-      console.warn('The instance has been deleted already');
-    }
-    try {
-      // If the instance has been deleted already by another source, we don't
-      // want this after hook to block the continuous integration pipeline.
-      const instance = bigtable.instance(instanceId2);
-      await instance.delete({});
-    } catch (e) {
-      console.warn('The instance has been deleted already');
+    for (const bigtable of [
+      new Bigtable(),
+      new Bigtable({projectId: SECOND_PROJECT_ID}),
+    ]) {
+      try {
+        // If the instance has been deleted already by another source, we don't
+        // want this after hook to block the continuous integration pipeline.
+        const instance = bigtable.instance(instanceId1);
+        await instance.delete({});
+      } catch (e) {
+        console.warn('The instance has been deleted already');
+      }
+      try {
+        // If the instance has been deleted already by another source, we don't
+        // want this after hook to block the continuous integration pipeline.
+        const instance = bigtable.instance(instanceId2);
+        await instance.delete({});
+      } catch (e) {
+        console.warn('The instance has been deleted already');
+      }
     }
   });
 
@@ -1007,7 +1011,7 @@ describe('Bigtable/ClientSideMetrics', () => {
       });
     });
   });
-  describe('Bigtable/ClientSideMetricsToMetricsHandler', () => {
+  describe.only('Bigtable/ClientSideMetricsToMetricsHandler', () => {
     async function getFakeBigtableWithHandler(
       projectId: string,
       done: mocha.Done,
@@ -1085,7 +1089,7 @@ describe('Bigtable/ClientSideMetrics', () => {
       return bigtable;
     }
 
-    describe('ReadRows', () => {
+    describe.only('ReadRows', () => {
       it('should send the metrics to the metrics handler for a ReadRows call', done => {
         (async () => {
           const bigtable = await mockBigtableWithNoInserts(

--- a/system-test/client-side-metrics-all-methods.ts
+++ b/system-test/client-side-metrics-all-methods.ts
@@ -37,10 +37,11 @@ import {
 import {ClientOptions} from 'google-gax';
 import {ClientSideMetricsConfigManager} from '../src/client-side-metrics/metrics-config-manager';
 import {MetricServiceClient} from '@google-cloud/monitoring';
+import {generateId} from './common';
 
 const SECOND_PROJECT_ID = 'cfdb-sdk-node-tests';
-const instanceId1 = 'emulator-test-instance';
-const instanceId2 = 'emulator-test-instance2';
+const instanceId1 = generateId('instance');
+const instanceId2 = generateId('instance');
 const tableId1 = 'my-table';
 const tableId2 = 'my-table2';
 const columnFamilyId = 'cf1';

--- a/system-test/client-side-metrics.ts
+++ b/system-test/client-side-metrics.ts
@@ -38,11 +38,11 @@ import {PassThrough} from 'stream';
 import {generateChunksFromRequest} from '../test-common/utils/readRowsImpl';
 import {TabularApiSurface} from '../src/tabular-api-surface';
 import {MetricServiceClient} from '@google-cloud/monitoring';
-import {ClientSideMetricsConfigManager} from '../src/client-side-metrics/metrics-config-manager';
+import {generateId} from './common';
 
 const SECOND_PROJECT_ID = 'cfdb-sdk-node-tests';
-const instanceId1 = 'emulator-test-instance';
-const instanceId2 = 'emulator-test-instance2';
+const instanceId1 = generateId('instance');
+const instanceId2 = generateId('instance');
 const tableId1 = 'my-table';
 const tableId2 = 'my-table2';
 const columnFamilyId = 'cf1';
@@ -330,7 +330,7 @@ async function checkForPublishedMetrics(projectId: string) {
   }
 }
 
-describe('Bigtable/ClientSideMetrics', () => {
+describe.only('Bigtable/ClientSideMetrics', () => {
   let defaultProjectId: string;
 
   before(async () => {

--- a/system-test/client-side-metrics.ts
+++ b/system-test/client-side-metrics.ts
@@ -41,6 +41,11 @@ import {MetricServiceClient} from '@google-cloud/monitoring';
 import {ClientSideMetricsConfigManager} from '../src/client-side-metrics/metrics-config-manager';
 
 const SECOND_PROJECT_ID = 'cfdb-sdk-node-tests';
+const instanceId1 = 'emulator-test-instance';
+const instanceId2 = 'emulator-test-instance2';
+const tableId1 = 'my-table';
+const tableId2 = 'my-table2';
+const columnFamilyId = 'cf1';
 
 class FakeHRTime {
   startTime = BigInt(0);
@@ -174,7 +179,7 @@ function readRowsAssertionCheck(
     status: '0',
     client_name: 'nodejs-bigtable',
     metricsCollectorData: {
-      instanceId: 'emulator-test-instance',
+      instanceId: instanceId1,
       table: 'my-table',
       cluster: 'fake-cluster3',
       zone: 'us-west1-c',
@@ -197,7 +202,7 @@ function readRowsAssertionCheck(
     streaming,
     client_name: 'nodejs-bigtable',
     metricsCollectorData: {
-      instanceId: 'emulator-test-instance',
+      instanceId: instanceId1,
       cluster: 'fake-cluster3',
       zone: 'us-west1-c',
       method,
@@ -220,7 +225,7 @@ function readRowsAssertionCheck(
     status: '0',
     client_name: 'nodejs-bigtable',
     metricsCollectorData: {
-      instanceId: 'emulator-test-instance',
+      instanceId: instanceId1,
       table: 'my-table2',
       cluster: 'fake-cluster3',
       zone: 'us-west1-c',
@@ -243,7 +248,7 @@ function readRowsAssertionCheck(
     streaming,
     client_name: 'nodejs-bigtable',
     metricsCollectorData: {
-      instanceId: 'emulator-test-instance',
+      instanceId: instanceId1,
       cluster: 'fake-cluster3',
       zone: 'us-west1-c',
       method,
@@ -326,11 +331,6 @@ async function checkForPublishedMetrics(projectId: string) {
 }
 
 describe('Bigtable/ClientSideMetrics', () => {
-  const instanceId1 = 'emulator-test-instance';
-  const instanceId2 = 'emulator-test-instance2';
-  const tableId1 = 'my-table';
-  const tableId2 = 'my-table2';
-  const columnFamilyId = 'cf1';
   let defaultProjectId: string;
 
   before(async () => {
@@ -706,7 +706,7 @@ describe('Bigtable/ClientSideMetrics', () => {
         status: '0',
         client_name: 'nodejs-bigtable',
         metricsCollectorData: {
-          instanceId: 'emulator-test-instance',
+          instanceId: instanceId1,
           table: 'my-table',
           cluster: 'fake-cluster3',
           zone: 'us-west1-c',
@@ -729,7 +729,7 @@ describe('Bigtable/ClientSideMetrics', () => {
         streaming: 'true',
         client_name: 'nodejs-bigtable',
         metricsCollectorData: {
-          instanceId: 'emulator-test-instance',
+          instanceId: instanceId1,
           cluster: 'fake-cluster3',
           zone: 'us-west1-c',
           method: 'Bigtable.ReadRows',
@@ -752,7 +752,7 @@ describe('Bigtable/ClientSideMetrics', () => {
         status: '0',
         client_name: 'nodejs-bigtable',
         metricsCollectorData: {
-          instanceId: 'emulator-test-instance',
+          instanceId: instanceId1,
           table: 'my-table2',
           cluster: 'fake-cluster3',
           zone: 'us-west1-c',
@@ -775,7 +775,7 @@ describe('Bigtable/ClientSideMetrics', () => {
         streaming: 'true',
         client_name: 'nodejs-bigtable',
         metricsCollectorData: {
-          instanceId: 'emulator-test-instance',
+          instanceId: instanceId1,
           cluster: 'fake-cluster3',
           zone: 'us-west1-c',
           method: 'Bigtable.ReadRows',
@@ -808,7 +808,7 @@ describe('Bigtable/ClientSideMetrics', () => {
           status: '0',
           client_name: 'nodejs-bigtable',
           metricsCollectorData: {
-            instanceId: 'emulator-test-instance',
+            instanceId: instanceId1,
             table: 'my-table',
             cluster: '<unspecified>',
             zone: 'global',
@@ -820,7 +820,7 @@ describe('Bigtable/ClientSideMetrics', () => {
           status: '0',
           streaming: 'true',
           metricsCollectorData: {
-            instanceId: 'emulator-test-instance',
+            instanceId: instanceId1,
             table: 'my-table',
             cluster: '<unspecified>',
             zone: 'global',
@@ -841,7 +841,7 @@ describe('Bigtable/ClientSideMetrics', () => {
           status: '0',
           client_name: 'nodejs-bigtable',
           metricsCollectorData: {
-            instanceId: 'emulator-test-instance',
+            instanceId: instanceId1,
             table: 'my-table2',
             cluster: '<unspecified>',
             zone: 'global',
@@ -853,7 +853,7 @@ describe('Bigtable/ClientSideMetrics', () => {
           status: '0',
           streaming: 'true',
           metricsCollectorData: {
-            instanceId: 'emulator-test-instance',
+            instanceId: instanceId1,
             table: 'my-table2',
             cluster: '<unspecified>',
             zone: 'global',
@@ -891,7 +891,7 @@ describe('Bigtable/ClientSideMetrics', () => {
           status: '0',
           client_name: 'nodejs-bigtable',
           metricsCollectorData: {
-            instanceId: 'emulator-test-instance',
+            instanceId: instanceId1,
             table: 'my-table',
             cluster: '<unspecified>',
             zone: 'global',
@@ -903,7 +903,7 @@ describe('Bigtable/ClientSideMetrics', () => {
           status: '0',
           streaming: 'true',
           metricsCollectorData: {
-            instanceId: 'emulator-test-instance',
+            instanceId: instanceId1,
             table: 'my-table',
             cluster: '<unspecified>',
             zone: 'global',
@@ -924,7 +924,7 @@ describe('Bigtable/ClientSideMetrics', () => {
           status: '0',
           client_name: 'nodejs-bigtable',
           metricsCollectorData: {
-            instanceId: 'emulator-test-instance',
+            instanceId: instanceId1,
             table: 'my-table2',
             cluster: '<unspecified>',
             zone: 'global',
@@ -936,7 +936,7 @@ describe('Bigtable/ClientSideMetrics', () => {
           status: '0',
           streaming: 'true',
           metricsCollectorData: {
-            instanceId: 'emulator-test-instance',
+            instanceId: instanceId1,
             table: 'my-table2',
             cluster: '<unspecified>',
             zone: 'global',


### PR DESCRIPTION
## Description

The system tests are failing frequently with a NOT_FOUND instance error. The hypothesis is that since the client side metrics system tests are always running against the same instance name `emulator-test-instance` that one test suite is deleting this instance while the other test suite is reading from it causing this error. The solution is that like the other system tests we should generate a unique id for the created instance so that two tests suites running at the same time do not interfere with one another. We also need to add some code for the unique case where we need to create instances on a second project for the `should send the metrics to the metrics handler for a single row read` test.

## Impact

Less Flakey tests

## Testing

Tests changed to use a unique instance id each time for client side metrics.
