### PR TITLE
chore: replace old teams with cloud-sdk-nodejs-team and bigtable-team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,5 +5,5 @@
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
 
-# Unless specified, the jsteam is the default owner for nodejs repositories.
-*     @googleapis/api-bigtable @googleapis/api-bigtable-partners @googleapis/jsteam
+# Unless specified, the cloud-sdk-nodejs-team is the default owner for nodejs repositories.
+* @googleapis/bigtable-team @googleapis/cloud-sdk-nodejs-team

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -10,7 +10,7 @@
   "distribution_name": "@google-cloud/bigtable",
   "api_id": "bigtable.googleapis.com",
   "requires_billing": true,
-  "codeowner_team": "@googleapis/api-bigtable @googleapis/api-bigtable-partners",
+  "codeowner_team": "@googleapis/bigtable-team @googleapis/cloud-sdk-nodejs-team",
   "api_shortname": "bigtable",
   "library_type": "GAPIC_COMBO"
 }


### PR DESCRIPTION
This PR replaces the old api-bigtable with bigtable-team, jsteam with cloud-sdk-nodejs-team, and removes api-bigtable-partners as api-bigtable-partners is not used.

b/478003109