### PR TITLE
test: Add a metric service client test and ensure universe domain gets used when writing the metrics

### DIFF
--- a/test/metric-service-client-credentials.ts
+++ b/test/metric-service-client-credentials.ts
@@ -16,12 +16,17 @@ import * as proxyquire from 'proxyquire';
 import {ClientOptions, grpc} from 'google-gax';
 import * as assert from 'assert';
 import {MetricServiceClient} from '@google-cloud/monitoring';
+import {MockServer} from '../src/util/mock-servers/mock-server';
+import {MockService} from '../src/util/mock-servers/mock-service';
+import {Bigtable} from '../src';
+import {BigtableClientMockService} from '../src/util/mock-servers/service-implementations/bigtable-client-mock-service';
 
 describe('Bigtable/MetricServiceClientCredentials', () => {
-  it('should pass the credentials to the exporter', done => {
+  it('should pass the credentials and universe domain to the exporter', done => {
     const clientOptions = {
       metricsEnabled: true,
       sslCreds: grpc.credentials.createInsecure(),
+      universeDomain: 'some-universe-domain.com',
     };
     class FakeExporter {
       constructor(options: ClientOptions) {
@@ -80,5 +85,41 @@ describe('Bigtable/MetricServiceClientCredentials', () => {
     const client = new MetricServiceClient(savedOptions);
     const projectIdUsed = await client.getProjectId();
     assert.strictEqual(projectIdUsed, SECOND_PROJECT_ID);
+  });
+  it('should pass the credentials and universe domain to the metric service client', done => {
+    const clientOptions = {
+      metricsEnabled: true,
+      sslCreds: grpc.credentials.createInsecure(),
+      universeDomain: 'some-universe-domain.com',
+    };
+    class FakeMetricServiceClient {
+      constructor(options: ClientOptions) {
+        try {
+          assert.strictEqual(options, clientOptions);
+          done();
+        } catch (e) {
+          done(e);
+        }
+      }
+    }
+    const FakeExporter = proxyquire('../src/client-side-metrics/exporter.js', {
+      '@google-cloud/monitoring': {
+        MetricServiceClient: FakeMetricServiceClient,
+      },
+    }).CloudMonitoringExporter;
+    const FakeCGPMetricsHandler = proxyquire(
+      '../src/client-side-metrics/gcp-metrics-handler.js',
+      {
+        './exporter': {
+          CloudMonitoringExporter: FakeExporter,
+        },
+      },
+    ).GCPMetricsHandler;
+    const FakeBigtable = proxyquire('../src/index.js', {
+      './client-side-metrics/gcp-metrics-handler': {
+        GCPMetricsHandler: FakeCGPMetricsHandler,
+      },
+    }).Bigtable;
+    new FakeBigtable(clientOptions);
   });
 });

--- a/test/metric-service-client-credentials.ts
+++ b/test/metric-service-client-credentials.ts
@@ -16,10 +16,6 @@ import * as proxyquire from 'proxyquire';
 import {ClientOptions, grpc} from 'google-gax';
 import * as assert from 'assert';
 import {MetricServiceClient} from '@google-cloud/monitoring';
-import {MockServer} from '../src/util/mock-servers/mock-server';
-import {MockService} from '../src/util/mock-servers/mock-service';
-import {Bigtable} from '../src';
-import {BigtableClientMockService} from '../src/util/mock-servers/service-implementations/bigtable-client-mock-service';
 
 describe('Bigtable/MetricServiceClientCredentials', () => {
   it('should pass the credentials and universe domain to the exporter', done => {


### PR DESCRIPTION
## Description

Adds a test to make sure the universe domain is used when writing metrics.

## Impact

Adds a test to ensure metrics are always written to the right place when universe domain is provided.

## Testing

Assuming the MetricServiceClient is working properly, this test ensures that universe domain is passed to the metric service client so that metrics will be written to the universe domain endpoint.

An even better test would be to set up a project at a different universe domain and check it for metrics after a write to ensure the metrics are actually getting written there, but that setup is a pretty heavy lift. I think the current test gives us enough confidence that the test is working correctly.
