### PR TITLE
feat: Enable csm by default

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -591,7 +591,7 @@ export class Bigtable {
     this.shouldReplaceProjectIdToken = this.projectId === '{{projectId}}';
 
     const handlers = !(options.metricsEnabled === false)
-      ? [new GCPMetricsHandler(options as ClientOptions)]
+      ? [new GCPMetricsHandler(Object.assign({}, options) as ClientOptions)]
       : [];
     this._metricsConfigManager = new ClientSideMetricsConfigManager(handlers);
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -590,10 +590,9 @@ export class Bigtable {
     this.projectName = `projects/${this.projectId}`;
     this.shouldReplaceProjectIdToken = this.projectId === '{{projectId}}';
 
-    const handlers =
-      options.metricsEnabled === true
-        ? [new GCPMetricsHandler(options as ClientOptions)]
-        : [];
+    const handlers = !(options.metricsEnabled === false)
+      ? [new GCPMetricsHandler(options as ClientOptions)]
+      : [];
     this._metricsConfigManager = new ClientSideMetricsConfigManager(handlers);
   }
 

--- a/test/metric-service-client-credentials.ts
+++ b/test/metric-service-client-credentials.ts
@@ -27,7 +27,7 @@ describe('Bigtable/MetricServiceClientCredentials', () => {
     class FakeExporter {
       constructor(options: ClientOptions) {
         try {
-          assert.strictEqual(options, clientOptions);
+          assert.deepStrictEqual(options, clientOptions);
           done();
         } catch (e) {
           done(e);
@@ -91,7 +91,7 @@ describe('Bigtable/MetricServiceClientCredentials', () => {
     class FakeMetricServiceClient {
       constructor(options: ClientOptions) {
         try {
-          assert.strictEqual(options, clientOptions);
+          assert.deepStrictEqual(options, clientOptions);
           done();
         } catch (e) {
           done(e);

--- a/testproxy/services/create-client.js
+++ b/testproxy/services/create-client.js
@@ -17,6 +17,9 @@ const normalizeCallback = require('./utils/normalize-callback.js');
 
 const grpc = require('@grpc/grpc-js');
 const {Bigtable} = require('../../build/src/index.js');
+const {
+  ClientSideMetricsConfigManager,
+} = require('../../build/src/client-side-metrics/metrics-config-manager');
 const {BigtableClient} = require('../../build/src/index.js').v2;
 
 const v2 = Symbol.for('v2');
@@ -81,6 +84,10 @@ const createClient = ({clientMap}) =>
       appProfileId,
       clientConfig,
     });
+    const handlers = [];
+    bigtable._metricsConfigManager = new ClientSideMetricsConfigManager(
+      handlers,
+    );
     bigtable[v2] = new BigtableClient(bigtable.options.BigtableClient);
     clientMap.set(clientId, bigtable);
   });


### PR DESCRIPTION
## Description

The client side metrics should be enabled by default

## Impact

To meet user needs. Get them using client side metrics by default.

## Testing

The system tests are already a good smoke test. They will start collecting metrics and they will tell us if there is a problem.

Some conformance tests fail due to connection issues when you turn the metrics on though so conformance test changes are necessary. We have to make it so that they don't try to send metrics due to connection issues with the test proxy environment. Here were the failures below:

=== RUN   TestReadRows_Generic_CloseClient
(node:4514) MetadataLookupWarning: received unexpected error = All promises were rejected code = UNKNOWN
[Servr log] 2025/08/20 20:02:20 There is 2s sleep on the server side
[Servr log] 2025/08/20 20:02:20 There is 2s sleep on the server side
[Servr log] 2025/08/20 20:02:20 There is 2s sleep on the server side
(node:4514) MetadataLookupWarning: received unexpected error = All promises were rejected code = UNKNOWN
/home/runner/work/nodejs-bigtable/nodejs-bigtable/node_modules/google-gax/node_modules/google-auth-library/build/src/auth/googleauth.js:284
        throw new Error(exports.GoogleAuthExceptionMessages.NO_ADC_FOUND);
              ^

Error: Could not load the default credentials. Browse to https://cloud.google.com/docs/authentication/getting-started for more information.
    at GoogleAuth.getApplicationDefaultAsync (/home/runner/work/nodejs-bigtable/nodejs-bigtable/node_modules/google-gax/node_modules/google-auth-library/build/src/auth/googleauth.js:284:15)
    at async #determineClient (/home/runner/work/nodejs-bigtable/nodejs-bigtable/node_modules/google-gax/node_modules/google-auth-library/build/src/auth/googleauth.js:732:36)
    at async GoogleAuth.getClient (/home/runner/work/nodejs-bigtable/nodejs-bigtable/node_modules/google-gax/node_modules/google-auth-library/build/src/auth/googleauth.js:709:20)
    at async GrpcClient._getCredentials (/home/runner/work/nodejs-bigtable/nodejs-bigtable/node_modules/google-gax/build/src/grpc.js:192:24)
    at async GrpcClient.createStub (/home/runner/work/nodejs-bigtable/nodejs-bigtable/node_modules/google-gax/build/src/grpc.js:373:23)

Node.js v20.19.4
    test_workflow.go:134: The RPC to test proxy encountered error: rpc error: code = Unavailable desc = error reading from server: read tcp 127.0.0.1:48370->127.0.0.1:9999: read: connection reset by peer
    test_workflow.go:134: The RPC to test proxy encountered error: rpc error: code = Unavailable desc = error reading from server: read tcp 127.0.0.1:48370->127.0.0.1:9999: read: connection reset by peer
    test_workflow.go:134: The RPC to test proxy encountered error: rpc error: code = Unavailable desc = error reading from server: read tcp 127.0.0.1:48370->127.0.0.1:9999: read: connection reset by peer
    test_workflow.go:81: cbt client closing failed: rpc error: code = Unavailable desc = error reading from server: read tcp 127.0.0.1:48370->127.0.0.1:9999: read: connection reset by peer
    test_workflow.go:81: cbt client closing failed: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial tcp :9999: connect: connection refused"
--- FAIL: TestReadRows_Generic_CloseClient (1.12s)
=== RUN   TestReadRows_Generic_DeadlineExceeded
    test_workflow.go:68: cbt client creation failed: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial tcp :9999: connect: connection refused"
--- FAIL: TestReadRows_Generic_DeadlineExceeded (0.00s)
=== RUN   TestSampleRowKeys_Generic_MultiStreams
    test_workflow.go:68: cbt client creation failed: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial tcp :9999: connect: connection refused"
--- FAIL: TestSampleRowKeys_Generic_MultiStreams (0.00s)
=== RUN   TestSampleRowKeys_Generic_DeadlineExceeded
    test_workflow.go:68: cbt client creation failed: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial tcp :9999: connect: connection refused"
--- FAIL: TestSampleRowKeys_Generic_DeadlineExceeded (0.00s)
FAIL