### PR TITLE
test: Better factoring and generate instance id for close test

### DIFF
--- a/system-test/read-rows.ts
+++ b/system-test/read-rows.ts
@@ -28,6 +28,7 @@ import {PassThrough} from 'stream';
 import * as proxyquire from 'proxyquire';
 import {TabularApiSurface} from '../src/tabular-api-surface';
 import * as mocha from 'mocha';
+import {generateId} from './common';
 
 const {grpc} = new GrpcClient();
 

--- a/system-test/read-rows.ts
+++ b/system-test/read-rows.ts
@@ -105,12 +105,9 @@ describe('Bigtable/Table', () => {
   }).Bigtable;
 
   const bigtable = new FakeBigtable();
-  const INSTANCE_NAME = 'fake-instance2';
+  const INSTANCE_NAME = generateId('instance');
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (bigtable as any).grpcCredentials = grpc.credentials.createInsecure();
-
-  const INSTANCE = bigtable.instance('instance');
-  const TABLE = INSTANCE.table('table');
 
   describe('close', () => {
     it('should fail when invoking readRows with closed client', async () => {
@@ -152,6 +149,8 @@ describe('Bigtable/Table', () => {
   });
 
   describe('createReadStream', () => {
+    const INSTANCE = bigtable.instance('instance');
+    const TABLE = INSTANCE.table('table');
     let endCalled: boolean;
     let error: ServiceError | null;
     let requestedOptions: Array<{}>;


### PR DESCRIPTION
## Description

Every once in a while the close client test acts up. It says the instance has already been created. This PR may fix this flakey test and if not at the very least it will make sure two running system tests don't interfere with one another.

## Impact

Less Flakey tests

## Testing

Test changed to be less Flakey
