### PR TITLE
build: generated admin sample support

### DIFF
--- a/owlbot.py
+++ b/owlbot.py
@@ -100,6 +100,18 @@ if staging.is_dir():
             contents = contents.replace("'../", "'../../../")
             tfn.write_text(contents)
 
+        # Finally, the samples. .v2 -> .admin.v2
+        samplesStr = str(samples)
+        sfns = [fn
+                    for fn
+                    in src_files[admin_version]
+                    if str(fn)[:len(samplesStr)] == samplesStr]
+        for sfn in sfns:
+            logging.info(f"munging sample file: {str(sfn)}")
+            contents = sfn.read_text()
+            contents = contents.replace(').v2', ').admin.v2')
+            sfn.write_text(contents)
+
         os.system(f"mkdir -p {inProtoPath}")
         s.copy([protos / '*'], destination=inProtoPath)
         os.system(f"mkdir -p src/{admin_version}")

--- a/samples/generated/admin/v2/bigtable_instance_admin.create_app_profile.js
+++ b/samples/generated/admin/v2/bigtable_instance_admin.create_app_profile.js
@@ -50,7 +50,7 @@ function main(parent, appProfileId, appProfile) {
   // const ignoreWarnings = true
 
   // Imports the Admin library
-  const {BigtableInstanceAdminClient} = require('@google-cloud/bigtable').v2;
+  const {BigtableInstanceAdminClient} = require('@google-cloud/bigtable').admin.v2;
 
   // Instantiates a client
   const adminClient = new BigtableInstanceAdminClient();

--- a/samples/generated/admin/v2/bigtable_instance_admin.create_cluster.js
+++ b/samples/generated/admin/v2/bigtable_instance_admin.create_cluster.js
@@ -46,7 +46,7 @@ function main(parent, clusterId, cluster) {
   // const cluster = {}
 
   // Imports the Admin library
-  const {BigtableInstanceAdminClient} = require('@google-cloud/bigtable').v2;
+  const {BigtableInstanceAdminClient} = require('@google-cloud/bigtable').admin.v2;
 
   // Instantiates a client
   const adminClient = new BigtableInstanceAdminClient();

--- a/samples/generated/admin/v2/bigtable_instance_admin.create_instance.js
+++ b/samples/generated/admin/v2/bigtable_instance_admin.create_instance.js
@@ -53,7 +53,7 @@ function main(parent, instanceId, instance, clusters) {
   // const clusters = [1,2,3,4]
 
   // Imports the Admin library
-  const {BigtableInstanceAdminClient} = require('@google-cloud/bigtable').v2;
+  const {BigtableInstanceAdminClient} = require('@google-cloud/bigtable').admin.v2;
 
   // Instantiates a client
   const adminClient = new BigtableInstanceAdminClient();

--- a/samples/generated/admin/v2/bigtable_instance_admin.create_logical_view.js
+++ b/samples/generated/admin/v2/bigtable_instance_admin.create_logical_view.js
@@ -44,7 +44,7 @@ function main(parent, logicalViewId, logicalView) {
   // const logicalView = {}
 
   // Imports the Admin library
-  const {BigtableInstanceAdminClient} = require('@google-cloud/bigtable').v2;
+  const {BigtableInstanceAdminClient} = require('@google-cloud/bigtable').admin.v2;
 
   // Instantiates a client
   const adminClient = new BigtableInstanceAdminClient();

--- a/samples/generated/admin/v2/bigtable_instance_admin.create_materialized_view.js
+++ b/samples/generated/admin/v2/bigtable_instance_admin.create_materialized_view.js
@@ -44,7 +44,7 @@ function main(parent, materializedViewId, materializedView) {
   // const materializedView = {}
 
   // Imports the Admin library
-  const {BigtableInstanceAdminClient} = require('@google-cloud/bigtable').v2;
+  const {BigtableInstanceAdminClient} = require('@google-cloud/bigtable').admin.v2;
 
   // Instantiates a client
   const adminClient = new BigtableInstanceAdminClient();

--- a/samples/generated/admin/v2/bigtable_instance_admin.delete_app_profile.js
+++ b/samples/generated/admin/v2/bigtable_instance_admin.delete_app_profile.js
@@ -40,7 +40,7 @@ function main(name, ignoreWarnings) {
   // const ignoreWarnings = true
 
   // Imports the Admin library
-  const {BigtableInstanceAdminClient} = require('@google-cloud/bigtable').v2;
+  const {BigtableInstanceAdminClient} = require('@google-cloud/bigtable').admin.v2;
 
   // Instantiates a client
   const adminClient = new BigtableInstanceAdminClient();

--- a/samples/generated/admin/v2/bigtable_instance_admin.delete_cluster.js
+++ b/samples/generated/admin/v2/bigtable_instance_admin.delete_cluster.js
@@ -35,7 +35,7 @@ function main(name) {
   // const name = 'abc123'
 
   // Imports the Admin library
-  const {BigtableInstanceAdminClient} = require('@google-cloud/bigtable').v2;
+  const {BigtableInstanceAdminClient} = require('@google-cloud/bigtable').admin.v2;
 
   // Instantiates a client
   const adminClient = new BigtableInstanceAdminClient();

--- a/samples/generated/admin/v2/bigtable_instance_admin.delete_instance.js
+++ b/samples/generated/admin/v2/bigtable_instance_admin.delete_instance.js
@@ -35,7 +35,7 @@ function main(name) {
   // const name = 'abc123'
 
   // Imports the Admin library
-  const {BigtableInstanceAdminClient} = require('@google-cloud/bigtable').v2;
+  const {BigtableInstanceAdminClient} = require('@google-cloud/bigtable').admin.v2;
 
   // Instantiates a client
   const adminClient = new BigtableInstanceAdminClient();

--- a/samples/generated/admin/v2/bigtable_instance_admin.delete_logical_view.js
+++ b/samples/generated/admin/v2/bigtable_instance_admin.delete_logical_view.js
@@ -43,7 +43,7 @@ function main(name) {
   // const etag = 'abc123'
 
   // Imports the Admin library
-  const {BigtableInstanceAdminClient} = require('@google-cloud/bigtable').v2;
+  const {BigtableInstanceAdminClient} = require('@google-cloud/bigtable').admin.v2;
 
   // Instantiates a client
   const adminClient = new BigtableInstanceAdminClient();

--- a/samples/generated/admin/v2/bigtable_instance_admin.delete_materialized_view.js
+++ b/samples/generated/admin/v2/bigtable_instance_admin.delete_materialized_view.js
@@ -43,7 +43,7 @@ function main(name) {
   // const etag = 'abc123'
 
   // Imports the Admin library
-  const {BigtableInstanceAdminClient} = require('@google-cloud/bigtable').v2;
+  const {BigtableInstanceAdminClient} = require('@google-cloud/bigtable').admin.v2;
 
   // Instantiates a client
   const adminClient = new BigtableInstanceAdminClient();

--- a/samples/generated/admin/v2/bigtable_instance_admin.get_app_profile.js
+++ b/samples/generated/admin/v2/bigtable_instance_admin.get_app_profile.js
@@ -35,7 +35,7 @@ function main(name) {
   // const name = 'abc123'
 
   // Imports the Admin library
-  const {BigtableInstanceAdminClient} = require('@google-cloud/bigtable').v2;
+  const {BigtableInstanceAdminClient} = require('@google-cloud/bigtable').admin.v2;
 
   // Instantiates a client
   const adminClient = new BigtableInstanceAdminClient();

--- a/samples/generated/admin/v2/bigtable_instance_admin.get_cluster.js
+++ b/samples/generated/admin/v2/bigtable_instance_admin.get_cluster.js
@@ -35,7 +35,7 @@ function main(name) {
   // const name = 'abc123'
 
   // Imports the Admin library
-  const {BigtableInstanceAdminClient} = require('@google-cloud/bigtable').v2;
+  const {BigtableInstanceAdminClient} = require('@google-cloud/bigtable').admin.v2;
 
   // Instantiates a client
   const adminClient = new BigtableInstanceAdminClient();

--- a/samples/generated/admin/v2/bigtable_instance_admin.get_iam_policy.js
+++ b/samples/generated/admin/v2/bigtable_instance_admin.get_iam_policy.js
@@ -40,7 +40,7 @@ function main(resource) {
   // const options = {}
 
   // Imports the Admin library
-  const {BigtableInstanceAdminClient} = require('@google-cloud/bigtable').v2;
+  const {BigtableInstanceAdminClient} = require('@google-cloud/bigtable').admin.v2;
 
   // Instantiates a client
   const adminClient = new BigtableInstanceAdminClient();

--- a/samples/generated/admin/v2/bigtable_instance_admin.get_instance.js
+++ b/samples/generated/admin/v2/bigtable_instance_admin.get_instance.js
@@ -35,7 +35,7 @@ function main(name) {
   // const name = 'abc123'
 
   // Imports the Admin library
-  const {BigtableInstanceAdminClient} = require('@google-cloud/bigtable').v2;
+  const {BigtableInstanceAdminClient} = require('@google-cloud/bigtable').admin.v2;
 
   // Instantiates a client
   const adminClient = new BigtableInstanceAdminClient();

--- a/samples/generated/admin/v2/bigtable_instance_admin.get_logical_view.js
+++ b/samples/generated/admin/v2/bigtable_instance_admin.get_logical_view.js
@@ -35,7 +35,7 @@ function main(name) {
   // const name = 'abc123'
 
   // Imports the Admin library
-  const {BigtableInstanceAdminClient} = require('@google-cloud/bigtable').v2;
+  const {BigtableInstanceAdminClient} = require('@google-cloud/bigtable').admin.v2;
 
   // Instantiates a client
   const adminClient = new BigtableInstanceAdminClient();

--- a/samples/generated/admin/v2/bigtable_instance_admin.get_materialized_view.js
+++ b/samples/generated/admin/v2/bigtable_instance_admin.get_materialized_view.js
@@ -36,7 +36,7 @@ function main(name) {
   // const name = 'abc123'
 
   // Imports the Admin library
-  const {BigtableInstanceAdminClient} = require('@google-cloud/bigtable').v2;
+  const {BigtableInstanceAdminClient} = require('@google-cloud/bigtable').admin.v2;
 
   // Instantiates a client
   const adminClient = new BigtableInstanceAdminClient();

--- a/samples/generated/admin/v2/bigtable_instance_admin.list_app_profiles.js
+++ b/samples/generated/admin/v2/bigtable_instance_admin.list_app_profiles.js
@@ -52,7 +52,7 @@ function main(parent) {
   // const pageToken = 'abc123'
 
   // Imports the Admin library
-  const {BigtableInstanceAdminClient} = require('@google-cloud/bigtable').v2;
+  const {BigtableInstanceAdminClient} = require('@google-cloud/bigtable').admin.v2;
 
   // Instantiates a client
   const adminClient = new BigtableInstanceAdminClient();

--- a/samples/generated/admin/v2/bigtable_instance_admin.list_clusters.js
+++ b/samples/generated/admin/v2/bigtable_instance_admin.list_clusters.js
@@ -42,7 +42,7 @@ function main(parent) {
   // const pageToken = 'abc123'
 
   // Imports the Admin library
-  const {BigtableInstanceAdminClient} = require('@google-cloud/bigtable').v2;
+  const {BigtableInstanceAdminClient} = require('@google-cloud/bigtable').admin.v2;
 
   // Instantiates a client
   const adminClient = new BigtableInstanceAdminClient();

--- a/samples/generated/admin/v2/bigtable_instance_admin.list_hot_tablets.js
+++ b/samples/generated/admin/v2/bigtable_instance_admin.list_hot_tablets.js
@@ -63,7 +63,7 @@ function main(parent) {
   // const pageToken = 'abc123'
 
   // Imports the Admin library
-  const {BigtableInstanceAdminClient} = require('@google-cloud/bigtable').v2;
+  const {BigtableInstanceAdminClient} = require('@google-cloud/bigtable').admin.v2;
 
   // Instantiates a client
   const adminClient = new BigtableInstanceAdminClient();

--- a/samples/generated/admin/v2/bigtable_instance_admin.list_instances.js
+++ b/samples/generated/admin/v2/bigtable_instance_admin.list_instances.js
@@ -39,7 +39,7 @@ function main(parent) {
   // const pageToken = 'abc123'
 
   // Imports the Admin library
-  const {BigtableInstanceAdminClient} = require('@google-cloud/bigtable').v2;
+  const {BigtableInstanceAdminClient} = require('@google-cloud/bigtable').admin.v2;
 
   // Instantiates a client
   const adminClient = new BigtableInstanceAdminClient();

--- a/samples/generated/admin/v2/bigtable_instance_admin.list_logical_views.js
+++ b/samples/generated/admin/v2/bigtable_instance_admin.list_logical_views.js
@@ -48,7 +48,7 @@ function main(parent) {
   // const pageToken = 'abc123'
 
   // Imports the Admin library
-  const {BigtableInstanceAdminClient} = require('@google-cloud/bigtable').v2;
+  const {BigtableInstanceAdminClient} = require('@google-cloud/bigtable').admin.v2;
 
   // Instantiates a client
   const adminClient = new BigtableInstanceAdminClient();

--- a/samples/generated/admin/v2/bigtable_instance_admin.list_materialized_views.js
+++ b/samples/generated/admin/v2/bigtable_instance_admin.list_materialized_views.js
@@ -48,7 +48,7 @@ function main(parent) {
   // const pageToken = 'abc123'
 
   // Imports the Admin library
-  const {BigtableInstanceAdminClient} = require('@google-cloud/bigtable').v2;
+  const {BigtableInstanceAdminClient} = require('@google-cloud/bigtable').admin.v2;
 
   // Instantiates a client
   const adminClient = new BigtableInstanceAdminClient();

--- a/samples/generated/admin/v2/bigtable_instance_admin.partial_update_cluster.js
+++ b/samples/generated/admin/v2/bigtable_instance_admin.partial_update_cluster.js
@@ -39,7 +39,7 @@ function main(cluster, updateMask) {
   // const updateMask = {}
 
   // Imports the Admin library
-  const {BigtableInstanceAdminClient} = require('@google-cloud/bigtable').v2;
+  const {BigtableInstanceAdminClient} = require('@google-cloud/bigtable').admin.v2;
 
   // Instantiates a client
   const adminClient = new BigtableInstanceAdminClient();

--- a/samples/generated/admin/v2/bigtable_instance_admin.partial_update_instance.js
+++ b/samples/generated/admin/v2/bigtable_instance_admin.partial_update_instance.js
@@ -39,7 +39,7 @@ function main(instance, updateMask) {
   // const updateMask = {}
 
   // Imports the Admin library
-  const {BigtableInstanceAdminClient} = require('@google-cloud/bigtable').v2;
+  const {BigtableInstanceAdminClient} = require('@google-cloud/bigtable').admin.v2;
 
   // Instantiates a client
   const adminClient = new BigtableInstanceAdminClient();

--- a/samples/generated/admin/v2/bigtable_instance_admin.set_iam_policy.js
+++ b/samples/generated/admin/v2/bigtable_instance_admin.set_iam_policy.js
@@ -49,7 +49,7 @@ function main(resource, policy) {
   // const updateMask = {}
 
   // Imports the Admin library
-  const {BigtableInstanceAdminClient} = require('@google-cloud/bigtable').v2;
+  const {BigtableInstanceAdminClient} = require('@google-cloud/bigtable').admin.v2;
 
   // Instantiates a client
   const adminClient = new BigtableInstanceAdminClient();

--- a/samples/generated/admin/v2/bigtable_instance_admin.test_iam_permissions.js
+++ b/samples/generated/admin/v2/bigtable_instance_admin.test_iam_permissions.js
@@ -42,7 +42,7 @@ function main(resource, permissions) {
   // const permissions = ['abc','def']
 
   // Imports the Admin library
-  const {BigtableInstanceAdminClient} = require('@google-cloud/bigtable').v2;
+  const {BigtableInstanceAdminClient} = require('@google-cloud/bigtable').admin.v2;
 
   // Instantiates a client
   const adminClient = new BigtableInstanceAdminClient();

--- a/samples/generated/admin/v2/bigtable_instance_admin.update_app_profile.js
+++ b/samples/generated/admin/v2/bigtable_instance_admin.update_app_profile.js
@@ -43,7 +43,7 @@ function main(appProfile, updateMask) {
   // const ignoreWarnings = true
 
   // Imports the Admin library
-  const {BigtableInstanceAdminClient} = require('@google-cloud/bigtable').v2;
+  const {BigtableInstanceAdminClient} = require('@google-cloud/bigtable').admin.v2;
 
   // Instantiates a client
   const adminClient = new BigtableInstanceAdminClient();

--- a/samples/generated/admin/v2/bigtable_instance_admin.update_cluster.js
+++ b/samples/generated/admin/v2/bigtable_instance_admin.update_cluster.js
@@ -69,7 +69,7 @@ function main(location, state, nodeScalingFactor, defaultStorageType, encryption
   // const encryptionConfig = {}
 
   // Imports the Admin library
-  const {BigtableInstanceAdminClient} = require('@google-cloud/bigtable').v2;
+  const {BigtableInstanceAdminClient} = require('@google-cloud/bigtable').admin.v2;
 
   // Instantiates a client
   const adminClient = new BigtableInstanceAdminClient();

--- a/samples/generated/admin/v2/bigtable_instance_admin.update_instance.js
+++ b/samples/generated/admin/v2/bigtable_instance_admin.update_instance.js
@@ -87,7 +87,7 @@ function main(displayName, state, createTime, satisfiesPzs, satisfiesPzi, tags) 
   // const tags = [1,2,3,4]
 
   // Imports the Admin library
-  const {BigtableInstanceAdminClient} = require('@google-cloud/bigtable').v2;
+  const {BigtableInstanceAdminClient} = require('@google-cloud/bigtable').admin.v2;
 
   // Instantiates a client
   const adminClient = new BigtableInstanceAdminClient();

--- a/samples/generated/admin/v2/bigtable_instance_admin.update_logical_view.js
+++ b/samples/generated/admin/v2/bigtable_instance_admin.update_logical_view.js
@@ -41,7 +41,7 @@ function main(logicalView) {
   // const updateMask = {}
 
   // Imports the Admin library
-  const {BigtableInstanceAdminClient} = require('@google-cloud/bigtable').v2;
+  const {BigtableInstanceAdminClient} = require('@google-cloud/bigtable').admin.v2;
 
   // Instantiates a client
   const adminClient = new BigtableInstanceAdminClient();

--- a/samples/generated/admin/v2/bigtable_instance_admin.update_materialized_view.js
+++ b/samples/generated/admin/v2/bigtable_instance_admin.update_materialized_view.js
@@ -41,7 +41,7 @@ function main(materializedView) {
   // const updateMask = {}
 
   // Imports the Admin library
-  const {BigtableInstanceAdminClient} = require('@google-cloud/bigtable').v2;
+  const {BigtableInstanceAdminClient} = require('@google-cloud/bigtable').admin.v2;
 
   // Instantiates a client
   const adminClient = new BigtableInstanceAdminClient();

--- a/samples/generated/admin/v2/bigtable_table_admin.check_consistency.js
+++ b/samples/generated/admin/v2/bigtable_table_admin.check_consistency.js
@@ -52,7 +52,7 @@ function main(name, consistencyToken) {
   // const dataBoostReadLocalWrites = {}
 
   // Imports the Admin library
-  const {BigtableTableAdminClient} = require('@google-cloud/bigtable').v2;
+  const {BigtableTableAdminClient} = require('@google-cloud/bigtable').admin.v2;
 
   // Instantiates a client
   const adminClient = new BigtableTableAdminClient();

--- a/samples/generated/admin/v2/bigtable_table_admin.copy_backup.js
+++ b/samples/generated/admin/v2/bigtable_table_admin.copy_backup.js
@@ -63,7 +63,7 @@ function main(parent, backupId, sourceBackup, expireTime) {
   // const expireTime = {}
 
   // Imports the Admin library
-  const {BigtableTableAdminClient} = require('@google-cloud/bigtable').v2;
+  const {BigtableTableAdminClient} = require('@google-cloud/bigtable').admin.v2;
 
   // Instantiates a client
   const adminClient = new BigtableTableAdminClient();

--- a/samples/generated/admin/v2/bigtable_table_admin.create_authorized_view.js
+++ b/samples/generated/admin/v2/bigtable_table_admin.create_authorized_view.js
@@ -47,7 +47,7 @@ function main(parent, authorizedViewId, authorizedView) {
   // const authorizedView = {}
 
   // Imports the Admin library
-  const {BigtableTableAdminClient} = require('@google-cloud/bigtable').v2;
+  const {BigtableTableAdminClient} = require('@google-cloud/bigtable').admin.v2;
 
   // Instantiates a client
   const adminClient = new BigtableTableAdminClient();

--- a/samples/generated/admin/v2/bigtable_table_admin.create_backup.js
+++ b/samples/generated/admin/v2/bigtable_table_admin.create_backup.js
@@ -49,7 +49,7 @@ function main(parent, backupId, backup) {
   // const backup = {}
 
   // Imports the Admin library
-  const {BigtableTableAdminClient} = require('@google-cloud/bigtable').v2;
+  const {BigtableTableAdminClient} = require('@google-cloud/bigtable').admin.v2;
 
   // Instantiates a client
   const adminClient = new BigtableTableAdminClient();

--- a/samples/generated/admin/v2/bigtable_table_admin.create_schema_bundle.js
+++ b/samples/generated/admin/v2/bigtable_table_admin.create_schema_bundle.js
@@ -45,7 +45,7 @@ function main(parent, schemaBundleId, schemaBundle) {
   // const schemaBundle = {}
 
   // Imports the Admin library
-  const {BigtableTableAdminClient} = require('@google-cloud/bigtable').v2;
+  const {BigtableTableAdminClient} = require('@google-cloud/bigtable').admin.v2;
 
   // Instantiates a client
   const adminClient = new BigtableTableAdminClient();

--- a/samples/generated/admin/v2/bigtable_table_admin.create_table.js
+++ b/samples/generated/admin/v2/bigtable_table_admin.create_table.js
@@ -62,7 +62,7 @@ function main(parent, tableId, table) {
   // const initialSplits = [1,2,3,4]
 
   // Imports the Admin library
-  const {BigtableTableAdminClient} = require('@google-cloud/bigtable').v2;
+  const {BigtableTableAdminClient} = require('@google-cloud/bigtable').admin.v2;
 
   // Instantiates a client
   const adminClient = new BigtableTableAdminClient();

--- a/samples/generated/admin/v2/bigtable_table_admin.create_table_from_snapshot.js
+++ b/samples/generated/admin/v2/bigtable_table_admin.create_table_from_snapshot.js
@@ -47,7 +47,7 @@ function main(parent, tableId, sourceSnapshot) {
   // const sourceSnapshot = 'abc123'
 
   // Imports the Admin library
-  const {BigtableTableAdminClient} = require('@google-cloud/bigtable').v2;
+  const {BigtableTableAdminClient} = require('@google-cloud/bigtable').admin.v2;
 
   // Instantiates a client
   const adminClient = new BigtableTableAdminClient();

--- a/samples/generated/admin/v2/bigtable_table_admin.delete_authorized_view.js
+++ b/samples/generated/admin/v2/bigtable_table_admin.delete_authorized_view.js
@@ -43,7 +43,7 @@ function main(name) {
   // const etag = 'abc123'
 
   // Imports the Admin library
-  const {BigtableTableAdminClient} = require('@google-cloud/bigtable').v2;
+  const {BigtableTableAdminClient} = require('@google-cloud/bigtable').admin.v2;
 
   // Instantiates a client
   const adminClient = new BigtableTableAdminClient();

--- a/samples/generated/admin/v2/bigtable_table_admin.delete_backup.js
+++ b/samples/generated/admin/v2/bigtable_table_admin.delete_backup.js
@@ -36,7 +36,7 @@ function main(name) {
   // const name = 'abc123'
 
   // Imports the Admin library
-  const {BigtableTableAdminClient} = require('@google-cloud/bigtable').v2;
+  const {BigtableTableAdminClient} = require('@google-cloud/bigtable').admin.v2;
 
   // Instantiates a client
   const adminClient = new BigtableTableAdminClient();

--- a/samples/generated/admin/v2/bigtable_table_admin.delete_schema_bundle.js
+++ b/samples/generated/admin/v2/bigtable_table_admin.delete_schema_bundle.js
@@ -42,7 +42,7 @@ function main(name) {
   // const etag = 'abc123'
 
   // Imports the Admin library
-  const {BigtableTableAdminClient} = require('@google-cloud/bigtable').v2;
+  const {BigtableTableAdminClient} = require('@google-cloud/bigtable').admin.v2;
 
   // Instantiates a client
   const adminClient = new BigtableTableAdminClient();

--- a/samples/generated/admin/v2/bigtable_table_admin.delete_snapshot.js
+++ b/samples/generated/admin/v2/bigtable_table_admin.delete_snapshot.js
@@ -36,7 +36,7 @@ function main(name) {
   // const name = 'abc123'
 
   // Imports the Admin library
-  const {BigtableTableAdminClient} = require('@google-cloud/bigtable').v2;
+  const {BigtableTableAdminClient} = require('@google-cloud/bigtable').admin.v2;
 
   // Instantiates a client
   const adminClient = new BigtableTableAdminClient();

--- a/samples/generated/admin/v2/bigtable_table_admin.delete_table.js
+++ b/samples/generated/admin/v2/bigtable_table_admin.delete_table.js
@@ -36,7 +36,7 @@ function main(name) {
   // const name = 'abc123'
 
   // Imports the Admin library
-  const {BigtableTableAdminClient} = require('@google-cloud/bigtable').v2;
+  const {BigtableTableAdminClient} = require('@google-cloud/bigtable').admin.v2;
 
   // Instantiates a client
   const adminClient = new BigtableTableAdminClient();

--- a/samples/generated/admin/v2/bigtable_table_admin.drop_row_range.js
+++ b/samples/generated/admin/v2/bigtable_table_admin.drop_row_range.js
@@ -45,7 +45,7 @@ function main(name) {
   // const deleteAllDataFromTable = true
 
   // Imports the Admin library
-  const {BigtableTableAdminClient} = require('@google-cloud/bigtable').v2;
+  const {BigtableTableAdminClient} = require('@google-cloud/bigtable').admin.v2;
 
   // Instantiates a client
   const adminClient = new BigtableTableAdminClient();

--- a/samples/generated/admin/v2/bigtable_table_admin.generate_consistency_token.js
+++ b/samples/generated/admin/v2/bigtable_table_admin.generate_consistency_token.js
@@ -36,7 +36,7 @@ function main(name) {
   // const name = 'abc123'
 
   // Imports the Admin library
-  const {BigtableTableAdminClient} = require('@google-cloud/bigtable').v2;
+  const {BigtableTableAdminClient} = require('@google-cloud/bigtable').admin.v2;
 
   // Instantiates a client
   const adminClient = new BigtableTableAdminClient();

--- a/samples/generated/admin/v2/bigtable_table_admin.get_authorized_view.js
+++ b/samples/generated/admin/v2/bigtable_table_admin.get_authorized_view.js
@@ -41,7 +41,7 @@ function main(name) {
   // const view = {}
 
   // Imports the Admin library
-  const {BigtableTableAdminClient} = require('@google-cloud/bigtable').v2;
+  const {BigtableTableAdminClient} = require('@google-cloud/bigtable').admin.v2;
 
   // Instantiates a client
   const adminClient = new BigtableTableAdminClient();

--- a/samples/generated/admin/v2/bigtable_table_admin.get_backup.js
+++ b/samples/generated/admin/v2/bigtable_table_admin.get_backup.js
@@ -36,7 +36,7 @@ function main(name) {
   // const name = 'abc123'
 
   // Imports the Admin library
-  const {BigtableTableAdminClient} = require('@google-cloud/bigtable').v2;
+  const {BigtableTableAdminClient} = require('@google-cloud/bigtable').admin.v2;
 
   // Instantiates a client
   const adminClient = new BigtableTableAdminClient();

--- a/samples/generated/admin/v2/bigtable_table_admin.get_iam_policy.js
+++ b/samples/generated/admin/v2/bigtable_table_admin.get_iam_policy.js
@@ -40,7 +40,7 @@ function main(resource) {
   // const options = {}
 
   // Imports the Admin library
-  const {BigtableTableAdminClient} = require('@google-cloud/bigtable').v2;
+  const {BigtableTableAdminClient} = require('@google-cloud/bigtable').admin.v2;
 
   // Instantiates a client
   const adminClient = new BigtableTableAdminClient();

--- a/samples/generated/admin/v2/bigtable_table_admin.get_schema_bundle.js
+++ b/samples/generated/admin/v2/bigtable_table_admin.get_schema_bundle.js
@@ -36,7 +36,7 @@ function main(name) {
   // const name = 'abc123'
 
   // Imports the Admin library
-  const {BigtableTableAdminClient} = require('@google-cloud/bigtable').v2;
+  const {BigtableTableAdminClient} = require('@google-cloud/bigtable').admin.v2;
 
   // Instantiates a client
   const adminClient = new BigtableTableAdminClient();

--- a/samples/generated/admin/v2/bigtable_table_admin.get_snapshot.js
+++ b/samples/generated/admin/v2/bigtable_table_admin.get_snapshot.js
@@ -36,7 +36,7 @@ function main(name) {
   // const name = 'abc123'
 
   // Imports the Admin library
-  const {BigtableTableAdminClient} = require('@google-cloud/bigtable').v2;
+  const {BigtableTableAdminClient} = require('@google-cloud/bigtable').admin.v2;
 
   // Instantiates a client
   const adminClient = new BigtableTableAdminClient();

--- a/samples/generated/admin/v2/bigtable_table_admin.get_table.js
+++ b/samples/generated/admin/v2/bigtable_table_admin.get_table.js
@@ -41,7 +41,7 @@ function main(name) {
   // const view = {}
 
   // Imports the Admin library
-  const {BigtableTableAdminClient} = require('@google-cloud/bigtable').v2;
+  const {BigtableTableAdminClient} = require('@google-cloud/bigtable').admin.v2;
 
   // Instantiates a client
   const adminClient = new BigtableTableAdminClient();

--- a/samples/generated/admin/v2/bigtable_table_admin.list_authorized_views.js
+++ b/samples/generated/admin/v2/bigtable_table_admin.list_authorized_views.js
@@ -55,7 +55,7 @@ function main(parent) {
   // const view = {}
 
   // Imports the Admin library
-  const {BigtableTableAdminClient} = require('@google-cloud/bigtable').v2;
+  const {BigtableTableAdminClient} = require('@google-cloud/bigtable').admin.v2;
 
   // Instantiates a client
   const adminClient = new BigtableTableAdminClient();

--- a/samples/generated/admin/v2/bigtable_table_admin.list_backups.js
+++ b/samples/generated/admin/v2/bigtable_table_admin.list_backups.js
@@ -102,7 +102,7 @@ function main(parent) {
   // const pageToken = 'abc123'
 
   // Imports the Admin library
-  const {BigtableTableAdminClient} = require('@google-cloud/bigtable').v2;
+  const {BigtableTableAdminClient} = require('@google-cloud/bigtable').admin.v2;
 
   // Instantiates a client
   const adminClient = new BigtableTableAdminClient();

--- a/samples/generated/admin/v2/bigtable_table_admin.list_schema_bundles.js
+++ b/samples/generated/admin/v2/bigtable_table_admin.list_schema_bundles.js
@@ -49,7 +49,7 @@ function main(parent) {
   // const pageToken = 'abc123'
 
   // Imports the Admin library
-  const {BigtableTableAdminClient} = require('@google-cloud/bigtable').v2;
+  const {BigtableTableAdminClient} = require('@google-cloud/bigtable').admin.v2;
 
   // Instantiates a client
   const adminClient = new BigtableTableAdminClient();

--- a/samples/generated/admin/v2/bigtable_table_admin.list_snapshots.js
+++ b/samples/generated/admin/v2/bigtable_table_admin.list_snapshots.js
@@ -47,7 +47,7 @@ function main(parent) {
   // const pageToken = 'abc123'
 
   // Imports the Admin library
-  const {BigtableTableAdminClient} = require('@google-cloud/bigtable').v2;
+  const {BigtableTableAdminClient} = require('@google-cloud/bigtable').admin.v2;
 
   // Instantiates a client
   const adminClient = new BigtableTableAdminClient();

--- a/samples/generated/admin/v2/bigtable_table_admin.list_tables.js
+++ b/samples/generated/admin/v2/bigtable_table_admin.list_tables.js
@@ -54,7 +54,7 @@ function main(parent) {
   // const pageToken = 'abc123'
 
   // Imports the Admin library
-  const {BigtableTableAdminClient} = require('@google-cloud/bigtable').v2;
+  const {BigtableTableAdminClient} = require('@google-cloud/bigtable').admin.v2;
 
   // Instantiates a client
   const adminClient = new BigtableTableAdminClient();

--- a/samples/generated/admin/v2/bigtable_table_admin.modify_column_families.js
+++ b/samples/generated/admin/v2/bigtable_table_admin.modify_column_families.js
@@ -47,7 +47,7 @@ function main(name, modifications) {
   // const ignoreWarnings = true
 
   // Imports the Admin library
-  const {BigtableTableAdminClient} = require('@google-cloud/bigtable').v2;
+  const {BigtableTableAdminClient} = require('@google-cloud/bigtable').admin.v2;
 
   // Instantiates a client
   const adminClient = new BigtableTableAdminClient();

--- a/samples/generated/admin/v2/bigtable_table_admin.restore_table.js
+++ b/samples/generated/admin/v2/bigtable_table_admin.restore_table.js
@@ -47,7 +47,7 @@ function main(parent, tableId) {
   // const backup = 'abc123'
 
   // Imports the Admin library
-  const {BigtableTableAdminClient} = require('@google-cloud/bigtable').v2;
+  const {BigtableTableAdminClient} = require('@google-cloud/bigtable').admin.v2;
 
   // Instantiates a client
   const adminClient = new BigtableTableAdminClient();

--- a/samples/generated/admin/v2/bigtable_table_admin.set_iam_policy.js
+++ b/samples/generated/admin/v2/bigtable_table_admin.set_iam_policy.js
@@ -49,7 +49,7 @@ function main(resource, policy) {
   // const updateMask = {}
 
   // Imports the Admin library
-  const {BigtableTableAdminClient} = require('@google-cloud/bigtable').v2;
+  const {BigtableTableAdminClient} = require('@google-cloud/bigtable').admin.v2;
 
   // Instantiates a client
   const adminClient = new BigtableTableAdminClient();

--- a/samples/generated/admin/v2/bigtable_table_admin.snapshot_table.js
+++ b/samples/generated/admin/v2/bigtable_table_admin.snapshot_table.js
@@ -60,7 +60,7 @@ function main(name, cluster, snapshotId) {
   // const description = 'abc123'
 
   // Imports the Admin library
-  const {BigtableTableAdminClient} = require('@google-cloud/bigtable').v2;
+  const {BigtableTableAdminClient} = require('@google-cloud/bigtable').admin.v2;
 
   // Instantiates a client
   const adminClient = new BigtableTableAdminClient();

--- a/samples/generated/admin/v2/bigtable_table_admin.test_iam_permissions.js
+++ b/samples/generated/admin/v2/bigtable_table_admin.test_iam_permissions.js
@@ -42,7 +42,7 @@ function main(resource, permissions) {
   // const permissions = ['abc','def']
 
   // Imports the Admin library
-  const {BigtableTableAdminClient} = require('@google-cloud/bigtable').v2;
+  const {BigtableTableAdminClient} = require('@google-cloud/bigtable').admin.v2;
 
   // Instantiates a client
   const adminClient = new BigtableTableAdminClient();

--- a/samples/generated/admin/v2/bigtable_table_admin.undelete_table.js
+++ b/samples/generated/admin/v2/bigtable_table_admin.undelete_table.js
@@ -36,7 +36,7 @@ function main(name) {
   // const name = 'abc123'
 
   // Imports the Admin library
-  const {BigtableTableAdminClient} = require('@google-cloud/bigtable').v2;
+  const {BigtableTableAdminClient} = require('@google-cloud/bigtable').admin.v2;
 
   // Instantiates a client
   const adminClient = new BigtableTableAdminClient();

--- a/samples/generated/admin/v2/bigtable_table_admin.update_authorized_view.js
+++ b/samples/generated/admin/v2/bigtable_table_admin.update_authorized_view.js
@@ -52,7 +52,7 @@ function main(authorizedView) {
   // const ignoreWarnings = true
 
   // Imports the Admin library
-  const {BigtableTableAdminClient} = require('@google-cloud/bigtable').v2;
+  const {BigtableTableAdminClient} = require('@google-cloud/bigtable').admin.v2;
 
   // Instantiates a client
   const adminClient = new BigtableTableAdminClient();

--- a/samples/generated/admin/v2/bigtable_table_admin.update_backup.js
+++ b/samples/generated/admin/v2/bigtable_table_admin.update_backup.js
@@ -45,7 +45,7 @@ function main(backup, updateMask) {
   // const updateMask = {}
 
   // Imports the Admin library
-  const {BigtableTableAdminClient} = require('@google-cloud/bigtable').v2;
+  const {BigtableTableAdminClient} = require('@google-cloud/bigtable').admin.v2;
 
   // Instantiates a client
   const adminClient = new BigtableTableAdminClient();

--- a/samples/generated/admin/v2/bigtable_table_admin.update_schema_bundle.js
+++ b/samples/generated/admin/v2/bigtable_table_admin.update_schema_bundle.js
@@ -48,7 +48,7 @@ function main(schemaBundle) {
   // const ignoreWarnings = true
 
   // Imports the Admin library
-  const {BigtableTableAdminClient} = require('@google-cloud/bigtable').v2;
+  const {BigtableTableAdminClient} = require('@google-cloud/bigtable').admin.v2;
 
   // Instantiates a client
   const adminClient = new BigtableTableAdminClient();

--- a/samples/generated/admin/v2/bigtable_table_admin.update_table.js
+++ b/samples/generated/admin/v2/bigtable_table_admin.update_table.js
@@ -53,7 +53,7 @@ function main(table, updateMask) {
   // const ignoreWarnings = true
 
   // Imports the Admin library
-  const {BigtableTableAdminClient} = require('@google-cloud/bigtable').v2;
+  const {BigtableTableAdminClient} = require('@google-cloud/bigtable').admin.v2;
 
   // Instantiates a client
   const adminClient = new BigtableTableAdminClient();

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,7 @@ import {
 import {google} from '../protos/protos';
 import {ServiceError} from 'google-gax';
 import * as v2 from './v2';
+import * as admin from './admin';
 import {PassThrough, Duplex} from 'stream';
 import grpcGcpModule = require('grpc-gcp');
 import {ClusterUtils} from './utils/cluster';
@@ -1135,11 +1136,13 @@ promisifyAll(Bigtable, {
  */
 
 module.exports = Bigtable;
+module.exports.admin = admin;
 module.exports.v2 = v2;
 module.exports.Bigtable = Bigtable;
 module.exports.SqlTypes = SqlTypes;
 
 export {v2};
+export {admin};
 export {protos};
 export {
   AppProfile,


### PR DESCRIPTION
Missed in https://github.com/googleapis/nodejs-bigtable/pull/1739

This edits the generated samples to point to the right import location, and also exports `admin` from the top-level package.

Note: the plan is to separate this stuff into its own package eventually, so I don't want to update the generator or anything, just shim into place for now.
