### PR TITLE
tests: also disable 'node18' tests in continuous/nightly for now

### DIFF
--- a/.kokoro/test.sh
+++ b/.kokoro/test.sh
@@ -24,13 +24,16 @@ npm install
 # If tests are running against main branch, configure flakybot
 # to open issues on failures:
 if [[ $KOKORO_BUILD_ARTIFACTS_SUBDIR = *"continuous"* ]] || [[ $KOKORO_BUILD_ARTIFACTS_SUBDIR = *"nightly"* ]]; then
-  export MOCHA_REPORTER_OUTPUT=test_output_sponge_log.xml
-  export MOCHA_REPORTER=xunit
-  cleanup() {
-    chmod +x $KOKORO_GFILE_DIR/linux_amd64/flakybot
-    $KOKORO_GFILE_DIR/linux_amd64/flakybot
-  }
-  trap cleanup EXIT HUP
+  #export MOCHA_REPORTER_OUTPUT=test_output_sponge_log.xml
+  #export MOCHA_REPORTER=xunit
+  #cleanup() {
+  #  chmod +x $KOKORO_GFILE_DIR/linux_amd64/flakybot
+  #  $KOKORO_GFILE_DIR/linux_amd64/flakybot
+  #}
+  #trap cleanup EXIT HUP
+
+  # These are currently disabled pending figuring out admin quota issues.
+  exit 0
 fi
 # Unit tests exercise the entire API surface, which may include
 # deprecation warnings:

--- a/.kokoro/test.sh
+++ b/.kokoro/test.sh
@@ -24,16 +24,13 @@ npm install
 # If tests are running against main branch, configure flakybot
 # to open issues on failures:
 if [[ $KOKORO_BUILD_ARTIFACTS_SUBDIR = *"continuous"* ]] || [[ $KOKORO_BUILD_ARTIFACTS_SUBDIR = *"nightly"* ]]; then
-  #export MOCHA_REPORTER_OUTPUT=test_output_sponge_log.xml
-  #export MOCHA_REPORTER=xunit
-  #cleanup() {
-  #  chmod +x $KOKORO_GFILE_DIR/linux_amd64/flakybot
-  #  $KOKORO_GFILE_DIR/linux_amd64/flakybot
-  #}
-  #trap cleanup EXIT HUP
-
-  # These are currently disabled pending figuring out admin quota issues.
-  exit 0
+  export MOCHA_REPORTER_OUTPUT=test_output_sponge_log.xml
+  export MOCHA_REPORTER=xunit
+  cleanup() {
+    chmod +x $KOKORO_GFILE_DIR/linux_amd64/flakybot
+    $KOKORO_GFILE_DIR/linux_amd64/flakybot
+  }
+  trap cleanup EXIT HUP
 fi
 # Unit tests exercise the entire API surface, which may include
 # deprecation warnings:

--- a/owlbot.py
+++ b/owlbot.py
@@ -62,6 +62,7 @@ if staging.is_dir():
             'samples/generated/v2/*',   # we don't want to encourage non-veneer use here.
             '.kokoro/samples-test.sh',  # get to green
             '.kokoro/system-test.sh',
+            '.kokoro/test.sh',
         ] + list(admin_files)
         logging.info(f"excluding files for non-admin: {excludes}")
         s.copy([library], excludes = excludes)
@@ -170,6 +171,7 @@ s.copy(templates,excludes=[
     '.github/workflows/ci.yaml',
     '.kokoro/samples-test.sh',  # get to green
     '.kokoro/system-test.sh',
+    '.kokoro/test.sh',
 ])
 
 node.postprocess_gapic_library_hermetic()


### PR DESCRIPTION
The previous PR was not quite enough to catch all of them.

Goes with: https://github.com/googleapis/google-cloud-node/issues/7863
