### PR TITLE
fix: directly import JS-native impl for crc32c on non-x64 platforms

### DIFF
--- a/src/execute-query/values.ts
+++ b/src/execute-query/values.ts
@@ -16,7 +16,13 @@ import {Duplex, Readable} from 'stream';
 import * as SqlTypes from './types';
 import {PreciseDate} from '@google-cloud/precise-date';
 import {NamedList} from './namedlist';
-const CRC32C = require('fast-crc32c');
+
+// fast-crc32c will segfault on import on non-x64 architectures, due to a
+// lack of SSE instructions.
+const CRC32C =
+  process.arch === 'x64'
+    ? require('fast-crc32c')
+    : require('fast-crc32c/impls/js_crc32c');
 
 export type BigtableMap = EncodedKeyMap;
 


### PR DESCRIPTION
Directly imports JS-native implementation for fast-crc32c on non-x64 platforms to avoid a segmentation fault. The problem was first introduced in 6.2.0 by https://github.com/googleapis/nodejs-bigtable/pull/1613.

Arm architectures (and anything without SSE instructions, really) will segmentation fault on import of the bigtable library. This is caused by the node-fast-crc32c library shotgun-importing the various possible implementations, but this approach fails on Arm due to issues interfacing with the relevant native library. (https://github.com/ashi009/node-fast-crc32c/issues/38) This workaround will cause it to check the architecture and load the JS module directly if needed.

This will be slower, but it should at least make it run again on Macs and Arm VMs.

Fixes https://github.com/googleapis/nodejs-bigtable/issues/1649

## Checklist

- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/nodejs-bigtable/issues/new/choose) before writing your code! That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease
- [?] Appropriate docs were updated
- [x] Appropriate comments were added, particularly in complex areas or places that require background
- [x] No new warnings or issues will be generated from this change

